### PR TITLE
fix: let ethers handle eth_call

### DIFF
--- a/apps/extension/src/core/domains/ethereum/handler.tabs.ts
+++ b/apps/extension/src/core/domains/ethereum/handler.tabs.ts
@@ -353,12 +353,6 @@ export class EthTabsHandler extends TabsHandler {
         const result = await provider.estimateGas(req)
         return result.toHexString()
       }
-      case "eth_call": {
-        const { params } = request as EthRequestArguments<"eth_call">
-        const req = ethers.providers.JsonRpcProvider.hexlifyTransaction(params[0])
-        const provider = await this.getProvider(url)
-        return await provider.call(req, params[1])
-      }
 
       case "personal_sign":
       case "eth_sign": {


### PR DESCRIPTION
ethers seems to handle eth_call better than us :)

this fixes ROME dapp that couldn't fetch $ROME balance.
https://housesofrome.com/play

their requests were not hex encoded like other dapps i've tested before, they send JSON content directly.
I've tested on solarbeam and our wagmi test dapp, as they both hex encode all payloads, and they still work fine.

