### PR TITLE
fix: send funds tip

### DIFF
--- a/apps/extension/src/core/domains/transactions/handler.ts
+++ b/apps/extension/src/core/domains/transactions/handler.ts
@@ -88,6 +88,7 @@ export default class AssetTransferHandler extends ExtensionHandler {
     fromAddress,
     toAddress,
     amount,
+    tip,
     reapBalance = false,
   }: RequestAssetTransfer): Promise<ResponseAssetTransfer> {
     try {
@@ -110,6 +111,7 @@ export default class AssetTransferHandler extends ExtensionHandler {
           amount,
           pair,
           toAddress,
+          tip,
           reapBalance,
           watchExtrinsic
         )
@@ -120,6 +122,7 @@ export default class AssetTransferHandler extends ExtensionHandler {
           amount,
           pair,
           toAddress,
+          tip,
           watchExtrinsic
         )
 
@@ -135,6 +138,7 @@ export default class AssetTransferHandler extends ExtensionHandler {
     fromAddress,
     toAddress,
     amount,
+    tip,
     reapBalance = false,
   }: RequestAssetTransfer): Promise<ResponseAssetTransferFeeQuery> {
     try {
@@ -149,9 +153,9 @@ export default class AssetTransferHandler extends ExtensionHandler {
 
     const tokenType = token.type
     if (tokenType === "native")
-      return await AssetTransfersRpc.checkFee(chainId, amount, pair, toAddress, reapBalance)
+      return await AssetTransfersRpc.checkFee(chainId, amount, pair, toAddress, tip, reapBalance)
     if (tokenType === "orml")
-      return await OrmlTokenTransfersRpc.checkFee(chainId, tokenId, amount, pair, toAddress)
+      return await OrmlTokenTransfersRpc.checkFee(chainId, tokenId, amount, pair, toAddress, tip)
 
     // force compilation error if any token types don't have a case
     const exhaustiveCheck: never = tokenType

--- a/apps/extension/src/core/libs/rpc/AssetTransfers.ts
+++ b/apps/extension/src/core/libs/rpc/AssetTransfers.ts
@@ -36,6 +36,7 @@ export default class AssetTransfersRpc {
     amount: string,
     from: KeyringPair,
     to: Address,
+    tip: string,
     reapBalance: boolean = false,
     callback: SubscriptionCallback<{
       nonce: string
@@ -48,6 +49,7 @@ export default class AssetTransfersRpc {
       amount,
       from,
       to,
+      tip,
       reapBalance,
       true
     )
@@ -87,6 +89,7 @@ export default class AssetTransfersRpc {
     amount: string,
     from: KeyringPair,
     to: Address,
+    tip: string,
     reapBalance: boolean = false
   ): Promise<ResponseAssetTransferFeeQuery> {
     const { tx, pendingTransferId, unsigned } = await this.prepareTransaction(
@@ -94,6 +97,7 @@ export default class AssetTransfersRpc {
       amount,
       from,
       to,
+      tip,
       reapBalance,
       false
     )
@@ -120,6 +124,7 @@ export default class AssetTransfersRpc {
     amount: string,
     from: KeyringPair,
     to: Address,
+    tip: string,
     reapBalance: boolean,
     sign: boolean
   ): Promise<{
@@ -164,7 +169,7 @@ export default class AssetTransfersRpc {
         metadataRpc,
         nonce,
         specVersion: specVersion as unknown as number,
-        tip: 0,
+        tip: tip ? Number(tip) : 0,
         transactionVersion: transactionVersion as unknown as number,
       },
       {

--- a/apps/extension/src/core/libs/rpc/OrmlTokenTransfers.ts
+++ b/apps/extension/src/core/libs/rpc/OrmlTokenTransfers.ts
@@ -41,13 +41,22 @@ export default class OrmlTokenTransfersRpc {
     amount: string,
     from: KeyringPair,
     to: Address,
+    tip: string,
     callback: SubscriptionCallback<{
       nonce: string
       hash: string
       status: ExtrinsicStatus
     }>
   ): Promise<void> {
-    const { tx, registry } = await this.prepareTransaction(chainId, tokenId, amount, from, to, true)
+    const { tx, registry } = await this.prepareTransaction(
+      chainId,
+      tokenId,
+      amount,
+      from,
+      to,
+      tip,
+      true
+    )
 
     const unsubscribe = await RpcFactory.subscribe(
       chainId,
@@ -85,7 +94,8 @@ export default class OrmlTokenTransfersRpc {
     tokenId: TokenId,
     amount: string,
     from: KeyringPair,
-    to: Address
+    to: Address,
+    tip: string
   ): Promise<ResponseAssetTransferFeeQuery> {
     const { tx, pendingTransferId, unsigned } = await this.prepareTransaction(
       chainId,
@@ -93,6 +103,7 @@ export default class OrmlTokenTransfersRpc {
       amount,
       from,
       to,
+      tip,
       false
     )
 
@@ -120,6 +131,7 @@ export default class OrmlTokenTransfersRpc {
     amount: string,
     from: KeyringPair,
     to: Address,
+    tip: string,
     sign: boolean
   ): Promise<{
     tx: Extrinsic
@@ -172,7 +184,7 @@ export default class OrmlTokenTransfersRpc {
         metadataRpc,
         nonce,
         specVersion: specVersion as unknown as number,
-        tip: 0,
+        tip: tip ? Number(tip) : 0,
         transactionVersion: transactionVersion as unknown as number,
       },
       {

--- a/apps/extension/src/core/types.ts
+++ b/apps/extension/src/core/types.ts
@@ -804,6 +804,7 @@ export interface RequestAssetTransfer {
   fromAddress: string
   toAddress: string
   amount: string
+  tip: string
   reapBalance?: boolean
 }
 

--- a/apps/extension/src/ui/api/api.ts
+++ b/apps/extension/src/ui/api/api.ts
@@ -127,22 +127,24 @@ export const api: MessageTypes = {
   transactionsSubscribe: (cb) => messageService.subscribe("pri(transactions.subscribe)", null, cb),
 
   // asset transfer messages
-  assetTransfer: (chainId, tokenId, fromAddress, toAddress, amount, reapBalance) =>
+  assetTransfer: (chainId, tokenId, fromAddress, toAddress, amount, tip, reapBalance) =>
     messageService.sendMessage("pri(assets.transfer)", {
       chainId,
       tokenId,
       fromAddress,
       toAddress,
       amount,
+      tip,
       reapBalance,
     }),
-  assetTransferCheckFees: (chainId, tokenId, fromAddress, toAddress, amount, reapBalance) =>
+  assetTransferCheckFees: (chainId, tokenId, fromAddress, toAddress, amount, tip, reapBalance) =>
     messageService.sendMessage("pri(assets.transfer.checkFees)", {
       chainId,
       tokenId,
       fromAddress,
       toAddress,
       amount,
+      tip,
       reapBalance,
     }),
   assetTransferApproveSign: (id, signature) =>

--- a/apps/extension/src/ui/api/types.ts
+++ b/apps/extension/src/ui/api/types.ts
@@ -158,6 +158,7 @@ export default interface MessageTypes {
     fromAddress: string,
     toAddress: string,
     amount: string,
+    tip: string,
     reapBalance?: boolean
   ) => Promise<ResponseAssetTransfer>
   assetTransferCheckFees: (
@@ -166,6 +167,7 @@ export default interface MessageTypes {
     fromAddress: string,
     toAddress: string,
     amount: string,
+    tip: string,
     reapBalance?: boolean
   ) => Promise<ResponseAssetTransferFeeQuery>
   assetTransferApproveSign: (

--- a/apps/extension/src/ui/domains/Asset/Send/SendForm.tsx
+++ b/apps/extension/src/ui/domains/Asset/Send/SendForm.tsx
@@ -17,6 +17,7 @@ import useChain from "@ui/hooks/useChain"
 import useToken from "@ui/hooks/useToken"
 import { isValidAddress } from "@talisman/util/isValidAddress"
 import { tokensToPlanck } from "@core/util"
+import { useTip } from "@ui/hooks/useTip"
 
 const SendAddressConvertInfo = lazy(() => import("./SendAddressConvertInfo"))
 
@@ -176,6 +177,7 @@ const schema = yup
       .string()
       .required("")
       .test("to-valid", "Invalid address (to)", (address) => isValidAddress(address as string)),
+    tip: yup.string().required(), // this will disable the review button until tip is fetched from tip station
   })
   .required()
 
@@ -237,10 +239,18 @@ export const SendForm = () => {
     [chain]
   )
 
+  // refresh tip while on edit form, but stop refreshing after review (showForm becomes false)
+  const { tip, error: tipError } = useTip(chainId, showForm)
+
+  useEffect(() => {
+    // force type with ! because undefined value is used to check for an invalid form.
+    setValue("tip", tip!)
+  }, [setValue, tip])
+
   useEffect(() => {
     // clear non-form error if any field is changed
-    setErrorMessage(undefined)
-  }, [amount, token, from, to])
+    setErrorMessage(tipError)
+  }, [amount, token, from, to, tip, tipError])
 
   // error if insufficient balance (it would be complicated do validate in schema while watching for balance & token)
   useEffect(() => {
@@ -250,10 +260,11 @@ export const SendForm = () => {
       amount &&
       balance &&
       isValid &&
-      balance.transferable.planck < BigInt(tokensToPlanck(amount, token.decimals))
+      tip &&
+      balance.transferable.planck < BigInt(tokensToPlanck(amount, token.decimals)) + BigInt(tip)
     )
       setErrorMessage("Insufficient balance")
-  }, [amount, balance, errorMessage, isValid, setError, token])
+  }, [amount, balance, errorMessage, isValid, setError, token, tip])
 
   if (!showForm) return null
 

--- a/apps/extension/src/ui/domains/Asset/Send/context.ts
+++ b/apps/extension/src/ui/domains/Asset/Send/context.ts
@@ -25,7 +25,7 @@ const useSendTokensProvider = ({ initialValues }: Props) => {
 
   const check = useCallback(
     async (newData: SendTokensInputs, allowReap: boolean = false) => {
-      const { amount, tokenId, from, to } = newData
+      const { amount, tokenId, from, to, tip } = newData
 
       const token = tokens[tokenId]
       if (!token) throw new Error("Token not found")
@@ -79,6 +79,7 @@ const useSendTokensProvider = ({ initialValues }: Props) => {
         from,
         to,
         transfer.amount.planck.toString(),
+        tip,
         allowReap
       )
 
@@ -90,7 +91,11 @@ const useSendTokensProvider = ({ initialValues }: Props) => {
           nativeToken.decimals,
           nativeToken.rates
         ),
-        amount: new BalanceFormatter(partialFee, nativeToken.decimals, nativeToken.rates),
+        amount: new BalanceFormatter(
+          BigInt(partialFee) + BigInt(tip),
+          nativeToken.decimals,
+          nativeToken.rates
+        ),
       }
 
       // for each currency involved, check if sufficient balance and if it will cause account to be reaped
@@ -156,7 +161,7 @@ const useSendTokensProvider = ({ initialValues }: Props) => {
 
   // execute the TX
   const send = useCallback(async () => {
-    const { amount, tokenId, from, to } = formData as SendTokensInputs
+    const { amount, tokenId, from, to, tip } = formData as SendTokensInputs
 
     const token = tokens[tokenId]
     if (!token) throw new Error("Token not found")
@@ -170,6 +175,7 @@ const useSendTokensProvider = ({ initialValues }: Props) => {
       from,
       to,
       tokensToPlanck(amount, token.decimals),
+      tip,
       hasAcceptedForfeit
     )
     setTransactionId(id)

--- a/apps/extension/src/ui/domains/Asset/Send/types.ts
+++ b/apps/extension/src/ui/domains/Asset/Send/types.ts
@@ -18,6 +18,7 @@ export type SendTokensInputs = {
   tokenId: TokenId
   from: string
   to: string
+  tip: string
 }
 
 export type SendTokensExpectedResult = {

--- a/apps/extension/src/ui/hooks/useTip.ts
+++ b/apps/extension/src/ui/hooks/useTip.ts
@@ -1,0 +1,96 @@
+import { ChainId } from "@core/types"
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+export type TipOptionName = "low" | "medium" | "high"
+export type TipOptions = Record<TipOptionName, string>
+type TipOptionsResolver = (response: Response, chainId: ChainId) => Promise<TipOptions>
+
+type GasStationInfo = {
+  url: string
+  resolver: TipOptionsResolver
+}
+
+const getAstarTipOptions: TipOptionsResolver = async (response) => {
+  const json = await response.json()
+
+  return {
+    low: json.data.tip.slow,
+    medium: json.data.tip.average,
+    high: json.data.tip.fast,
+  }
+}
+
+// each gas station has a different response shape
+const gasStations: Record<ChainId, GasStationInfo> = {
+  astar: {
+    url: "https://astar-gas-station.herokuapp.com/api/astar/gasnow",
+    resolver: getAstarTipOptions,
+  },
+  shiden: {
+    url: "https://astar-gas-station.herokuapp.com/api/shiden/gasnow",
+    resolver: getAstarTipOptions,
+  },
+  shibuya: {
+    url: "https://astar-gas-station.herokuapp.com/api/shibuya/gasnow",
+    resolver: getAstarTipOptions,
+  },
+}
+
+const useTipStation = (chainId?: ChainId, autoRefresh = true) => {
+  const [tipOptions, setTipOptions] = useState<TipOptions>()
+  const [error, setError] = useState<string>()
+
+  // reset if chain changes
+  useEffect(() => {
+    setTipOptions(undefined)
+    setError(undefined)
+  }, [chainId])
+
+  const fetchTipOptions = useCallback(async () => {
+    if (!chainId) return
+    const gasStationInfo = gasStations[chainId]
+    if (gasStationInfo) {
+      try {
+        const response = await fetch(gasStationInfo.url)
+        const options = await gasStationInfo.resolver(response, chainId)
+        setTipOptions(options)
+      } catch (err) {
+        setError("Failed to fetch tip options")
+      }
+    } else setTipOptions({ low: "0", medium: "0", high: "0" })
+  }, [chainId])
+
+  // auto refresh
+  useEffect(() => {
+    if (!autoRefresh) return () => {}
+
+    const interval = setInterval(fetchTipOptions, 10_000)
+    return () => clearInterval(interval)
+  }, [autoRefresh, fetchTipOptions])
+
+  // initial fetch
+  useEffect(() => {
+    fetchTipOptions()
+  }, [fetchTipOptions])
+
+  const requiresTip = useMemo(() => Boolean(chainId && gasStations[chainId]), [chainId])
+
+  return { requiresTip, tipOptions, error }
+}
+
+export const useTip = (chainId?: string, autoRefresh = true, option: TipOptionName = "medium") => {
+  const { requiresTip, tipOptions, error } = useTipStation(chainId, autoRefresh)
+
+  const tip = useMemo(() => {
+    if (!requiresTip) return "0"
+    if (!tipOptions) return undefined
+    return tipOptions[option]
+  }, [option, requiresTip, tipOptions])
+
+  return {
+    requiresTip,
+    tipOptions,
+    tip,
+    error,
+  }
+}


### PR DESCRIPTION
fixes the issue where send funds wizard isn't working on Astar

introduces a new useTip hook, used to return substrate tip to add for transaction on a given network
for now, only astar networks (astar, shiden, shibuya) are implemented in useTip, it will return "0" for other networks.