### PR TITLE
fix: allow substrate auth request on evm dapps

### DIFF
--- a/apps/extension/src/core/handlers/Tabs.ts
+++ b/apps/extension/src/core/handlers/Tabs.ts
@@ -56,7 +56,7 @@ export default class Tabs extends TabsHandler {
 
   private async authorize(url: string, request: RequestAuthorizeTab): Promise<boolean> {
     const siteFromUrl = await this.stores.sites.getSiteFromUrl(url)
-    if (siteFromUrl) {
+    if (siteFromUrl?.addresses) {
       // this url was seen in the past
       assert(
         siteFromUrl.addresses?.length,


### PR DESCRIPTION
fixes a bug where if a dapp auths a user with EVM, then tries to auth the user with substrate, Talisman considers that user had previously rejected the auth request and throws an error.