### PR TITLE
fix: incorrect balances in ledger import picker

### DIFF
--- a/apps/extension/src/ui/domains/Account/LedgerAccountPicker.tsx
+++ b/apps/extension/src/ui/domains/Account/LedgerAccountPicker.tsx
@@ -135,7 +135,7 @@ const useLedgerChainAccounts = (chainId: string, selectedAccounts: LedgerAccount
     try {
       // required for formating balances correctly
       const chains = { [chain.id]: chain }
-      const tokens = chain.nativeToken?.id ? { [chain.nativeToken.id]: token } : {}
+      const tokens = { [token.id]: token }
 
       const accountIndex = ledgerAccounts.length
       const { address } = await ledger.getAddress(false, accountIndex, 0)


### PR DESCRIPTION
fixes a bug in ledger import were values were displayed without considering the token decimals