### PR TITLE
fix: add network select icon border-radius and reduced gap between icon and name

### DIFF
--- a/apps/extension/src/ui/domains/Ethereum/NetworkLogo.tsx
+++ b/apps/extension/src/ui/domains/Ethereum/NetworkLogo.tsx
@@ -2,7 +2,6 @@ import styled from "styled-components"
 import globeIcon from "@talisman/theme/icons/globe.white.svg"
 import { useEvmNetwork } from "@ui/hooks/useEvmNetwork"
 import { classNames } from "@talisman/util/classNames"
-import { useEffect, useRef } from "react"
 
 const NetworkLogoContainer = styled.picture`
   & {
@@ -16,6 +15,7 @@ const NetworkLogoContainer = styled.picture`
     left: 0;
     width: 100%;
     height: 100%;
+    border-radius: 50%;
   }
 `
 

--- a/apps/extension/src/ui/domains/Ethereum/NetworkSelect.tsx
+++ b/apps/extension/src/ui/domains/Ethereum/NetworkSelect.tsx
@@ -8,7 +8,7 @@ import { NetworkLogo } from "./NetworkLogo"
 
 const NetworkItem = styled.div`
   display: flex;
-  gap: 1.2rem;
+  gap: 1rem;
 `
 
 type NetworkSelectProps = {


### PR DESCRIPTION
#### before
![before](https://user-images.githubusercontent.com/2741569/173535505-705d2eac-a052-4543-a81d-5009748ca729.png)

#### after
![after](https://user-images.githubusercontent.com/2741569/173535486-a4d8e8cb-413a-47ad-89d9-542656a7bc27.png)