### PR TITLE
fix: send funds breaks if no token supplied

### DIFF
--- a/apps/extension/src/ui/domains/Asset/Picker.tsx
+++ b/apps/extension/src/ui/domains/Asset/Picker.tsx
@@ -177,22 +177,29 @@ const AssetPicker: FC<IProps> = ({
   className,
   showChainsWithBalanceFirst,
 }) => {
-  const allTokens = useTokens()
   const chains = useChains()
   const chainsMap = useMemo(
     () => Object.fromEntries((chains || []).map((chain) => [chain.id, chain])),
     [chains]
   )
-  // const evmNetworksList = useEvmNetworks()
+
   const allChains = useSortedChains()
   const chainsWithPrefix: Chain[] = useHasPrefixChainsFilter(allChains)
   const tokensWithNormalSorting = useChainsTokens(chainsWithPrefix)
   const tokensWithBalanceFirst = useChainsTokensWithBalanceFirst(tokensWithNormalSorting, address)
-  const tokens = showChainsWithBalanceFirst ? tokensWithBalanceFirst : tokensWithNormalSorting
+  const tokens = useMemo(
+    () => (showChainsWithBalanceFirst ? tokensWithBalanceFirst : tokensWithNormalSorting),
+    [showChainsWithBalanceFirst, tokensWithBalanceFirst, tokensWithNormalSorting]
+  )
 
   const [selectedTokenId, setSelectedTokenId] = useState<TokenId | undefined>(
-    () => value ?? defaultValue ?? tokens[0].id ?? undefined
+    () => value ?? defaultValue ?? tokens[0]?.id ?? undefined
   )
+
+  // if not set yet, set a token as soon as tokens are loaded
+  useEffect(() => {
+    if (selectedTokenId === undefined && tokens.length > 0) setSelectedTokenId(tokens[0].id)
+  }, [selectedTokenId, tokens])
 
   // trigger parent's onChange
   useEffect(() => {


### PR DESCRIPTION
Send funds modal was throwing an error when trying to set a default token in the asset picker, if none was supplied.
This explains why it was breaking using the popup's generic "send fund", but not form the accounts list where we set the first available token in that account