### PR TITLE
fix: navigate back to custom tokens after create

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/CustomTokens/CustomTokenAdd.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/CustomTokens/CustomTokenAdd.tsx
@@ -105,7 +105,7 @@ export const CustomTokenAdd = () => {
         assert(tokenInfo.evmNetworkId === token.evmNetworkId, "Token mismatch")
         // save the object composed with CoinGecko and chain data
         await api.addCustomErc20Token(tokenInfo)
-        navigate("/")
+        navigate("/tokens")
       } catch (err) {
         setError(`Failed to add the token : ${(err as Error)?.message ?? ""}`)
       }
@@ -171,7 +171,12 @@ export const CustomTokenAdd = () => {
         </Split>
         <ErrorDiv>{error}</ErrorDiv>
         <Footer>
-          <SimpleButton type="submit" primary disabled={!isValid} processing={isSubmitting}>
+          <SimpleButton
+            type="submit"
+            primary
+            disabled={!isValid || isLoading}
+            processing={isSubmitting}
+          >
             <PlusIcon />
             Add Token
           </SimpleButton>


### PR DESCRIPTION
Fixes #35 

- [x] after creating a custom token, redirect the user to custom tokens list so he can add another
- [x] disable submit button while fetching ERC20 infos

Note: moonriver was busy this morning, it took more than a second to pull ERC20 info, noticed the submit button was active during the fetch so i disabled it.