### PR TITLE
fix: error when dapp calls eth_getBlockByNumber

### DIFF
--- a/apps/extension/src/core/domains/ethereum/handler.tabs.ts
+++ b/apps/extension/src/core/domains/ethereum/handler.tabs.ts
@@ -446,18 +446,6 @@ export class EthTabsHandler extends TabsHandler {
         return this.signMessage(url, request as EthRequestArguments<"eth_sign">)
       }
 
-      case "eth_getBlockByHash":
-      case "eth_getBlockByNumber": {
-        const {
-          params: [blockTag, withTransactions],
-        } = request as EthRequestArguments<"eth_getBlockByHash">
-        const provider = await this.getProvider(url)
-        if (withTransactions) {
-          return await provider.getBlockWithTransactions(blockTag)
-        }
-        return await provider.getBlock(blockTag)
-      }
-
       case "eth_sendTransaction": {
         const {
           params: [txRequest],


### PR DESCRIPTION
fixes an issue raised by a test user where no transaction requests would ever show up on https://nftrade.com

Before sending a tx, the site calls eth_getBlockByNumber("latest"), which throws an error with Talisman.

We were handling this message manually, I don't recall why.
I believe that most `eth_xxxxx` message are better handled by the RPC itself, except when they need signing from wallet of course

I deleted our handler and it fixed the bug.
This same handler was handling eth_getBlockByHash, I can't test it as I don't know any dapp that uses it but I'm pretty sure the RPC will handle it better than us too, so I deleted both.

Note : we are now the proud owners of [Pink Rabbit #2191](https://nftrade.com/assets/moonriver/0x08716e418e68564c96b68192e985762740728018/259383)