### PR TITLE
fix: eth_chainId cache and allow public methods

### DIFF
--- a/apps/extension/src/ui/hooks/useAuthorisedSites.tsx
+++ b/apps/extension/src/ui/hooks/useAuthorisedSites.tsx
@@ -8,5 +8,11 @@ const INITIAL_VALUE: AuthorizedSites = {}
 const subscribe = (subject: BehaviorSubject<AuthorizedSites>) =>
   api.authorizedSitesSubscribe((v) => subject.next(v))
 
+const authorisedSitesOnly = (value: AuthorizedSites): AuthorizedSites => {
+  const result = { ...value }
+  for (let id in result) if (!result[id].addresses && !result[id].ethAddresses) delete result[id]
+  return result
+}
+
 export const useAuthorisedSites = () =>
-  useMessageSubscription("authorizedSitesSubscribe", INITIAL_VALUE, subscribe)
+  useMessageSubscription("authorizedSitesSubscribe", INITIAL_VALUE, subscribe, authorisedSitesOnly)


### PR DESCRIPTION
- [x] when dapp calls eth_chainId, return value from the authorisedSites store
- [x] eth_chainId do not trigger auth and returns undefined if site is unauthorised
- [x] eth_accounts do not trigger auth and returns empty array if site is unauthorised

retested fully on major ETH and dotsama EVM dapps, UX is much smoother