### PR TITLE
fix: link from onboarding to dashboard should not close browser window

### DIFF
--- a/apps/extension/src/ui/apps/onboard/routes/Complete.tsx
+++ b/apps/extension/src/ui/apps/onboard/routes/Complete.tsx
@@ -70,8 +70,8 @@ export const Complete = () => (
         <BtnComplete
           autoFocus
           primary
-          onClick={() => {
-            api.dashboardOpen("/accounts")
+          onClick={async () => {
+            await api.dashboardOpen("/accounts")
             window.close()
           }}
         >


### PR DESCRIPTION
When a user completes the onboarding process, they are sent to the dashboard to view their account balances.

We achieve this by opening a new tab on the dashboard and closing the current tab.

However, we don't wait for the new tab to open before closing the current tab.

As such, if a user has only one tab open in their browser (and their browser is set to close the window when all tabs are closed), the user will be left staring at an empty screen (no browser window left!).
This is confusing for a user who just clicked a button labelled `Go to my account`.

The fix: wait for the new tab to open before closing the current tab.
Tested on chrome on linux.