### PR TITLE
feat: poll evm native & erc20 balances

### DIFF
--- a/apps/extension/src/core/libs/evmRpc/NativeBalances.ts
+++ b/apps/extension/src/core/libs/evmRpc/NativeBalances.ts
@@ -58,18 +58,6 @@ export default class NativeBalancesEvmRpc {
     return await this.fetchNativeBalances(addresses, evmNetworks)
   }
 
-  private static async getEvmNetworkProviders(
-    evmNetworks: Array<Pick<EvmNetwork, "id" | "nativeToken">>
-  ): Promise<Record<EvmNetworkId, JsonRpcBatchProvider>> {
-    return Object.fromEntries(
-      await Promise.all(
-        evmNetworks.map((evmNetwork) =>
-          getProviderForEvmNetworkId(evmNetwork.id).then((provider) => [evmNetwork.id, provider])
-        )
-      )
-    )
-  }
-
   private static async fetchNativeBalances(
     addresses: Address[],
     evmNetworks: Array<Pick<EvmNetwork, "id" | "nativeToken">>
@@ -122,6 +110,18 @@ export default class NativeBalancesEvmRpc {
 
     // return to caller
     return new Balances(balances)
+  }
+
+  private static async getEvmNetworkProviders(
+    evmNetworks: Array<Pick<EvmNetwork, "id" | "nativeToken">>
+  ): Promise<Record<EvmNetworkId, JsonRpcBatchProvider>> {
+    return Object.fromEntries(
+      await Promise.all(
+        evmNetworks.map((evmNetwork) =>
+          getProviderForEvmNetworkId(evmNetwork.id).then((provider) => [evmNetwork.id, provider])
+        )
+      )
+    )
   }
 
   private static async getFreeBalance(


### PR DESCRIPTION
The evm balances mvp only fetches the balances once per subscriber :sob:

This PR implements a 6-second polling interval.

To note: for each outgoing connection we don't begin the 6-second countdown to the next request until the existing request has completed.
This should prevent the scenario where we stack up a bunch of pending requests.