### PR TITLE
fix: better hide balance

### DIFF
--- a/apps/extension/src/@talisman/theme/global.tsx
+++ b/apps/extension/src/@talisman/theme/global.tsx
@@ -242,7 +242,6 @@ const Global = createGlobalStyle`
     }
 
     ::after {
-      transition: all var(--transition-speed) ease-in;
       backdrop-filter: blur(10px);
       content:"";
       background: radial-gradient(rgba(90, 90, 90, 0.2) 0%, rgba(90, 90, 90, 0) 100%);

--- a/apps/extension/src/ui/apps/popup/components/TotalFiatBalance.tsx
+++ b/apps/extension/src/ui/apps/popup/components/TotalFiatBalance.tsx
@@ -69,6 +69,11 @@ const Side = styled.div`
 // force height to prevent flickering
 const TotalFiat = styled.div`
   height: 2.9rem;
+
+  span {
+    display: inline-block;
+    min-width: 15rem;
+  }
 `
 
 export const TotalFiatBalance = ({ className }: { className?: string }) => {

--- a/apps/extension/src/ui/domains/Asset/Fiat.tsx
+++ b/apps/extension/src/ui/domains/Asset/Fiat.tsx
@@ -52,12 +52,10 @@ export const Fiat = ({
   noCountUp = false,
   isBalance = false,
 }: FiatProps) => {
-  const { refReveal, isRevealable, isRevealed, effectiveNoCountUp } = useRevealableBalance(
-    isBalance,
-    noCountUp
-  )
+  const { refReveal, isRevealable, isRevealed, isHidden, effectiveNoCountUp } =
+    useRevealableBalance(isBalance, noCountUp)
 
-  if (amount === null || amount === undefined) return null
+  const render = amount !== null && amount !== undefined
 
   return (
     <span
@@ -69,11 +67,13 @@ export const Fiat = ({
         className
       )}
     >
-      <DisplayValue
-        amount={amount}
-        currency={currency || undefined}
-        noCountUp={effectiveNoCountUp}
-      />
+      {render && (
+        <DisplayValue
+          amount={isHidden ? 0 : amount}
+          currency={currency || undefined}
+          noCountUp={effectiveNoCountUp}
+        />
+      )}
     </span>
   )
 }

--- a/apps/extension/src/ui/domains/Asset/Tokens.tsx
+++ b/apps/extension/src/ui/domains/Asset/Tokens.tsx
@@ -58,10 +58,8 @@ export const Tokens: FC<TokensProps> = ({
   noCountUp,
   isBalance = false,
 }) => {
-  const { refReveal, isRevealable, isRevealed, effectiveNoCountUp } = useRevealableBalance(
-    isBalance,
-    noCountUp
-  )
+  const { refReveal, isRevealable, isRevealed, isHidden, effectiveNoCountUp } =
+    useRevealableBalance(isBalance, noCountUp)
 
   const tooltip = useMemo(
     () =>
@@ -73,7 +71,7 @@ export const Tokens: FC<TokensProps> = ({
     [amount, decimals, noTooltip, symbol]
   )
 
-  if (amount === null || amount === undefined) return null
+  const render = amount !== null && amount !== undefined
 
   return (
     <Component
@@ -85,9 +83,15 @@ export const Tokens: FC<TokensProps> = ({
         className
       )}
     >
-      <WithTooltip as="span" tooltip={tooltip} noWrap>
-        <DisplayValue amount={amount} symbol={symbol} noCountUp={effectiveNoCountUp} />
-      </WithTooltip>
+      {render && (
+        <WithTooltip as="span" tooltip={tooltip} noWrap>
+          <DisplayValue
+            amount={isHidden ? 0 : amount}
+            symbol={symbol}
+            noCountUp={effectiveNoCountUp}
+          />
+        </WithTooltip>
+      )}
     </Component>
   )
 }

--- a/apps/extension/src/ui/hooks/useRevealableBalance.ts
+++ b/apps/extension/src/ui/hooks/useRevealableBalance.ts
@@ -9,7 +9,8 @@ export const useRevealableBalance = (isBalance?: boolean, noCountUp?: boolean) =
   const refReveal = useRef<HTMLDivElement>(null)
   const [isRevealed, setIsRevealed] = useState(false)
 
-  const isRevealable = useMemo(() => isBalance && hideBalances, [hideBalances, isBalance])
+  const isRevealable = useMemo(() => Boolean(isBalance && hideBalances), [hideBalances, isBalance])
+  const isHidden = useMemo(() => isRevealable && !isRevealed, [isRevealable, isRevealed])
 
   // locks noCountUp once it set
   useEffect(() => {
@@ -40,6 +41,7 @@ export const useRevealableBalance = (isBalance?: boolean, noCountUp?: boolean) =
     refReveal,
     isRevealable,
     isRevealed: !isRevealable || isRevealed, //if not revealable, it's revealed
+    isHidden,
     effectiveNoCountUp,
   }
 }


### PR DESCRIPTION
Problem has been raised twice on public server that sometimes balances don't get blurred when activating the hide balance feature. 
[latest report](https://discord.com/channels/858891448271634473/858918692082155540/988994585869041704)
I couldn't reproduce it, it might be browser/OS specific.

This PR aims at replacing the balance value by 0 when balances are hidden so that even if there is a problem with the blur, the value won't appear on screen.

- [x] replace balances by 0 when hidden
- [x] fix the main portfolio value reveal (click wasn't revealing the value since react 18 PR)

Note : to prevent the 0 to appear when switching state, i had to remove the opacity transition.