### PR TITLE
fix: analytics popup appears when unnecessary

### DIFF
--- a/apps/extension/src/ui/domains/Settings/Analytics/AnalyticsAlert.tsx
+++ b/apps/extension/src/ui/domains/Settings/Analytics/AnalyticsAlert.tsx
@@ -104,19 +104,17 @@ export const AlertCard = styled(({ className, onLearnMoreClick, onAccept, onReje
 `
 
 const AnalyticsAlertPopupDrawer = () => {
-  // we should display the alert only once in the popup
-  const [hasAnalyticsRequestShown, setHasAnalyticsRequestShown] = useState<boolean>(false)
-  const { close, isOpen } = useOpenClose(!hasAnalyticsRequestShown)
+  const { close, isOpen, setIsOpen } = useOpenClose()
   const { update } = useSettings()
 
   useEffect(() => {
     const sub = appStore.observable.subscribe(({ analyticsRequestShown }) => {
-      setHasAnalyticsRequestShown(analyticsRequestShown)
+      setIsOpen(!analyticsRequestShown)
     })
     return () => {
       sub.unsubscribe()
     }
-  }, [])
+  }, [setIsOpen])
 
   const handleOpenLearnMore = useCallback(() => {
     api.dashboardOpen("/settings/analytics")
@@ -133,7 +131,7 @@ const AnalyticsAlertPopupDrawer = () => {
   )
 
   return (
-    <Drawer open={!hasAnalyticsRequestShown && isOpen} anchor="bottom">
+    <Drawer open={isOpen} anchor="bottom">
       <AlertCard
         onLearnMoreClick={handleOpenLearnMore}
         onAccept={() => handleAcceptReject(true)}


### PR DESCRIPTION
This PR fixes a bug where analytics drawer was sometimes appearing briefly while popup content was loading.
It was due to the fact that while waiting to get the information from the backend that the popup had already been shown, it was considered that it was never been shown.

The issue in the business logic was already there but bug didn't appear on screen until the React 18 upgrade.

https://user-images.githubusercontent.com/26880866/175083973-d33693b6-5659-413f-ba9c-34042692f5f1.mp4


