### PR TITLE
fix: serializable add eth network request

### DIFF
--- a/apps/extension/src/core/domains/ethereum/requestsStore.networks.ts
+++ b/apps/extension/src/core/domains/ethereum/requestsStore.networks.ts
@@ -1,6 +1,6 @@
-import type { AddEthereumChainRequest, AddEthereumChainParameter } from "@core/types"
 import { stripUrl } from "@core/handlers/helpers"
-import { RequestStore } from "@core/libs/RequestStore"
+import { RequestStore, TRespondableRequest } from "@core/libs/RequestStore"
+import type { AddEthereumChainParameter, AddEthereumChainRequest } from "@core/types"
 
 class AddNetworkError extends Error {}
 
@@ -8,8 +8,11 @@ export default class EthereumNetworksRequestsStore extends RequestStore<
   AddEthereumChainRequest,
   null
 > {
-  protected mapRequestToData(req: AddEthereumChainRequest) {
-    return req
+  protected mapRequestToData(
+    req: TRespondableRequest<AddEthereumChainRequest, null>
+  ): AddEthereumChainRequest {
+    const { resolve, reject, ...data } = req
+    return data
   }
 
   async requestAddNetwork(url: string, network: AddEthereumChainParameter) {


### PR DESCRIPTION
Same bug as the one for transaction requests, resolve/reject methods were preventing the add network request to be serializable, which breaks the subscription on firefox.

@chidg If mapRequestToData's sole purpose is to remove resolve and reject methods, shouldn't we implement it in base store instead of having to override it for each actual store ? 