### PR TITLE
feat: allow users to delete derived accounts

### DIFF
--- a/apps/extension/src/ui/domains/Account/Item.tsx
+++ b/apps/extension/src/ui/domains/Account/Item.tsx
@@ -99,7 +99,7 @@ const AccountItem = ({
           <PopNav trigger={<IconMore />} className="icon more" closeOnMouseOut>
             <PopNav.Item onClick={() => openAddressFormatter(address)}>Copy address</PopNav.Item>
             <PopNav.Item onClick={() => openAccountRename(address)}>Rename</PopNav.Item>
-            {["SEED", "JSON", "DERIVED"].includes(account?.origin as string) && (
+            {["DERIVED", "SEED", "JSON"].includes(account?.origin as string) && (
               <PopNav.Item
                 onClick={async () => {
                   const { exportedJson } = await api.accountExport(address)
@@ -109,7 +109,7 @@ const AccountItem = ({
                 Export Private Key
               </PopNav.Item>
             )}
-            {["SEED", "JSON", "HARDWARE"].includes(account?.origin as string) && (
+            {["DERIVED", "SEED", "JSON", "HARDWARE"].includes(account?.origin as string) && (
               <PopNav.Item onClick={() => openAccountRemove(address)}>Remove Account</PopNav.Item>
             )}
             {account?.type === "ethereum" && (


### PR DESCRIPTION
This PR allows users to delete their derived accounts.

It also changes the logic for account creation:

Previously we would calculate a new account derivation index based on the number of derived accounts in the keyring.

Now, we simply derive each account from `0` to `1000` and check if it already exists in the keyring.
The first account which does not exist is then created.

We will probably want to port the `seed import` `multi-account-select` screen across to the `create derived account` button in order to make this PR feature-complete.
But imo the PR is still in a better state than the current prod branch.
I'd prefer confusion over what account index clicking `New account` will create than the current `No deleting accounts for you!` approach.