### PR TITLE
fix ledger asset transfer bug

### DIFF
--- a/apps/extension/src/core/libs/rpc/PendingTransfers.ts
+++ b/apps/extension/src/core/libs/rpc/PendingTransfers.ts
@@ -21,6 +21,7 @@ class PendingTransfer {
 
   constructor(data: PendingTransferInfo) {
     this.data = data
+    this.transfer = this.transfer.bind(this)
   }
 
   async transfer(


### PR DESCRIPTION
Fixes a bug where the `transfer` method on the PendingTransfer class was not bound to the class, preventing transfer from going ahead