### PR TITLE
fix: prevent "manifest is not valid json" error in chrome on extension reloading

### DIFF
--- a/apps/extension/webpack/webpack.dev.js
+++ b/apps/extension/webpack/webpack.dev.js
@@ -19,10 +19,6 @@ module.exports = merge(common, {
           from: "manifest.json",
           to: distDir,
           context: "public",
-          // overwrite non-transformed manifest.json
-          // force: true,
-          // copied last to overwrite the `dist/manifest.json` copied by the `from "."` pattern
-          // priority: 10,
           transform(content) {
             // Parse the manifest
             const manifest = JSON.parse(content.toString())
@@ -38,6 +34,7 @@ module.exports = merge(common, {
           from: ".",
           to: distDir,
           context: "public",
+          // do not copy the manifest, that's handled separately
           filter: (filepath) => filepath !== manifestPath,
         },
       ],


### PR DESCRIPTION
Chrome was bugging out on webpack rebuild because `manifest.json` was copied twice into the dist dir, and the first time was not valid json. 

This PR prevents manifest.json being copied on the first instance.