### PR TITLE
fix: hide balances using an image

### DIFF
--- a/apps/extension/public/images/blur.svg
+++ b/apps/extension/public/images/blur.svg
@@ -1,0 +1,9 @@
+ <svg height="100" width="100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="f1" x="0" y="0">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="15" />
+    </filter>
+  </defs>
+  <rect width="100" height="100" stroke-width="3" 
+  fill="white" filter="url(#f1)" />
+</svg> 

--- a/apps/extension/src/@talisman/theme/global.tsx
+++ b/apps/extension/src/@talisman/theme/global.tsx
@@ -233,21 +233,22 @@ const Global = createGlobalStyle`
     overflow:hidden;
     border-radius:6px;
     cursor:pointer;
-    color:var(--color-foreground);
+    color:transparent; // transparent so text doesn't appear through transparent bg
 
     &.balance-reveal {
       overflow:visible;
       border-radius:0;
-      color:inherit;
+      color:inherit; // original text color
     }
 
     ::after {
-      backdrop-filter: blur(10px);
       content:"";
-      background: radial-gradient(rgba(90, 90, 90, 0.2) 0%, rgba(90, 90, 90, 0) 100%);
+      background-image:url(/images/blur.svg);
+      opacity: 0.15;
+      background-size:100% 100%;
       border-radius:6px;
       position:absolute;
-      overflow:0;
+      overflow:hidden;
       top:0;
       left:0;
       width:100%;
@@ -255,8 +256,7 @@ const Global = createGlobalStyle`
     }
 
     &.balance-reveal::after {
-      backdrop-filter: blur(0);
-      opacity:0;
+      display:none;
     }
   }
 

--- a/apps/extension/src/ui/apps/popup/components/TotalFiatBalance.tsx
+++ b/apps/extension/src/ui/apps/popup/components/TotalFiatBalance.tsx
@@ -24,7 +24,6 @@ const Container = styled.div`
 
   span {
     font-size: var(--font-size-large);
-    color: var(--color-foreground);
     font-weight: var(--font-weight-bold);
   }
 


### PR DESCRIPTION
Uses an image to hide balance, in order to support Firefox

Firefox : 
![image](https://user-images.githubusercontent.com/26880866/178126789-2bf90451-1edf-460d-9cfa-55d5dd259620.png)

Chrome : 
![image](https://user-images.githubusercontent.com/26880866/178126803-e3ad5569-6e84-47a7-901d-3e4c778e2326.png)
