### PR TITLE
fix: never block evm sign reject

### DIFF
--- a/apps/extension/src/ui/apps/popup/pages/AddCustomErc20Token.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/AddCustomErc20Token.tsx
@@ -3,15 +3,16 @@ import StyledGrid from "@talisman/components/Grid"
 import { IconButton } from "@talisman/components/IconButton"
 import { SimpleButton } from "@talisman/components/SimpleButton"
 import { XIcon } from "@talisman/theme/icons"
-import { api } from "@ui/api"
-import { useEvmNetwork } from "@ui/hooks/useEvmNetwork"
-import { useParams } from "react-router-dom"
-import { useCallback, useState } from "react"
-import styled from "styled-components"
-import Layout, { Content, Header, Footer } from "../Layout"
 import unknownToken from "@talisman/theme/icons/custom-token-generic.svg"
+import { api } from "@ui/api"
 import { CustomErc20TokenViewDetails } from "@ui/domains/Erc20Tokens/CustomErc20TokenViewDetails"
 import { useEthWatchAssetRequestById } from "@ui/hooks/useEthWatchAssetRequestById"
+import { useEvmNetwork } from "@ui/hooks/useEvmNetwork"
+import { useCallback, useState } from "react"
+import { useParams } from "react-router-dom"
+import styled from "styled-components"
+
+import Layout, { Content, Footer, Header } from "../Layout"
 
 const TokenLogo = styled.img`
   width: 5.4rem;
@@ -111,10 +112,10 @@ export const AddCustomErc20Token = () => {
     setError(undefined)
     try {
       await api.ethWatchAssetRequestCancel(id)
-      window.close()
     } catch (err) {
-      setError((err as Error).message)
+      // ignore
     }
+    window.close()
   }, [id])
 
   if (!request || !request.token || !network) return null

--- a/apps/extension/src/ui/domains/Sign/SignRequestContext/AnySignRequestContext.ts
+++ b/apps/extension/src/ui/domains/Sign/SignRequestContext/AnySignRequestContext.ts
@@ -38,15 +38,14 @@ export const useAnySigningRequest = <T extends AnySigningRequest>({
 
   // handle request rejection
   const reject = useCallback(async () => {
-    setStatus.processing("Rejecting request")
-    if (!currentRequest) return
     try {
-      await cancelSignFn(currentRequest.id)
-      setStatus.success("Rejected")
+      if (currentRequest) await cancelSignFn(currentRequest.id)
     } catch (err) {
-      setStatus.error("Failed to reject sign request")
+      // ignore, request doesn't exist
+      // we just want popup to close
     }
-  }, [cancelSignFn, currentRequest, setStatus])
+    window.close()
+  }, [cancelSignFn, currentRequest])
 
   return {
     id: currentRequest?.id,


### PR DESCRIPTION
Fixed an issue on sign EVM popup where clicking reject/sign would display an error message "failed to reject request".

This happened when the request had already been processed. Now it will just close the popup.