### PR TITLE
fix: remove global TypeRegistry from signing handler and use new memo…

### DIFF
--- a/apps/extension/src/core/domains/signing/handler.ts
+++ b/apps/extension/src/core/domains/signing/handler.ts
@@ -40,9 +40,7 @@ export default class SigningHandler extends ExtensionHandler {
     if (isJsonPayload(payload)) {
       const { blockHash, genesisHash, signedExtensions } = payload
 
-      const chains = await db.chains.toArray()
-      const chain = chains.find((c) => c.genesisHash === genesisHash)
-
+      const chain = await db.chains.get({ genesisHash })
       if (chain) registry = await getTypeRegistry(chain.id, blockHash)
 
       // Get the metadata for the genesisHash


### PR DESCRIPTION
I noticed in signing handlers, we were still using a global `TypeRegistry`
This could potentially be memory-unsafe as over time it could grow larger.

I replaced this with the `getTypeRegistry` function in the case of a JSON payload request; for a raw request, we can't extract the necessary details, so we just have to instantiate a blank TypeRegistry.