### PR TITLE
feat: portfolio support for more locked types

### DIFF
--- a/apps/extension/src/core/domains/balances/types/index.ts
+++ b/apps/extension/src/core/domains/balances/types/index.ts
@@ -24,7 +24,7 @@ export interface RequestBalancesByParamsSubscribe {
   addressesByChain: AddressesByChain
 }
 
-export type BalanceLockType = "democracy" | "staking" | "vesting" | "other"
+export type BalanceLockType = "democracy" | "staking" | "vesting" | "dapp-staking" | "other"
 export type LockedBalance = {
   type: BalanceLockType
   amount: string //planck

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/useChainTokenBalances.ts
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/useChainTokenBalances.ts
@@ -26,6 +26,7 @@ type ChainTokenBalancesParams = {
 const getBalanceLockTypeTitle = (input: BalanceLockType, allLocks: LockedBalance[]) => {
   if (!input) return input
   if (input === "democracy") return "Governance"
+  if (input === "dapp-staking") return "DApp staking"
   if (input === "other")
     return allLocks.some(({ type }) => type !== "other") ? "Locked (other)" : "Locked"
 


### PR DESCRIPTION
Related to #121 

Adds support for following token lock types in Portfolio V2 : calamvst, ormlvest, phrelect, stkngdel, kiltpstk, dapstake
Following token lock types are ignored and will simply appear as "locked" because I have no idea what they are : pdexlock, phala/sp

Also added chainId tag in sentry traces to help identifying on which chain unknown token types are.