### PR TITLE
Re-add terser webpack plugin to prod webpack config

### DIFF
--- a/apps/extension/webpack/webpack.prod.js
+++ b/apps/extension/webpack/webpack.prod.js
@@ -3,6 +3,7 @@
 const { merge } = require("webpack-merge")
 const CopyPlugin = require("copy-webpack-plugin")
 const ZipPlugin = require("zip-webpack-plugin")
+const TerserPlugin = require("terser-webpack-plugin")
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin
 
 const common = require("./webpack.common.js")
@@ -68,7 +69,7 @@ const config = (env) =>
     ].filter(Boolean),
     optimization: {
       minimize: true,
-      minimizer: [() => ({ terserOptions: { compress: true } })],
+      minimizer: [new TerserPlugin({ terserOptions: { compress: true } })],
     },
   })
 


### PR DESCRIPTION
Terser Webpack Plugin was removed under the impression that webpack 5 now includes it by default, however the builds produced using this config resulted in much larger files. This PR re-adds the plugin for the production webpack config to ensure small build artefacts.
