### PR TITLE
fix: control back button target

### DIFF
--- a/apps/extension/src/@talisman/components/BackButton.tsx
+++ b/apps/extension/src/@talisman/components/BackButton.tsx
@@ -1,8 +1,9 @@
-import styled from "styled-components"
 import Button from "@talisman/components/Button"
 import { ChevronLeftIcon } from "@talisman/theme/icons"
-import { useNavigate } from "react-router-dom"
 import { FC, useCallback } from "react"
+import { To, useNavigate } from "react-router-dom"
+import styled from "styled-components"
+
 import { ILinkProps } from "./Link"
 
 const StyledButton = styled(Button)`
@@ -22,9 +23,9 @@ const StyledButton = styled(Button)`
   }
 `
 
-export const BackButton: FC<ILinkProps> = ({ children, ...props }) => {
+export const BackButton: FC<ILinkProps> = ({ children, to, ...props }) => {
   const navigate = useNavigate()
-  const handleBackClick = useCallback(() => navigate(-1), [navigate])
+  const handleBackClick = useCallback(() => navigate(to ?? (-1 as To)), [navigate, to])
 
   return (
     <StyledButton small onClick={handleBackClick} {...props}>

--- a/apps/extension/src/ui/apps/dashboard/layout/index.tsx
+++ b/apps/extension/src/ui/apps/dashboard/layout/index.tsx
@@ -17,15 +17,16 @@ type LayoutProps = {
   centered?: boolean
   large?: boolean
   withBack?: boolean
+  backTo?: string
   className?: string
 }
 
-const UnstyledLayout: FC<LayoutProps> = ({ withBack, children, className }) => (
+const UnstyledLayout: FC<LayoutProps> = ({ withBack, backTo, children, className }) => (
   <main className={className}>
     <SideBar />
     <section className="main-area">
       <div className="children">
-        {!!withBack && <BackButton className="back" />}
+        {!!withBack && <BackButton className="back" to={backTo} />}
         {children}
       </div>
       <Suspense fallback={null}>

--- a/apps/extension/src/ui/apps/dashboard/routes/About.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/About.tsx
@@ -19,7 +19,7 @@ const Description = styled.div`
 
 const About = () => {
   return (
-    <Layout withBack centered>
+    <Layout withBack centered backTo="/settings">
       <HeaderBlock title="About" />
       <Description>
         <p>

--- a/apps/extension/src/ui/apps/dashboard/routes/CustomTokens/CustomTokens.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/CustomTokens/CustomTokens.tsx
@@ -117,7 +117,7 @@ export const CustomTokens = () => {
   if (!sortedTokens) return null
 
   return (
-    <Layout withBack centered>
+    <Layout withBack centered backTo="/settings">
       <HeaderBlock title="Manage custom tokens" text="Add or delete custom ERC20 tokens" />
       <TokensList>
         {sortedTokens.map((token) => (

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/Options.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/Options.tsx
@@ -61,7 +61,7 @@ const Options = () => {
   )
 
   return (
-    <Layout centered withBack>
+    <Layout centered withBack backTo="/settings">
       <HeaderBlock title="Extension options" text="Customise your extension experience" />
       <Spacer />
       <Grid columns={1}>

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/SecurityPrivacySettings.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/SecurityPrivacySettings.tsx
@@ -1,12 +1,12 @@
-import HeaderBlock from "@talisman/components/HeaderBlock"
-import Spacer from "@talisman/components/Spacer"
-import Grid from "@talisman/components/Grid"
 import Field from "@talisman/components/Field"
+import Grid from "@talisman/components/Grid"
+import HeaderBlock from "@talisman/components/HeaderBlock"
 import Setting from "@talisman/components/Setting"
+import Spacer from "@talisman/components/Spacer"
 import Layout from "@ui/apps/dashboard/layout"
-import styled from "styled-components"
 import { useSettings } from "@ui/hooks/useSettings"
 import { useNavigate } from "react-router-dom"
+import styled from "styled-components"
 
 const LinkText = styled.span`
   color: var(--color-primary);
@@ -21,7 +21,7 @@ const SecurityPrivacySettings = () => {
   const { useAnalyticsTracking, useErrorTracking, update } = useSettings()
   const navigate = useNavigate()
   return (
-    <Layout centered withBack>
+    <Layout centered withBack backTo="/settings">
       <HeaderBlock title="Security and Privacy" text="Control security and privacy preferences" />
       <Spacer />
       <Grid columns={1}>

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/SitesConnected.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/SitesConnected.tsx
@@ -1,8 +1,8 @@
-import Settings from "@ui/domains/Settings"
 import Layout from "@ui/apps/dashboard/layout"
+import Settings from "@ui/domains/Settings"
 
 const AccountIndex = () => (
-  <Layout centered withBack>
+  <Layout centered withBack backTo="/settings">
     <Settings.AuthorisedSites />
   </Layout>
 )


### PR DESCRIPTION
Fixes : 
- #163 
- #146 

Added a `backTo` property on dashboard layout, allowing to set url target when clicking on the back button, ignoring the browser nav flow.
Used this property on all settings sub page to make sure clicking the back button redirects to the settings hub.