### PR TITLE
fix: add a sleep when adding ledger account

### DIFF
--- a/apps/extension/src/core/domains/accounts/handler.ts
+++ b/apps/extension/src/core/domains/accounts/handler.ts
@@ -39,7 +39,6 @@ export default class AccountsHandler extends ExtensionHandler {
   //   - account seed (unlocked via password)
 
   private async accountCreate({ name, type }: RequestAccountCreate): Promise<boolean> {
-    await sleep(1000)
     const password = await this.stores.password.getPassword()
     assert(password, "Not logged in")
 
@@ -168,15 +167,13 @@ export default class AccountsHandler extends ExtensionHandler {
     }
   }
 
-  private async accountsCreateHardware({
+  private accountsCreateHardware({
     accountIndex,
     address,
     addressOffset,
     genesisHash,
     name,
-  }: Omit<RequestAccountCreateHardware, "hardwareType">): Promise<boolean> {
-    await sleep(1000)
-
+  }: Omit<RequestAccountCreateHardware, "hardwareType">): boolean {
     keyring.addHardware(address, "ledger", {
       accountIndex,
       addressOffset,

--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddDerived.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddDerived.tsx
@@ -1,4 +1,5 @@
 import { AccountAddressType } from "@core/domains/accounts/types"
+import { sleep } from "@core/util/sleep"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { FormField } from "@talisman/components/Field/FormField"
 import HeaderBlock from "@talisman/components/HeaderBlock"
@@ -81,6 +82,9 @@ const AccountNew = () => {
         },
         { autoClose: false }
       )
+
+      // pause to prevent double notification
+      await sleep(1000)
 
       try {
         await api.accountCreate(name, type)

--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddLedger/AddLedgerSelectAccount.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddLedger/AddLedgerSelectAccount.tsx
@@ -1,3 +1,4 @@
+import { sleep } from "@core/util/sleep"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { notify, notifyUpdate } from "@talisman/components/Notifications"
 import { SimpleButton } from "@talisman/components/SimpleButton"
@@ -85,6 +86,9 @@ export const AddLedgerSelectAccount = () => {
         },
         { autoClose: false }
       )
+
+      // pause to prevent double notification
+      await sleep(1000)
 
       try {
         await importAccounts(accounts)


### PR DESCRIPTION
Adding a ledger account is a synchronous operation, causing a problem on UI where the "processing..." notification didn't have time to display before beeing replaced by the "success" notification.
This results in displaying 2 distinct notifications.

Added a `sleep(1000)` frontend side to prevent batch imports to be slow.

