### PR TITLE
feat: enable mimic metamask by default

### DIFF
--- a/apps/extension/src/core/domains/app/store.settings.ts
+++ b/apps/extension/src/core/domains/app/store.settings.ts
@@ -22,6 +22,6 @@ export const settingsStore = new SettingsStore("settings", {
   useAnalyticsTracking: undefined, // undefined for onboarding
   hideBalances: false,
   allowNotifications: true,
-  shouldMimicMetaMask: false,
+  shouldMimicMetaMask: true,
   autoLockTimeout: 0,
 })


### PR DESCRIPTION
- [x] changed default value in settings
- [x] tested that it doesn't trigger annoying popups/tabs when browsing (and attempting to connect) ethereum dapps, if not onboarded yet.
- [x] tested that we can log on to opensea right after onboarding

Note:  it will only affect newly onboarded users. Old users will still have to turn on the feature.