### PR TITLE
fix: error if to many decimals in amount

### DIFF
--- a/apps/extension/src/ui/domains/Asset/Send/SendForm.tsx
+++ b/apps/extension/src/ui/domains/Asset/Send/SendForm.tsx
@@ -1,4 +1,5 @@
 import { EthGasSettings } from "@core/domains/ethereum/types"
+import { Token } from "@core/domains/tokens/types"
 import { tokensToPlanck } from "@core/util"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { Box } from "@talisman/components/Box"
@@ -21,8 +22,9 @@ import {
   useEffect,
   useMemo,
   useState,
+  ReactNode,
 } from "react"
-import { useForm } from "react-hook-form"
+import { useForm, FieldError } from "react-hook-form"
 import styled from "styled-components"
 import * as yup from "yup"
 
@@ -31,7 +33,7 @@ import AssetPicker from "../Picker"
 import { useSendTokens } from "./context"
 import { EthTransactionFees, FeeSettings } from "./EthTransactionFees"
 import { SendDialogContainer } from "./SendDialogContainer"
-import { SendTokensInputs } from "./types"
+import { SendTokensInputs, TransferableToken } from "./types"
 import { useTransferableTokenById } from "./useTransferableTokens"
 
 const SendAddressConvertInfo = lazy(() => import("./SendAddressConvertInfo"))
@@ -153,6 +155,17 @@ const Container = styled(SendDialogContainer)`
   }
 `
 
+const FieldContainer = ({ error, children }: { error?: FieldError; children: ReactNode }) => (
+  <div className="relative">
+    {children}
+    {!!error?.message && (
+      <div className="text-alert-warn absolute bottom-[-1em] left-0 !h-[1em] text-xs leading-none">
+        {error?.message}
+      </div>
+    )}
+  </div>
+)
+
 const AvailableBalance = styled(Balance)`
   .loader {
     display: none;
@@ -179,6 +192,13 @@ const cleanupAmountInput = (amount: string) => {
   )
 }
 
+// ensures the input doesn't have more decimals than target token allows
+const isDecimalsValid = (amount?: string, token?: Token) => {
+  if (!amount || !token) return true
+  const decimals = Number(amount.split(".")[1]?.length ?? 0)
+  return decimals < token.decimals
+}
+
 const REVALIDATE = { shouldValidate: true, shouldDirty: true, shouldTouch: true }
 
 const substrateSchema = {
@@ -187,15 +207,22 @@ const substrateSchema = {
 
 // validation checks, used only to toggle submit button's disabled prop
 // (validation errors are not displayed on screen)
-const getSchema = (isEvm: boolean) =>
+const getSchema = (isEvm: boolean, tokens?: TransferableToken[]) =>
   yup
     .object({
+      transferableTokenId: yup.string().required(""),
       amount: yup
         .string()
         .required("")
         .transform(cleanupAmount)
-        .test("amount-gt0", "", (value) => Number(value) > 0),
-      transferableTokenId: yup.string().required(""),
+        .test("amount-gt0", "", (value) => Number(value) > 0)
+        .when("transferableTokenId", (transferableTokenId, schema) => {
+          const token = tokens?.find((t) => t.id === transferableTokenId)?.token
+          return schema.test({
+            test: (amount: string) => isDecimalsValid(amount, token),
+            message: `To many decimals (max ${token?.decimals})`,
+          })
+        }),
       from: yup
         .string()
         .required("")
@@ -211,11 +238,11 @@ const getSchema = (isEvm: boolean) =>
     .required("")
 
 export const SendForm = () => {
-  const { formData, check, showForm } = useSendTokens()
+  const { formData, check, showForm, transferableTokens } = useSendTokens()
   const [isEvm, setIsEvm] = useState(false)
   const [gasSettings, setGasSettings] = useState<EthGasSettings | undefined>(formData?.gasSettings)
 
-  const schema = useMemo(() => getSchema(isEvm), [isEvm])
+  const schema = useMemo(() => getSchema(isEvm, transferableTokens), [isEvm, transferableTokens])
 
   // react-hook-form
   const {
@@ -321,7 +348,9 @@ export const SendForm = () => {
       balance &&
       isValid &&
       tip &&
-      balance.transferable.planck < BigInt(tokensToPlanck(amount, token.decimals)) + BigInt(tip)
+      // user input may include to many decimals, make sure to exclude them before converting to BigInt
+      balance.transferable.planck <
+        BigInt(tokensToPlanck(amount, token.decimals).split(".")[0]) + BigInt(tip)
     )
       setErrorMessage("Insufficient balance")
   }, [amount, balance, errorMessage, isValid, setError, token, tip])
@@ -341,7 +370,7 @@ export const SendForm = () => {
       <form onSubmit={handleSubmit(submit)}>
         <article>
           <div>I want to send</div>
-          <div>
+          <FieldContainer error={errors.amount}>
             <InputAutoWidth
               className={`amount ${amount?.length > 0 && parseFloat(amount) > 0 ? `active` : ""}`}
               value={amount} // controlled : this is bad but we need to enforce the value to be a number
@@ -360,7 +389,8 @@ export const SendForm = () => {
               onChange={onAssetChange}
               showChainsWithBalanceFirst
             />
-          </div>
+          </FieldContainer>
+
           <div>
             <span>from</span>
             {/* Set a tabindex to ensure the underlying popup can receive focus (workaround to the wildcard transform issue) */}


### PR DESCRIPTION
fixes #214 

- prevent error if user enters to many decimals in send funds
- displays an error so user can understand why he can't proceed

Note : used an interesting yup validation schema lookup technique, discovered along the way