### PR TITLE
Fix/form validation errors not disappearing

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddSecret/AccountAddSecretMnemonic.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddSecret/AccountAddSecretMnemonic.tsx
@@ -293,6 +293,7 @@ export const AccountAddSecretMnemonic = () => {
   const handleTypeChange = useCallback(
     (type: AccountAddressType) => {
       setValue("type", type, { shouldValidate: true })
+      // revalidate to get rid of "invalid mnemonic" with a private key, when switching to ethereum
       trigger()
     },
     [setValue, trigger]

--- a/apps/extension/src/ui/apps/onboard/routes/Password.tsx
+++ b/apps/extension/src/ui/apps/onboard/routes/Password.tsx
@@ -3,10 +3,9 @@ import { Box } from "@talisman/components/Box"
 import { PasswordStrength } from "@talisman/components/PasswordStrength"
 import { AnalyticsPage, sendAnalyticsEvent } from "@ui/api/analytics"
 import { useAnalyticsPageView } from "@ui/hooks/useAnalyticsPageView"
-import { useCallback } from "react"
+import { useCallback, useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { useNavigate } from "react-router-dom"
-import styled from "styled-components"
 import * as yup from "yup"
 
 import { OnboardButton } from "../components/OnboardButton"
@@ -14,10 +13,6 @@ import { OnboardDialog } from "../components/OnboardDialog"
 import { OnboardFormField } from "../components/OnboardFormField"
 import { useOnboard } from "../context"
 import { Layout } from "../layout"
-
-const A = styled.a`
-  color: var(--color-foreground);
-`
 
 type FormData = {
   password?: string
@@ -50,6 +45,7 @@ export const PasswordPage = () => {
     register,
     handleSubmit,
     watch,
+    trigger,
     formState: { errors, isValid, isSubmitting },
   } = useForm<FormData>({
     mode: "all",
@@ -58,6 +54,11 @@ export const PasswordPage = () => {
     resolver: yupResolver(schema),
   })
   const password = watch("password")
+
+  // revalidate to get rid of "must match" error message after editing first field
+  useEffect(() => {
+    trigger()
+  }, [trigger, password])
 
   const submit = useCallback(
     async (fields: FormData) => {


### PR DESCRIPTION
Fixes #162 

Switching from polkadot type to ethereum type will revalidate the form

Also fixes similar bug in onboarding v3 where the "passwords must match" error message wouldn't disappear after editing the 1st field (validation rule beeing on the 2nd field)