### PR TITLE
fix: tailwind on box issue on prod builds

### DIFF
--- a/apps/extension/src/@talisman/components/Box.tsx
+++ b/apps/extension/src/@talisman/components/Box.tsx
@@ -1,4 +1,3 @@
-import { getOverflowAncestors } from "@floating-ui/react-dom"
 import { custom, fontSizes } from "@talisman/theme/definitions"
 import { CSSProperties } from "react"
 import styled, { CSSObject, DefaultTheme } from "styled-components"

--- a/apps/extension/src/ui/domains/Portfolio/AssetBalanceCellValue.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetBalanceCellValue.tsx
@@ -42,9 +42,11 @@ export const AssetBalanceCellValue = ({
         className={className}
         noWrap
       >
-        <Box
-          fg={locked ? "mid" : "foreground"}
-          className={classNames("flex items-center justify-end gap-2")}
+        <div
+          className={classNames(
+            "flex items-center justify-end gap-2",
+            locked ? "text-body-secondary" : "text-body"
+          )}
         >
           <div>
             <Tokens
@@ -58,7 +60,7 @@ export const AssetBalanceCellValue = ({
               <LockIcon className="lock" />
             </div>
           ) : null}
-        </Box>
+        </div>
         <div>{fiat === null ? "-" : <Fiat currency="usd" amount={fiat} isBalance />}</div>
       </Box>
     </WithTooltip>

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
@@ -202,12 +202,12 @@ const AssetRow = ({ balances, symbol, locked }: AssetRowProps) => {
             w="100%"
             h="100%"
           >
-            <Box className="flex items-center gap-2" fontsize="small" fg="foreground" bold noWrap>
+            <div className="text-body flex items-center gap-2 whitespace-nowrap text-sm font-bold">
               {token.symbol}
               {isFetching && (
                 <FetchingIcon data-spin className="inline align-baseline opacity-100" />
               )}
-            </Box>
+            </div>
             {!!networkIds.length && (
               <Box fontsize="normal">
                 <NetworksLogoStack networkIds={networkIds} />


### PR DESCRIPTION
Fixes a bug where styles are different between dev and prod builds.
On prod builds, tailwind classNames set on Box component generates syles that may be overriden by the inline styles of the Box component.

ex: 
![image](https://user-images.githubusercontent.com/26880866/193399207-ef671c83-09ba-4d87-93d6-80279bb5ac5d.png)


Guideline to prevent this : don't use tailwind classes on Box component (Box shouldn't be used anymore anyway)