### PR TITLE
Update manifest strict min version to the correct string format for Mozilla add ons store

### DIFF
--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -32,7 +32,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "strict_min_version": "95"
+      "strict_min_version": "95.0"
     }
   },
   "minimum_chrome_version": "92"


### PR DESCRIPTION
Discovered when attempting to upload to Mozilla add ons store. String must be in the format of "95.0".