### PR TITLE
fix: filter balance objects which do not have a toJson method

### DIFF
--- a/apps/extension/src/core/domains/balances/types/balances.ts
+++ b/apps/extension/src/core/domains/balances/types/balances.ts
@@ -1,6 +1,7 @@
 import { ChainList } from "@core/domains/chains/types"
 import { EvmNetworkList } from "@core/domains/ethereum/types"
 import { TokenList, TokenRateCurrency, TokenRates } from "@core/domains/tokens/types"
+import { log } from "@core/log"
 import { NonFunctionProperties } from "@core/util/FunctionPropertyNames"
 import isArrayOf from "@core/util/isArrayOf"
 import { planckToTokens } from "@core/util/planckToTokens"
@@ -71,7 +72,18 @@ export class Balances {
    */
   toJSON = (): BalancesStorage =>
     Object.fromEntries(
-      Object.entries(this.#balances).map(([id, balance]) => [id, balance.toJSON()])
+      Object.entries(this.#balances)
+        .map(([id, balance]) => {
+          let balanceJson
+          try {
+            balanceJson = balance.toJSON()
+          } catch (error) {
+            log.error(error, { balance, id })
+            return null
+          }
+          return [id, balanceJson]
+        })
+        .filter(Array.isArray)
     );
 
   /**


### PR DESCRIPTION
Not entirely happy with this, since as far as I can tell there should be no way for non-balance objects to end up in this array, but it will do for now