### PR TITLE
fix: polygon underpriced transactions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14118,7 +14118,7 @@ __metadata:
     "@esbuild-plugins/node-globals-polyfill": ^0.1.1
     "@metamask/eth-sig-util": 4.0.1
     "@tailwindcss/forms": ^0.5.3
-    "@talismn/wagmi-connector": 0.1.0
+    "@talismn/wagmi-connector": ^0.0.4
     "@types/react": 18.0.14
     "@types/react-dom": 18.0.5
     "@vitejs/plugin-react": ^2.1.0


### PR DESCRIPTION
Bug is caused by our "apply minimum possible value to get tx mined in next block" check that we implemented to fix problems on non-busy networks
This PR disabled the check for Polygon and Mumbai, as it's specific to those networks.
See  https://github.com/ethers-io/ethers.js/issues/2828#issuecomment-1283014250

