### PR TITLE
feat: inject in all frames

### DIFF
--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -12,7 +12,8 @@
     {
       "matches": ["https://*/*", "http://localhost/*"],
       "js": ["content_script.js"],
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "all_frames": true
     }
   ],
   "background": {


### PR DESCRIPTION
Fixes #261 

Some sites, such as polygonscan.com, call window.ethereum from an iframe.

test case : "Connect to web3", in the Contracts Write tab of this page : 
https://polygonscan.com/token/0x8a953cfe442c5e8855cc6c61b1293fa648bae472#writeContract