### PR TITLE
fix: no param on system_properties call

### DIFF
--- a/apps/extension/src/core/util/getMetadataDef.ts
+++ b/apps/extension/src/core/util/getMetadataDef.ts
@@ -89,7 +89,7 @@ export const getMetadataDef = async (
     // fetch the metadata from the chain
     const [metadataRpc, chainProperties] = await Promise.all([
       RpcFactory.send<HexString>(chain.id, "state_getMetadata", [blockHash], !!blockHash),
-      RpcFactory.send(chain.id, "system_properties", [blockHash], !!blockHash),
+      RpcFactory.send(chain.id, "system_properties", [], true),
     ])
 
     assert(!specVersion || specVersion === runtimeSpecVersion, "specVersion mismatch")


### PR DESCRIPTION
Removed blockHash parameter on system_properties call, I added it out of habit but this method accepts no argument.
This fixes metadata fetching on ASTAR as they explicitely check that there is no argument, throwing an error if there is one