### PR TITLE
fix: arbiscan compatibility

### DIFF
--- a/apps/extension/src/core/domains/ethereum/handler.tabs.ts
+++ b/apps/extension/src/core/domains/ethereum/handler.tabs.ts
@@ -572,7 +572,6 @@ export class EthTabsHandler extends TabsHandler {
   ): Promise<ResponseType<TMessageType>> {
     switch (type) {
       case "pub(eth.subscribe)":
-        // TODO unsubscribe
         return this.ethSubscribe(id, url, port)
 
       case "pub(eth.request)":

--- a/apps/extension/src/core/domains/sitesAuthorised/handler.ts
+++ b/apps/extension/src/core/domains/sitesAuthorised/handler.ts
@@ -24,7 +24,7 @@ export default class SitesAuthorisationHandler extends ExtensionHandler {
     return true
   }
 
-  private authorizeApprove({ id, addresses = [], ethChainId }: AuthRequestApprove): boolean {
+  private authorizeApprove({ id, addresses = [] }: AuthRequestApprove): boolean {
     const queued = this.state.requestStores.sites.getRequest(id)
     assert(queued, "Unable to find request")
 
@@ -34,7 +34,7 @@ export default class SitesAuthorisationHandler extends ExtensionHandler {
       withEthAccounts: queued.request.ethereum ? undefined : addresses.some(isEthereumAddress),
     })
     const { resolve } = queued
-    resolve({ addresses, ethChainId })
+    resolve({ addresses })
 
     return true
   }

--- a/apps/extension/src/core/domains/sitesAuthorised/types.ts
+++ b/apps/extension/src/core/domains/sitesAuthorised/types.ts
@@ -18,7 +18,6 @@ export type AuthRequestAddresses = AuthRequestAddress[]
 export type AuthRequestApprove = {
   id: string
   addresses: AuthRequestAddresses
-  ethChainId?: number
 }
 
 export interface AuthRequestBase {
@@ -28,7 +27,7 @@ export interface AuthRequestBase {
   url: string
 }
 
-export type AuthRequestResponse = { addresses: AuthRequestAddresses; ethChainId?: number }
+export type AuthRequestResponse = { addresses: AuthRequestAddresses }
 export type AuthRequest = Resolver<AuthRequestResponse> & AuthRequestBase
 
 // authorized site types ----------------------------------

--- a/apps/extension/src/core/handlers/State.ts
+++ b/apps/extension/src/core/handlers/State.ts
@@ -11,6 +11,7 @@ import { SitesRequestsStore, sitesAuthorisationStore } from "@core/domains/sites
 import EvmWatchAssetRequestsStore from "@core/domains/tokens/evmWatchAssetRequestsStore"
 import { sleep } from "@core/util/sleep"
 import Browser from "webextension-polyfill"
+import { DEFAULT_ETH_CHAIN_ID } from "@core/constants"
 
 const WINDOW_OPTS: Browser.Windows.CreateCreateDataType = {
   // This is not allowed on FF, only on Chrome - disable completely
@@ -35,7 +36,7 @@ export default class State {
       () => this.popupOpen(),
       async (request, response) => {
         if (!response) return
-        const { addresses = [], ethChainId } = response
+        const { addresses = [] } = response
         const {
           idStr,
           request: { origin, ethereum },
@@ -50,7 +51,10 @@ export default class State {
 
         if (ethereum) {
           siteAuth.ethAddresses = addresses
-          siteAuth.ethChainId = ethChainId
+
+          // set a default value for ethChainId only if empty
+          // some sites switch the network before requesting auth, ex nova.arbiscan.io
+          if (!siteAuth.ethChainId) siteAuth.ethChainId = DEFAULT_ETH_CHAIN_ID
         } else siteAuth.addresses = addresses
 
         await sitesAuthorisationStore.set({

--- a/apps/extension/src/ui/api/api.ts
+++ b/apps/extension/src/ui/api/api.ts
@@ -132,8 +132,8 @@ export const api: MessageTypes = {
   // authorization requests messages ------------------------------------
   authRequestsSubscribe: (cb) =>
     messageService.subscribe("pri(sites.requests.subscribe)", null, cb),
-  authrequestApprove: (id, addresses, ethChainId) =>
-    messageService.sendMessage("pri(sites.requests.approve)", { id, addresses, ethChainId }),
+  authrequestApprove: (id, addresses) =>
+    messageService.sendMessage("pri(sites.requests.approve)", { id, addresses }),
   authrequestReject: (id) => messageService.sendMessage("pri(sites.requests.reject)", { id }),
   authrequestIgnore: (id) => messageService.sendMessage("pri(sites.requests.ignore)", { id }),
 

--- a/apps/extension/src/ui/api/types.ts
+++ b/apps/extension/src/ui/api/types.ts
@@ -140,11 +140,7 @@ export default interface MessageTypes {
 
   // authorization requests message types ------------------------------------
   authRequestsSubscribe: (cb: (requests: AuthorizeRequest[]) => void) => UnsubscribeFn
-  authrequestApprove: (
-    id: AuthRequestId,
-    addresses: AuthRequestAddresses,
-    chainId?: number
-  ) => Promise<boolean>
+  authrequestApprove: (id: AuthRequestId, addresses: AuthRequestAddresses) => Promise<boolean>
   authrequestReject: (id: AuthRequestId) => Promise<boolean>
   authrequestIgnore: (id: AuthRequestId) => Promise<boolean>
 

--- a/apps/extension/src/ui/hooks/useCurrentAuthorisationRequest.tsx
+++ b/apps/extension/src/ui/hooks/useCurrentAuthorisationRequest.tsx
@@ -5,6 +5,7 @@ import { api } from "@ui/api"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
 import useAccounts from "./useAccounts"
+import useAuthorisedSiteById from "./useAuthorisedSiteById"
 import { useAuthRequests } from "./useAuthRequests"
 
 interface IProps {
@@ -20,7 +21,6 @@ const useCurrentAuthorisationRequest = ({ onSuccess, onError, onRejection, onIgn
   const { items: connected, toggle, set } = useSet<string>()
   const authRequests = useAuthRequests()
   const ethereum = !!currentRequest?.request.ethereum
-  const [chainId, setChainId] = useState(DEFAULT_ETH_CHAIN_ID) // Default to moonbeam
   const [showEthAccounts, setShowEthAccounts] = useState(false)
 
   const accounts = useMemo(
@@ -45,9 +45,9 @@ const useCurrentAuthorisationRequest = ({ onSuccess, onError, onRejection, onIgn
   }, [authRequests, setCurrentRequest, onError])
 
   const authorise = useCallback(() => {
-    api.authrequestApprove(currentRequest?.id as string, connected, ethereum ? chainId : undefined)
+    api.authrequestApprove(currentRequest?.id as string, connected)
     onSuccess()
-  }, [currentRequest?.id, connected, ethereum, chainId, onSuccess])
+  }, [currentRequest?.id, connected, onSuccess])
 
   const reject = useCallback(() => {
     api.authrequestReject(currentRequest?.id as string)
@@ -71,8 +71,6 @@ const useCurrentAuthorisationRequest = ({ onSuccess, onError, onRejection, onIgn
     authorise,
     reject,
     ignore,
-    chainId,
-    setChainId,
     ethereum,
     isMissingEthAccount,
     showEthAccounts,


### PR DESCRIPTION
2 bug fixes identified while trying to test transactions on nova.arbiscan.io :
- support for uppercase hexadecimal chainId in switch/add_ethereumNetwork messages
- don't override the ethChainId when authenticating, as some dapps set the network before requesting auth