### PR TITLE
Add pub(accounts.unsubscribe) message

### DIFF
--- a/apps/extension/src/core/handlers/Tabs.ts
+++ b/apps/extension/src/core/handlers/Tabs.ts
@@ -95,7 +95,7 @@ export default class Tabs extends TabsHandler {
     }))
   }
 
-  private accountsSubscribe(url: string, id: string, port: Port): boolean {
+  private accountsSubscribe(url: string, id: string, port: Port) {
     return genericAsyncSubscription<"pub(accounts.subscribe)">(
       id,
       port,
@@ -307,6 +307,10 @@ export default class Tabs extends TabsHandler {
 
       case "pub(accounts.subscribe)":
         return this.accountsSubscribe(url, id, port)
+
+      case "pub(accounts.unsubscribe)":
+        // noop, needed to comply with polkadot.js behaviour
+        return true
 
       case "pub(bytes.sign)":
         await this.stores.sites.ensureUrlAuthorized(


### PR DESCRIPTION
Polkadot.js now implements this message and the injected object sends it by default as part of it's cleanup routine. 
Not handling the message was raising an error on the dapp; however there is no real change to our logic needed.

Closes #338

Sorry, accidentally based these changes on evm-signing branch. RIP. GN. 🥱