### PR TITLE
fix: rpc cycling on all errors

### DIFF
--- a/apps/extension/src/core/constants.ts
+++ b/apps/extension/src/core/constants.ts
@@ -13,3 +13,6 @@ export const DEFAULT_PORTFOLIO_TOKENS_ETHEREUM = [
 // those are suffixed by chainId or networkId for dedupping chains
 export const DEFAULT_SEND_FUNDS_TOKEN_SUBSTRATE = "polkadot-native-dot-polkadot"
 export const DEFAULT_SEND_FUNDS_TOKEN_ETHEREUM = "1-native-eth-1"
+
+// talisman onfinality api key
+export const API_KEY_ONFINALITY = "e1b2f3ea-f003-42f5-adf6-d2e6aa3ecfe4"

--- a/apps/extension/src/core/domains/ethereum/rpcProviders.ts
+++ b/apps/extension/src/core/domains/ethereum/rpcProviders.ts
@@ -1,3 +1,4 @@
+import { API_KEY_ONFINALITY } from "@core/constants"
 import { db } from "@core/libs/db"
 import { log } from "@core/log"
 import { ethers } from "ethers"
@@ -14,6 +15,19 @@ const RPC_CALL_TIMEOUT = 20_000
 
 const throwAfter = (ms: number, reason: any = "timeout") =>
   new Promise((_, reject) => setTimeout(() => reject(reason), ms))
+
+const resolveRpcUrl = (rpcUrl: string) => {
+  // inject api key here because we don't want them in the store (user can modify urls of rpcs)
+  return rpcUrl
+    .replace(
+      /^https:\/\/([A-z-]+)\.api\.onfinality\.io\/public-ws\/?$/,
+      `https://$1.api.onfinality.io/ws?apikey=${API_KEY_ONFINALITY}`
+    )
+    .replace(
+      /^https:\/\/([A-z-]+)\.api\.onfinality\.io\/rpc\/?$/,
+      `https://$1.api.onfinality.io/rpc?apikey=${API_KEY_ONFINALITY}`
+    )
+}
 
 const isUnhealthyRpcError = (err: any) => {
   // expected errors that are not related to RPC health
@@ -112,7 +126,7 @@ const getEvmNetworkProvider = async (
 ): Promise<ethers.providers.JsonRpcProvider | null> => {
   if (!Array.isArray(ethereumNetwork.rpcs)) return null
 
-  const urls = ethereumNetwork.rpcs.map(({ url }) => url)
+  const urls = ethereumNetwork.rpcs.map(({ url }) => url).map(resolveRpcUrl)
   const network = { name: ethereumNetwork.name ?? "unknown network", chainId: ethereumNetwork.id }
 
   const url = await getHealthyRpc(urls, network)
@@ -129,6 +143,7 @@ const getEvmNetworkProvider = async (
       // use 1 so we change RPC as soon as we detect a throttling, without trying again
       throttleLimit: 1,
     }
+
     const provider =
       batch === true
         ? new BatchRpcProvider(connection, network)

--- a/apps/extension/src/core/util/addCustomChainRpcs.ts
+++ b/apps/extension/src/core/util/addCustomChainRpcs.ts
@@ -1,7 +1,5 @@
+import { API_KEY_ONFINALITY } from "@core/constants"
 import type { Chain } from "@core/domains/chains/types"
-
-// talisman onfinality api key
-const onfinalityApiKey = "e1b2f3ea-f003-42f5-adf6-d2e6aa3ecfe4"
 
 /**
  * Helper function to add our onfinality RPCs to an array of chains.
@@ -17,7 +15,7 @@ const addCustomChainRpcs = (chains: Chain[]): Chain[] =>
       .map((rpc) => {
         rpc.url = rpc.url.replace(
           /^wss:\/\/([A-z-]+)\.api\.onfinality\.io\/public-ws\/?$/,
-          `wss://$1.api.onfinality.io/ws?apikey=${onfinalityApiKey}`
+          `wss://$1.api.onfinality.io/ws?apikey=${API_KEY_ONFINALITY}`
         )
         return rpc
       })


### PR DESCRIPTION
- detects all RPC errors by inheriting from ethers's providers and overriding the `send` method.
- also includes a mechanism to inject onfinality's api keys on evm rpc urls.