### PR TITLE
fix: better fee options

### DIFF
--- a/apps/extension/src/core/util/getFeeHistoryAnalysis.ts
+++ b/apps/extension/src/core/util/getFeeHistoryAnalysis.ts
@@ -7,9 +7,9 @@ const BLOCKS_HISTORY_LENGTH = 4
 const REWARD_PERCENTILES = [10, 20, 30]
 
 export const DEFAULT_ETH_PRIORITY_OPTIONS: EthPriorityOptions = {
-  low: parseUnits("1", "gwei"),
-  medium: parseUnits("1.5", "gwei"),
-  high: parseUnits("2", "gwei"),
+  low: parseUnits("1.5", "gwei"),
+  medium: parseUnits("1.6", "gwei"),
+  high: parseUnits("1.7", "gwei"),
 }
 
 type FeeHistory = {
@@ -22,6 +22,7 @@ type FeeHistory = {
 export type FeeHistoryAnalysis = {
   options: EthPriorityOptions
   gasUsedRatio: number
+  isValid: boolean
 }
 
 export const getFeeHistoryAnalysis = async (
@@ -72,6 +73,7 @@ export const getFeeHistoryAnalysis = async (
         high: medMaxPriorityFeePerGas[2],
       },
       gasUsedRatio: avgGasUsedRatio,
+      isValid: !feeHistory.gasUsedRatio.includes(0), // if a 0 is found, not all blocks contained a transaction
     }
   } catch (err) {
     Sentry.captureException(err)
@@ -79,6 +81,7 @@ export const getFeeHistoryAnalysis = async (
     return {
       options: DEFAULT_ETH_PRIORITY_OPTIONS,
       gasUsedRatio: -1,
+      isValid: false,
     }
   }
 }

--- a/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
@@ -129,22 +129,24 @@ const useBlockFeeData = (provider?: ethers.providers.JsonRpcProvider, withFeeOpt
         ])
 
         if (feeOptions && !UNRELIABLE_GASPRICE_NETWORK_IDS.includes(provider.network.chainId)) {
-          // `gasPrice - baseFee` is equal to the current minimum maxPriorityPerGas value required to make it into next block
-          // if smaller than our historical data based value, use it.
-          // this prevents paying to much fee based on historical data when other users are setting unnecessarily high fees on their transactions.
+          // minimum maxPriorityPerGas value required to be considered valid into next block is equal to `gasPrice - baseFee`
           let minimumMaxPriorityFeePerGas = gPrice.sub(baseFeePerGas ?? 0)
           if (minimumMaxPriorityFeePerGas.lt(0)) {
-            // on a busy network, when there is a sudden lowering of amount of transactions,
-            // it can happen that baseFeePerGas is higher than gPrice
+            // on a busy network, when there is a sudden lowering of amount of transactions, it can happen that baseFeePerGas is higher than gPrice
             minimumMaxPriorityFeePerGas = BigNumber.from("0")
           }
 
-          if (minimumMaxPriorityFeePerGas.lt(feeOptions.options.low))
+          // if feeHistory is invalid (network is inactive), use minimumMaxPriorityFeePerGas for all options.
+          // else if feeHistory is valid but network usage below 80% (active but not busy), use it for the low priority option if lower
+          // this prevents paying to much fee based on historical data when other users are setting unnecessarily high fees on their transactions.
+          if (!feeOptions.isValid) {
             feeOptions.options.low = minimumMaxPriorityFeePerGas
-          if (minimumMaxPriorityFeePerGas.lt(feeOptions.options.medium))
             feeOptions.options.medium = minimumMaxPriorityFeePerGas
-          if (minimumMaxPriorityFeePerGas.lt(feeOptions.options.high))
             feeOptions.options.high = minimumMaxPriorityFeePerGas
+          } else if (feeOptions.gasUsedRatio < 0.8)
+            feeOptions.options.low = minimumMaxPriorityFeePerGas.lt(feeOptions.options.low)
+              ? minimumMaxPriorityFeePerGas
+              : feeOptions.options.low
         }
 
         setGasPrice(gPrice)


### PR DESCRIPTION
- compatibility with Exosama (empty blocks in history were creating invalid fee options)
- better logic in fee options calculation

```
- if fee history contains at least a block with 0 transaction, ignore history and only consider gas price, for all 3 options.
- else if network usage is below 80%, use min(gas price, low option value) for low option. use history (20/30 percentiles) for medium and high priority.
- else consider network usage to be high enough to rely only on fee history analysis (10/20/30 percentiles)
```