### PR TITLE
fix: if tx fail to submit, display rpc error

### DIFF
--- a/apps/extension/src/core/domains/ethereum/handler.extension.ts
+++ b/apps/extension/src/core/domains/ethereum/handler.extension.ts
@@ -41,7 +41,7 @@ const getHumanReadableErrorMessage = (error: unknown) => {
   } = error as { code?: string; reason?: string; error?: any }
 
   if (serverError) {
-    const message = serverError?.error?.message ?? serverError?.reason ?? serverError?.message
+    const message = serverError.error?.message ?? serverError.reason ?? serverError.message
     return message
       .replace("VM Exception while processing transaction: revert", "")
       .replace("VM Exception while processing transaction:", "")


### PR DESCRIPTION
found the issue while working on this support ticket : 
https://discord.com/channels/858891448271634473/1049999838625931294

when tx failed to be submitted, we were displaying a generic error message provided by ethers, for example "processing response error".
This fix will display the actual message found in the RPC reponse. for example : 
![image](https://user-images.githubusercontent.com/26880866/209938576-85f8dbc9-fedc-4905-a108-bdef9bfcf3a1.png)
