### PR TITLE
feat: select account after creation

### DIFF
--- a/apps/extension/src/core/domains/accounts/types.ts
+++ b/apps/extension/src/core/domains/accounts/types.ts
@@ -94,14 +94,14 @@ export interface RequestAccountCreate {
 
 export interface AccountsMessages {
   // account message signatures
-  "pri(accounts.create)": [RequestAccountCreate, boolean]
-  "pri(accounts.create.seed)": [RequestAccountCreateFromSeed, boolean]
-  "pri(accounts.create.json)": [RequestAccountCreateFromJson, boolean]
+  "pri(accounts.create)": [RequestAccountCreate, string]
+  "pri(accounts.create.seed)": [RequestAccountCreateFromSeed, string]
+  "pri(accounts.create.json)": [RequestAccountCreateFromJson, string]
   "pri(accounts.create.hardware.substrate)": [
     Omit<RequestAccountCreateHardware, "hardwareType">,
-    boolean
+    string
   ]
-  "pri(accounts.create.hardware.ethereum)": [RequestAccountCreateHardwareEthereum, boolean]
+  "pri(accounts.create.hardware.ethereum)": [RequestAccountCreateHardwareEthereum, string]
   "pri(accounts.forget)": [RequestAccountForget, boolean]
   "pri(accounts.export)": [RequestAccountExport, ResponseAccountExport]
   "pri(accounts.rename)": [RequestAccountRename, boolean]

--- a/apps/extension/src/ui/api/types.ts
+++ b/apps/extension/src/ui/api/types.ts
@@ -96,13 +96,13 @@ export default interface MessageTypes {
   addressFromMnemonic: (mnemonic: string, type?: AccountAddressType) => Promise<string>
 
   // account message types ---------------------------------------------------
-  accountCreate: (name: string, type: AccountAddressType) => Promise<boolean>
-  accountCreateFromSeed: (name: string, seed: string, type?: AccountAddressType) => Promise<boolean>
-  accountCreateFromJson: (json: string, password: string) => Promise<boolean>
+  accountCreate: (name: string, type: AccountAddressType) => Promise<string>
+  accountCreateFromSeed: (name: string, seed: string, type?: AccountAddressType) => Promise<string>
+  accountCreateFromJson: (json: string, password: string) => Promise<string>
   accountCreateHardware: (
     request: Omit<RequestAccountCreateHardware, "hardwareType">
-  ) => Promise<boolean>
-  accountCreateHardwareEthereum: (name: string, address: string, path: string) => Promise<boolean>
+  ) => Promise<string>
+  accountCreateHardwareEthereum: (name: string, address: string, path: string) => Promise<string>
   accountsSubscribe: (cb: (accounts: AccountJson[]) => void) => UnsubscribeFn
   accountForget: (address: string) => Promise<boolean>
   accountExport: (

--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddDerived.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddDerived.tsx
@@ -10,9 +10,9 @@ import { sleep } from "@talismn/util"
 import { api } from "@ui/api"
 import { AccountTypeSelector } from "@ui/domains/Account/AccountTypeSelector"
 import useAccounts from "@ui/hooks/useAccounts"
+import { useSelectAccountAndNavigate } from "@ui/hooks/useSelectAccountAndNavigate"
 import { useCallback, useMemo } from "react"
 import { useForm } from "react-hook-form"
-import { useNavigate } from "react-router-dom"
 import styled from "styled-components"
 import * as yup from "yup"
 
@@ -44,9 +44,9 @@ const Spacer = styled.div<{ small?: boolean }>`
 `
 
 const AccountNew = () => {
-  const navigate = useNavigate()
   const allAccounts = useAccounts()
   const accountNames = useMemo(() => allAccounts.map((a) => a.name), [allAccounts])
+  const { setAddress } = useSelectAccountAndNavigate("/portfolio")
 
   const schema = useMemo(
     () =>
@@ -87,13 +87,13 @@ const AccountNew = () => {
       await sleep(1000)
 
       try {
-        await api.accountCreate(name, type)
+        setAddress(await api.accountCreate(name, type))
+
         notifyUpdate(notificationId, {
           type: "success",
           title: "Account created",
           subtitle: name,
         })
-        navigate("/portfolio")
       } catch (err) {
         notifyUpdate(notificationId, {
           type: "error",
@@ -102,7 +102,7 @@ const AccountNew = () => {
         })
       }
     },
-    [navigate]
+    [setAddress]
   )
 
   const handleTypeChange = useCallback(

--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddJson.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddJson.tsx
@@ -7,9 +7,9 @@ import { SimpleButton } from "@talisman/components/SimpleButton"
 import Spacer from "@talisman/components/Spacer"
 import { ArrowRightIcon } from "@talisman/theme/icons"
 import { api } from "@ui/api"
+import { useSelectAccountAndNavigate } from "@ui/hooks/useSelectAccountAndNavigate"
 import { useCallback } from "react"
 import { useForm } from "react-hook-form"
-import { useNavigate } from "react-router-dom"
 import * as yup from "yup"
 
 import Layout from "../layout"
@@ -37,7 +37,7 @@ const getFileContent = (file?: File) =>
   })
 
 const AccountJson = () => {
-  const navigate = useNavigate()
+  const { setAddress } = useSelectAccountAndNavigate("/portfolio")
 
   const submit = useCallback(
     async ({ fileContent, password }: FormData) => {
@@ -50,13 +50,12 @@ const AccountJson = () => {
         { autoClose: false }
       )
       try {
-        await api.accountCreateFromJson(fileContent, password)
+        setAddress(await api.accountCreateFromJson(fileContent, password))
         notifyUpdate(notificationId, {
           type: "success",
           title: "Account created",
           subtitle: "",
         })
-        navigate("/portfolio")
       } catch (err) {
         notifyUpdate(notificationId, {
           type: "error",
@@ -65,7 +64,7 @@ const AccountJson = () => {
         })
       }
     },
-    [navigate]
+    [setAddress]
   )
 
   const {

--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddLedger/AddLedgerSelectAccount.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddLedger/AddLedgerSelectAccount.tsx
@@ -7,9 +7,10 @@ import Spacer from "@talisman/components/Spacer"
 import { sleep } from "@talismn/util"
 import { LedgerEthereumAccountPicker } from "@ui/domains/Account/LedgerEthereumAccountPicker"
 import { LedgerSubstrateAccountPicker } from "@ui/domains/Account/LedgerSubstrateAccountPicker"
+import { useSelectAccountAndNavigate } from "@ui/hooks/useSelectAccountAndNavigate"
 import { FC, useCallback, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
-import { Navigate, useNavigate } from "react-router-dom"
+import { Navigate } from "react-router-dom"
 import styled from "styled-components"
 import * as yup from "yup"
 
@@ -100,7 +101,7 @@ type FormData = {
 
 export const AddLedgerSelectAccount = () => {
   const { data, importAccounts } = useAddLedgerAccount()
-  const navigate = useNavigate()
+  const { setAddress } = useSelectAccountAndNavigate("/portfolio")
 
   const schema = useMemo(
     () =>
@@ -139,13 +140,13 @@ export const AddLedgerSelectAccount = () => {
       await sleep(1000)
 
       try {
-        await importAccounts(accounts)
+        const addresses = await importAccounts(accounts)
         notifyUpdate(notificationId, {
           type: "success",
           title: `Account${suffix} imported`,
           subtitle: null,
         })
-        navigate("/")
+        setAddress(addresses[0])
       } catch (err) {
         notifyUpdate(notificationId, {
           type: "error",
@@ -154,7 +155,7 @@ export const AddLedgerSelectAccount = () => {
         })
       }
     },
-    [importAccounts, navigate]
+    [importAccounts, setAddress]
   )
 
   const handleAccountsChange = useCallback(

--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddLedger/context.ts
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddLedger/context.ts
@@ -44,9 +44,15 @@ const useAddLedgerAccountProvider = () => {
 
       setData((prev) => ({ ...prev, accounts }))
 
+      const addresses: string[] = []
       for (const account of accounts)
-        if ("genesisHash" in account) await api.accountCreateHardware(account)
-        else await api.accountCreateHardwareEthereum(account.name, account.address, account.path)
+        addresses.push(
+          "genesisHash" in account
+            ? await api.accountCreateHardware(account)
+            : await api.accountCreateHardwareEthereum(account.name, account.address, account.path)
+        )
+
+      return addresses
     },
     [chain?.genesisHash, data.type]
   )

--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddSecret/AccountAddSecretAccounts.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddSecret/AccountAddSecretAccounts.tsx
@@ -5,6 +5,7 @@ import { notify, notifyUpdate } from "@talisman/components/Notifications"
 import { SimpleButton } from "@talisman/components/SimpleButton"
 import Spacer from "@talisman/components/Spacer"
 import { DerivedFromMnemonicAccountPicker } from "@ui/domains/Account/DerivedFromMnemonicAccountPicker"
+import { useSelectAccountAndNavigate } from "@ui/hooks/useSelectAccountAndNavigate"
 import { useCallback, useEffect, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { Navigate, useNavigate } from "react-router-dom"
@@ -45,6 +46,7 @@ type FormData = {
 export const AccountAddSecretAccounts = () => {
   const { data, importAccounts } = useAccountAddSecret()
   const navigate = useNavigate()
+  const { setAddress } = useSelectAccountAndNavigate("/portfolio")
 
   const name = useMemo(
     () => data.name ?? (data.type === "ethereum" ? "Ethereum Account" : "Polkadot Account"),
@@ -84,14 +86,15 @@ export const AccountAddSecretAccounts = () => {
         { autoClose: false }
       )
       try {
-        await importAccounts(accounts)
+        const addresses = await importAccounts(accounts)
 
         notifyUpdate(notificationId, {
           type: "success",
           title: `Account${suffix} imported`,
           subtitle: null,
         })
-        navigate("/")
+
+        setAddress(addresses[0])
       } catch (err) {
         notifyUpdate(notificationId, {
           type: "error",
@@ -100,7 +103,7 @@ export const AccountAddSecretAccounts = () => {
         })
       }
     },
-    [importAccounts, navigate]
+    [importAccounts, setAddress]
   )
 
   const handleAccountsChange = useCallback(

--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddSecret/AccountAddSecretMnemonic.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddSecret/AccountAddSecretMnemonic.tsx
@@ -11,6 +11,7 @@ import { api } from "@ui/api"
 import { AccountTypeSelector } from "@ui/domains/Account/AccountTypeSelector"
 import AccountAvatar from "@ui/domains/Account/Avatar"
 import useAccounts from "@ui/hooks/useAccounts"
+import { useSelectAccountAndNavigate } from "@ui/hooks/useSelectAccountAndNavigate"
 import { Wallet } from "ethers"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
@@ -161,6 +162,7 @@ const testValidMnemonic = async (val?: string) => {
 export const AccountAddSecretMnemonic = () => {
   const { data, updateData } = useAccountAddSecret()
   const navigate = useNavigate()
+  const { setAddress } = useSelectAccountAndNavigate("/portfolio")
 
   const allAccounts = useAccounts()
   const accountAddresses = useMemo(() => allAccounts.map((a) => a.address), [allAccounts])
@@ -271,13 +273,12 @@ export const AccountAddSecretMnemonic = () => {
         )
         try {
           const uri = await getAccountUri(mnemonic, type)
-          await api.accountCreateFromSeed(name, uri, type)
+          setAddress(await api.accountCreateFromSeed(name, uri, type))
           notifyUpdate(notificationId, {
             type: "success",
             title: "Account imported",
             subtitle: name,
           })
-          navigate("/portfolio")
         } catch (err) {
           notifyUpdate(notificationId, {
             type: "error",
@@ -287,7 +288,7 @@ export const AccountAddSecretMnemonic = () => {
         }
       }
     },
-    [navigate, updateData]
+    [navigate, setAddress, updateData]
   )
 
   const handleTypeChange = useCallback(

--- a/apps/extension/src/ui/apps/dashboard/routes/AccountAddSecret/context.ts
+++ b/apps/extension/src/ui/apps/dashboard/routes/AccountAddSecret/context.ts
@@ -29,12 +29,14 @@ const useAccountAddSecretProvider = () => {
   const importAccounts = useCallback(async (accounts: RequestAccountCreateFromSeed[]) => {
     setData((prev) => ({ ...prev, accounts }))
 
-    await Promise.all(
+    const addresses = await Promise.all(
       accounts.map(({ name, seed, type }) => api.accountCreateFromSeed(name, seed, type))
     )
 
     // poudre de perlimpinpin
     await sleep(1000)
+
+    return addresses
   }, [])
 
   return { data, updateData, importAccounts }

--- a/apps/extension/src/ui/hooks/useSelectAccountAndNavigate.ts
+++ b/apps/extension/src/ui/hooks/useSelectAccountAndNavigate.ts
@@ -1,0 +1,21 @@
+import { useSelectedAccount } from "@ui/domains/Portfolio/SelectedAccountContext"
+import { useEffect, useState } from "react"
+import { useNavigate } from "react-router-dom"
+
+export const useSelectAccountAndNavigate = (url: string) => {
+  const navigate = useNavigate()
+  const [address, setAddress] = useState<string>()
+  const { account, accounts, select } = useSelectedAccount()
+
+  // wait for requested account to exist, then select it
+  useEffect(() => {
+    if (address && accounts.find((a) => a.address === address)) select(address)
+  }, [accounts, address, select])
+
+  // wait for current account to be the requested one, then navigate
+  useEffect(() => {
+    if (address && account?.address === address) navigate(url)
+  }, [account?.address, address, navigate, url])
+
+  return { setAddress }
+}


### PR DESCRIPTION
closes #366 
 
after an account is added/imported/created, sets this account as the currently selected one before redirecting to the portfolio