### PR TITLE
Allow setting a custom title for receive funds modal

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/layout/SideBar.tsx
+++ b/apps/extension/src/ui/apps/dashboard/layout/SideBar.tsx
@@ -254,7 +254,7 @@ export const SideBar = () => {
   const { open: openReceiveTokensModal } = useReceiveTokensModal()
   const handleCopyClick = useCallback(() => {
     if (account) openCopyAddressModal(account.address)
-    else openReceiveTokensModal()
+    else openReceiveTokensModal("Select address to copy")
     genericEvent("open copy address", { from: "sidebar" })
   }, [account, genericEvent, openCopyAddressModal, openReceiveTokensModal])
 

--- a/apps/extension/src/ui/domains/Asset/Receive/ReceiveTokensModal.tsx
+++ b/apps/extension/src/ui/domains/Asset/Receive/ReceiveTokensModal.tsx
@@ -14,11 +14,11 @@ const Dialog = styled(ModalDialog)`
 
 // This control is injected directly in the layout of dashboard
 export const ReceiveTokensModal = () => {
-  const { isOpen, close } = useReceiveTokensModal()
+  const { isOpen, close, title } = useReceiveTokensModal()
 
   return (
     <Modal open={isOpen} onClose={close}>
-      <Dialog title="Receive funds" onClose={close}>
+      <Dialog title={title} onClose={close}>
         <ReceiveTokensForm />
       </Dialog>
     </Modal>

--- a/apps/extension/src/ui/domains/Asset/Receive/ReceiveTokensModalContext.ts
+++ b/apps/extension/src/ui/domains/Asset/Receive/ReceiveTokensModalContext.ts
@@ -1,8 +1,25 @@
 import { useOpenClose } from "@talisman/hooks/useOpenClose"
 import { provideContext } from "@talisman/util/provideContext"
+import { useCallback, useState } from "react"
 
 const useReceiveTokensProvider = () => {
-  return useOpenClose()
+  const [title, setTitle] = useState("Receive Funds")
+
+  const { open: baseOpen, ...openClose } = useOpenClose()
+
+  const open = useCallback(
+    (titleText?: string) => {
+      if (titleText) setTitle(titleText)
+      baseOpen()
+    },
+    [baseOpen]
+  )
+
+  return {
+    ...openClose,
+    open,
+    title,
+  }
 }
 
 export const [ReceiveTokensModalProvider, useReceiveTokensModal] =


### PR DESCRIPTION
Intended to reduce confusion on getting the receive funds modal when attempting to copy address when no account selected