### PR TITLE
fix: substrate authorise check

### DIFF
--- a/apps/extension/src/core/handlers/Tabs.ts
+++ b/apps/extension/src/core/handlers/Tabs.ts
@@ -66,7 +66,8 @@ export default class Tabs extends TabsHandler {
 
   private async authorize(url: string, request: RequestAuthorizeTab): Promise<boolean> {
     const siteFromUrl = await this.stores.sites.getSiteFromUrl(url)
-    if (siteFromUrl) {
+    // site may exist if created during a connection with EVM API
+    if (siteFromUrl?.addresses) {
       // this url was seen in the past
       assert(
         siteFromUrl.addresses?.length,


### PR DESCRIPTION
Bug : if user has connected to a dapp using EVM, Talisman will reject `pub(authorize.tab)`
It's been there since we launched EVM but is blocking for LIDO integration. Should release it ASAP.

replicable by launching https://github.com/mixbytes/lido-template-dotsama-connectors