### PR TITLE
fix: bubble up errors from db migration error boundary to the top level one

### DIFF
--- a/apps/extension/src/@talisman/components/ErrorBoundaryDatabaseMigration.tsx
+++ b/apps/extension/src/@talisman/components/ErrorBoundaryDatabaseMigration.tsx
@@ -38,6 +38,10 @@ export class ErrorBoundaryDatabaseMigration extends Component<Props, State> {
     if (error.message === `Error ${MIGRATION_ERROR_MSG}`) {
       return { hasError: true }
     }
+
+    // bubble up the error to our main ErrorBoundary
+    if (error) throw error
+
     return { hasError: false }
   }
 


### PR DESCRIPTION
prevents infinite loops when an error occurs in UI