### PR TITLE
fix: staleIsValid fix

### DIFF
--- a/apps/extension/src/ui/domains/Ethereum/Sign/useIsValidEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/Sign/useIsValidEthTransaction.ts
@@ -39,5 +39,5 @@ export const useIsValidEthTransaction = (
     setStaleIsValid(false)
   }, [priority])
 
-  return { isValid: !!data, error, staleIsValid, isLoading }
+  return { isValid: !!data, error, staleIsValid: !!data || staleIsValid, isLoading }
 }


### PR DESCRIPTION
Forgot to take a screenshot but I just had an issue on Arbitrum Nova telling me my transaction was exceeding the allowance. Basically, my gasLimit was to low.
Custom gas settings reflected that, and raising gas limit by just a little (100) got rid of the error.

However main tx screen still had the approve button disabled, because it's using a stale (n-1) validation.

This PR makes the stale validation to also return true in case new value is true.