### PR TITLE
fix: eth_signTypedData now uses v4

### DIFF
--- a/apps/extension/src/core/domains/ethereum/handler.extension.ts
+++ b/apps/extension/src/core/domains/ethereum/handler.extension.ts
@@ -206,7 +206,7 @@ export class EthHandler extends ExtensionHandler {
 
       if (method === "personal_sign") {
         signature = personalSign({ privateKey, data: request })
-      } else if (["eth_signTypedData", "eth_signTypedData_v1"].includes(method)) {
+      } else if (method === "eth_signTypedData_v1") {
         signature = signTypedData({
           privateKey,
           data: JSON.parse(request as string),
@@ -218,7 +218,7 @@ export class EthHandler extends ExtensionHandler {
           data: JSON.parse(request as string),
           version: SignTypedDataVersion.V3,
         })
-      } else if (method === "eth_signTypedData_v4") {
+      } else if (["eth_signTypedData", "eth_signTypedData_v4"].includes(method)) {
         signature = signTypedData({
           privateKey,
           data: JSON.parse(request as string),


### PR DESCRIPTION
Fixes #454 

eth_signTypedData was an alias of eth_signTypedData_v1 instead of eth_signTypedData_v4.
confirmed in their changelog https://github.com/MetaMask/eth-sig-util/blob/554420a9bef69fd4307ad7a762fe81f875e57c76/CHANGELOG.md#changed-2