### PR TITLE
fix: allow eth_blockNumber calls without auth

### DIFF
--- a/apps/extension/src/core/domains/ethereum/handler.tabs.ts
+++ b/apps/extension/src/core/domains/ethereum/handler.tabs.ts
@@ -342,6 +342,8 @@ export class EthTabsHandler extends TabsHandler {
     url: string,
     request: EthRequestArguments<K>
   ): Promise<unknown> {
+    // obtain the chain id without checking auth.
+    // note: this method is only called if method doesn't require auth, or if auth is already checked
     const chainId = await this.getChainId(url)
 
     const ethereumNetwork = await chaindataProvider.getEvmNetwork(chainId.toString())


### PR DESCRIPTION
Closes #265 

- added `eth_blockNumber` to the list of requests that can be called without authenticating
- fixed `getFallbackRequest` to obtain a provider without auth

note: `getFallbackRequest` is only called if method doesn't require auth, or if auth is already checked