### PR TITLE
Prevent errors in paraverse protector

### DIFF
--- a/apps/extension/src/core/domains/app/protector/ParaverseProtector.ts
+++ b/apps/extension/src/core/domains/app/protector/ParaverseProtector.ts
@@ -131,9 +131,9 @@ export default class ParaverseProtector {
     try {
       const sha = await this.getCommitSha(`${METAMASK_REPO}${COMMIT_PATH}`)
       if (sha !== this.#commits.metamask) {
-        this.#commits.metamask = sha
         const mmConfig = await this.getMetamaskData()
         this.#metamaskDetector = new MetamaskDetector(mmConfig)
+        this.#commits.metamask = sha
         this.persistData("metamask", sha, mmConfig)
       }
     } catch (error) {
@@ -145,8 +145,8 @@ export default class ParaverseProtector {
     try {
       const sha = await this.getCommitSha(`${POLKADOT_REPO}${COMMIT_PATH}`)
       if (sha !== this.#commits.polkadot) {
-        this.#commits.polkadot = sha
         this.lists.polkadot = await this.getPolkadotData()
+        this.#commits.polkadot = sha
         this.persistData("polkadot", sha, this.lists.polkadot)
       }
     } catch (error) {
@@ -162,8 +162,8 @@ export default class ParaverseProtector {
     try {
       const sha = await this.getCommitSha(`${PHISHFORT_REPO}${COMMIT_PATH}`)
       if (sha !== this.#commits.phishfort) {
-        this.#commits.phishfort = sha
         this.lists.phishfort.deny = await this.getPhishFortData()
+        this.#commits.phishfort = sha
         this.persistData("phishfort", sha, this.lists.phishfort)
       }
     } catch (error) {


### PR DESCRIPTION
In some cases compressed data could not be uncompressed, potentially due to bad responses being stored
After this PR:
 - Data will be stored in uncompressed format to reduce risk of errors with compression/decompression
 - Errors will be thrown when fetching data, and handled when storing data, so that if data could not be fetched, nothing will be stored
 
