### PR TITLE
fix: undefined free balance on equilibrium tokens

### DIFF
--- a/packages/balances-substrate-equilibrium/src/SubstrateEquilibriumModule.ts
+++ b/packages/balances-substrate-equilibrium/src/SubstrateEquilibriumModule.ts
@@ -326,7 +326,6 @@ export const SubEquilibriumModule: BalanceModule<
 
         // query rpc
         const result = await chainConnector.send(chainId, method, params)
-        log.log("fetchBalances", result)
         return formatRpcResult(chainId, queries, result[0])
       })
     )


### PR DESCRIPTION
After onboarding, equilibrium balances are added to the database with `free:undefined` instead of `free:"0"`

this "breaks" the empty wallet test currently in place, and makes the "fund your wallet" UI disappear.

As all other balances all have `free:"0"` , I assume this is a bug of this library.