### PR TITLE
fix: display the 3 default ethereum tokens on empty wallet

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/useDisplayBalances.ts
+++ b/apps/extension/src/ui/domains/Portfolio/useDisplayBalances.ts
@@ -13,7 +13,8 @@ const shouldDisplayBalance = (balance: Balance, account?: AccountJsonAny) => {
     balance.total.planck > 0 ||
     (account?.type !== "ethereum" &&
       DEFAULT_PORTFOLIO_TOKENS_SUBSTRATE.includes(balance.tokenId)) ||
-    (account?.type === "ethereum" && DEFAULT_PORTFOLIO_TOKENS_ETHEREUM.includes(balance.tokenId)) ||
+    ((!account || account?.type === "ethereum") &&
+      DEFAULT_PORTFOLIO_TOKENS_ETHEREUM.includes(balance.tokenId)) ||
     (account?.genesisHash && account.genesisHash === balance.chain?.genesisHash)
   )
 }


### PR DESCRIPTION
if all accounts selected, prevents seeing shimmers for the 3 default tokens if user has less than 5 balances.