### PR TITLE
fix: remove duplicate EncryptResult + DecryptResult definitions

### DIFF
--- a/apps/playground/src/components/Substrate/Sumi.tsx
+++ b/apps/playground/src/components/Substrate/Sumi.tsx
@@ -5,18 +5,6 @@ import { Section } from "../Section"
 import { DecryptResult, EncryptResult, TalismanSigner } from "./types"
 import { useWallet } from "./useWallet"
 
-// TODO: Move these to a common package and import them both here and in the extension
-/** BEGIN: Copy-paste from apps/extension/src/core/domains/encrypt/types.ts **/
-export interface EncryptResult {
-  id: number
-  result: string
-}
-export interface DecryptResult {
-  id: number
-  result: string
-}
-/** END: Copy-paste from apps/extension/src/core/domains/encrypt/types.ts **/
-
 const DATA_TO_ENCRYPT =
   "data to encrypt yeet yeet yeeeeeet. this is a loooooong message blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah"
 


### PR DESCRIPTION
Didn't catch this when merging in preconstruct. Seems to be breaking the playground `build` command.

I think the `./types` file didn't exist yet when I added these two interfaces to `Sumi.tsx`, but then `./types` came in later through a rebase / merge of dev.