### PR TITLE
Prevent excessive posthog calls for spirit key ownership

### DIFF
--- a/apps/extension/src/core/domains/app/store.app.ts
+++ b/apps/extension/src/core/domains/app/store.app.ts
@@ -23,6 +23,7 @@ export type AppStoreData = {
   showWalletFunding: boolean
   hasSpiritKey: boolean
   showDotNomPoolStakingBanner: boolean
+  needsSpiritKeyUpdate: boolean
 }
 
 const ANALYTICS_VERSION = "1.5.0"
@@ -35,6 +36,7 @@ export const DEFAULT_APP_STATE: AppStoreData = {
   analyticsRequestShown: gt(process.env.VERSION!, ANALYTICS_VERSION), // assume user has onboarded with analytics if current version is newer
   showWalletFunding: false, // true after onboarding with a newly created account
   hasSpiritKey: false,
+  needsSpiritKeyUpdate: false,
   showDotNomPoolStakingBanner: true,
 }
 


### PR DESCRIPTION
In the past 30 days we have had 1 million events for `Spirit key ownership check` in posthog. We are now paying for posthog events and 1 million costs about USD $225. We only need to notify posthog when spirit key status actually changes.