### PR TITLE
Support removeAllListeners method on injected ethereum provider

### DIFF
--- a/apps/extension/src/core/injectEth/getInjectableEvmProvider.ts
+++ b/apps/extension/src/core/injectEth/getInjectableEvmProvider.ts
@@ -55,6 +55,7 @@ export const getInjectableEvmProvider = (sendRequest: SendRequest) => {
     on: eventEmitter.on.bind(eventEmitter),
     off: eventEmitter.off.bind(eventEmitter),
     removeListener: eventEmitter.removeListener.bind(eventEmitter),
+    removeAllListeners: eventEmitter.removeAllListeners.bind(eventEmitter),
   }
 
   const isConnected = () => {


### PR DESCRIPTION
`removeAllListeners` is not a required method for EIP-1193 but it appears some dapps expect it to be there.
The [EIP documentation suggests](https://eips.ethereum.org/EIPS/eip-1193) to simply extend the EventEmitter class to create the provider, which would also include the `removeAllListeners` method, so I assume it will not be harmful to add it.

Closes #591