### PR TITLE
ci: fix ci warning: `set-output` command is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: PORT_PREFIX=talisman EXTENSION_PREFIX=talisman yarn run test
       - name: Extract short SHA
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Build
         run: COMMIT_SHA_SHORT=${{ steps.vars.outputs.sha_short }} PORT_PREFIX=talisman EXTENSION_PREFIX=talisman yarn run build:extension:ci
       - name: Upload build artifacts


### PR DESCRIPTION
[docs here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)