### PR TITLE
fix: balances-demo show token/chain colors on same background as webapp

### DIFF
--- a/apps/balances-demo/package.json
+++ b/apps/balances-demo/package.json
@@ -19,15 +19,13 @@
     "anylogger-loglevel": "^1.0.0",
     "loglevel": "^1.8.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "tinycolor2": "^1.6.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",
     "@talismn/eslint-config": "workspace:^",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
-    "@types/tinycolor2": "^1.4.3",
     "@vitejs/plugin-react": "^3.0.0",
     "autoprefixer": "^10.4.12",
     "eslint": "^7.5.0",

--- a/apps/balances-demo/src/App.tsx
+++ b/apps/balances-demo/src/App.tsx
@@ -3,7 +3,6 @@ import { useAllAddresses, useBalances, useTokens } from "@talismn/balances-react
 import { Token } from "@talismn/chaindata-provider"
 import { classNames, formatDecimals } from "@talismn/util"
 import { Fragment, useEffect, useMemo, useState } from "react"
-import tinycolor from "tinycolor2"
 
 export function App(): JSX.Element {
   const addresses = useExtensionAddresses()
@@ -43,13 +42,8 @@ export function App(): JSX.Element {
 
               <span>
                 <span
-                  className={classNames(
-                    "rounded-sm p-2 text-center",
-                    tinycolor(balance.token?.themeColor).getLuminance() >= 0.6
-                      ? "text-body-black"
-                      : ""
-                  )}
-                  style={{ background: balance.token?.themeColor }}
+                  className={classNames("rounded-sm bg-[#1a1a1a] p-2 text-center font-bold")}
+                  style={{ color: balance.token?.themeColor }}
                 >
                   {balance.token?.themeColor}
                 </span>
@@ -60,15 +54,10 @@ export function App(): JSX.Element {
               <span>
                 <span
                   className={classNames(
-                    "min-w-[6rem] overflow-hidden overflow-ellipsis whitespace-nowrap rounded-sm p-2 text-center",
-                    tinycolor(
-                      balance.chain?.themeColor || balance.evmNetwork?.themeColor
-                    ).getLuminance() >= 0.6
-                      ? "text-body-black"
-                      : ""
+                    "min-w-[6rem] overflow-hidden overflow-ellipsis whitespace-nowrap rounded-sm bg-[#1a1a1a] p-2 text-center font-bold"
                   )}
                   style={{
-                    background: balance.chain?.themeColor || balance.evmNetwork?.themeColor,
+                    color: balance.chain?.themeColor || balance.evmNetwork?.themeColor,
                   }}
                 >
                   {balance.chain?.name || balance.evmNetwork?.name}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6689,13 +6689,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/tinycolor2@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "@types/tinycolor2@npm:1.4.3"
-  checksum: 61984b2825d4ee902016ef24777787bb2fb9e4999ccd4f7e5a709442c00cf90ba4afa510b9c78f18dcc83c03305d597d5fe3825a6aad38354f95c68af70ebc1b
-  languageName: node
-  linkType: hard
-
 "@types/trusted-types@npm:^2.0.2":
   version: 2.0.2
   resolution: "@types/trusted-types@npm:2.0.2"
@@ -8617,7 +8610,6 @@ __metadata:
     "@talismn/eslint-config": "workspace:^"
     "@types/react": ^18.0.26
     "@types/react-dom": ^18.0.9
-    "@types/tinycolor2": ^1.4.3
     "@vitejs/plugin-react": ^3.0.0
     anylogger: ^1.0.11
     anylogger-loglevel: ^1.0.0
@@ -8628,7 +8620,6 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     tailwindcss: ^3.2.4
-    tinycolor2: ^1.6.0
     typescript: ^4.9.3
     vite: ^4.0.0
   languageName: unknown
@@ -20234,13 +20225,6 @@ __metadata:
     es5-ext: ~0.10.46
     next-tick: 1
   checksum: ef3f27a0702a88d885bcbb0317c3e3ecd094ce644da52e7f7d362394a125d9e3578292a8f8966071a980d8abbc3395725333b1856f3ae93835b46589f700d938
-  languageName: node
-  linkType: hard
-
-"tinycolor2@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "tinycolor2@npm:1.6.0"
-  checksum: 6df4d07fceeedc0a878d7bac47e2cd47c1ceeb1078340a9eb8a295bc0651e17c750f73d47b3028d829f30b85c15e0572c0fd4142083e4c21a30a597e47f47230
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To make it easier to see whether the colors selected are good or just plain terrible, the balances-demo app now shows them infront of the same background color as used in the webapp!