### PR TITLE
fix: token transfers on picasso

### DIFF
--- a/apps/extension/src/core/domains/transactions/rpc/AssetTransfers.ts
+++ b/apps/extension/src/core/domains/transactions/rpc/AssetTransfers.ts
@@ -241,20 +241,26 @@ export default class AssetTransfersRpc {
 
     const unsigned = transaction.tx
 
-    // without this next line, the extrinsic (referred to here as `unsigned`) will fail (wasm runtime panic) when submitted to the Picasso chain
-    // there are probably other chains which it will also fail on, but Picasso is the first one we've noticed it on
+    // If the following line of code is not added, the extrinsic (referred to as "unsigned" here)
+    // will fail when submitted to the Picasso chain, resulting in a wasm runtime panic.
+    // It's possible that other chains will also experience this issue, but Picasso is the first
+    // one where we've encountered it.
     //
-    // `@substrate/txwrapper-core` sets the `assetId` to `0` inside of `defineMethod here:
+    // In the defineMethod function of @substrate/txwrapper-core, the assetId is set to 0.
+    // You can find the code for this function here:
     // https://github.com/paritytech/txwrapper-core/blob/90a231e07e69de96602f92d37897493ac2e7b7f7/packages/txwrapper-core/src/core/method/defineMethod.ts#LL160C3-L160C10
     //
-    // as far as I can tell, on most chains the assetId is ignored and therefore the encoding of this `0` is nothing i.e. `` in the hex-encoded extrinsic
-    // however, on Picasso the assetId is not ignored, and the `0` set by `defineMethod` ends up being encoded as `01 00000000`
-    // this causes a wasm runtime panic when the extrinsic is submitted to the chain
+    // As far as we can tell, on most chains, the assetId is ignored, so the encoding of 0 is
+    // nothing, represented as an empty string in the hex-encoded extrinsic.
+    // However, on the Picasso chain, the assetId is not ignored, and the 0 set by defineMethod is
+    // encoded as 01 00000000.
+    // This causes a wasm runtime panic when the extrinsic is submitted to the chain.
     //
-    // Picasso extrinsics constructed using polkadot.js apps encode the `assetId` as `00`, and these extrinsics don't cause a runtime panic when submitted
+    // Extrinsics constructed using polkadot.js apps for the Picasso chain encode the assetId as 00,
+    // and these extrinsics don't cause a runtime panic when submitted.
     //
-    // when we override what `@substrate/txwrapper-core` has done (defaulted to `0`) and instead set the `assetId` back to `undefined`, our extrinsics
-    // also encode the `assetId` field as `00`
+    // If we override the default assetId value from @substrate/txwrapper-core (which sets assetId to 0)
+    // and instead set assetId back to undefined, our extrinsics also encode the assetId field as 00.
     if (unsigned.assetId === 0) unsigned.assetId = undefined
 
     // create the unsigned extrinsic


### PR DESCRIPTION
The `assetId` field on an extrinsic, as far as I can tell, is used to identify which asset we should be paying gas with.

I don't really know how it works, but I do know that on most chains it's not even used (encodes to nothing), while on picasso the default encoding of `number: 0` -> `hex: 01 00000000` is incorrect.
It should be encoded as `hex: 00`, which is what happens when it's set to `undefined` in the `SignerPayloadJSON`.

The `@substrate/txwrapper-core` library is responsible for incorrectly setting it to a default value of `0` when constructing the `SignerPayloadJSON`.

I'm not sure why our type registry is converting the `0` into what I think is a u128 for every chain - I've made several passes to check if we're creating the registry incorrectly and haven't found any issues there.

My latest guess is that maybe pjs apps isn't setting the input `assetId` to `0` in the payload to begin with, unlike the txwrapper-core lib. But I haven't confirmed this.