### PR TITLE
refactor: getTypeRegistry to off-load core logic to the @substrate/txwrapper-core package

### DIFF
--- a/apps/extension/src/core/util/getMetadataDef.ts
+++ b/apps/extension/src/core/util/getMetadataDef.ts
@@ -20,7 +20,7 @@ const getCacheKey = (genesisHash: HexString, specVersion?: number) =>
 // those are stored as base64 for lower storage size
 const encodeMetadataRpc = (metadataRpc: HexString) => base64Encode(hexToU8a(metadataRpc))
 const decodeMetadataRpc = (encoded: string) => u8aToHex(base64Decode(encoded))
-const decodeMetaCalls = (encoded: string) => base64Decode(encoded)
+const decodeMetaCalls = (encoded: string) => u8aToHex(base64Decode(encoded))
 
 /**
  *

--- a/apps/extension/src/core/util/getTypeRegistry.ts
+++ b/apps/extension/src/core/util/getTypeRegistry.ts
@@ -1,20 +1,13 @@
-import { log } from "@core/log"
 import { chaindataProvider } from "@core/rpcs/chaindata"
-import {
-  getMetadataDef,
-  getMetadataFromDef,
-  getMetadataRpcFromDef,
-} from "@core/util/getMetadataDef"
+import { getMetadataDef, getMetadataFromDef } from "@core/util/getMetadataDef"
 import { typesBundle } from "@polkadot/apps-config/api"
-import { Metadata, TypeRegistry } from "@polkadot/types"
-import { getSpecAlias, getSpecTypes } from "@polkadot/types-known/util"
+import { allNetworks as substrateSS58Registry } from "@polkadot/networks"
+import { TypeRegistry } from "@polkadot/types"
+import { getSpecTypes } from "@polkadot/types-known/util"
 import { hexToNumber, isHex } from "@polkadot/util"
-
-// metadata may have been added manually to the store, for a chain that Talisman doesn't know about (not in chaindata)
-// => use either chainId or genesisHash as identifier
+import { ChainProperties, GetRegistryOptsCore, getRegistryBase } from "@substrate/txwrapper-core"
 
 /**
- *
  * @param chainIdOrHash chainId or genesisHash
  * @param specVersion specVersion of the metadata to be loaded (if not defined, will fetch latest)
  * @param blockHash if specVersion isn't specified, this is the blockHash where to fetch the correct metadata from (if not defined, will fetch latest)
@@ -27,57 +20,74 @@ export const getTypeRegistry = async (
   blockHash?: string,
   signedExtensions?: string[]
 ) => {
-  const registry = new TypeRegistry()
-
   const chain = await (isHex(chainIdOrHash)
     ? chaindataProvider.getChain({ genesisHash: chainIdOrHash })
     : chaindataProvider.getChain(chainIdOrHash))
 
-  // register typesBundle in registry for legacy (pre metadata v14) chains
-  if (typesBundle.spec && chain?.specName && typesBundle.spec[chain.specName]) {
-    const chainBundle =
-      chain.chainName && typesBundle.chain?.[chain.chainName]
-        ? { chain: { [chain.chainName]: typesBundle.chain[chain.chainName] } }
-        : {}
-    const specBundle =
-      chain.specName && typesBundle.spec?.[chain.specName]
-        ? { spec: { [chain.specName]: typesBundle.spec[chain.specName] } }
-        : {}
-    const legacyTypesBundle = { ...chainBundle, ...specBundle }
-
-    if (legacyTypesBundle) {
-      log.debug(`Setting known types for chain ${chain.id}`)
-      registry.clearCache()
-      registry.setKnownTypes({ typesBundle: legacyTypesBundle })
-      registry.register(
-        getSpecTypes(
-          registry,
-          chain.chainName,
-          chain.specName,
-          parseInt(chain.specVersion ?? "0", 10) ?? 0
-        )
-      )
-      registry.knownTypes.typesAlias = getSpecAlias(registry, chain.chainName, chain.specName)
-    }
-  }
-
   const numSpecVersion = typeof specVersion === "string" ? hexToNumber(specVersion) : specVersion
   const metadataDef = await getMetadataDef(chainIdOrHash, numSpecVersion, blockHash)
-  const metadataRpc = metadataDef ? getMetadataRpcFromDef(metadataDef) : undefined
+  const metadataRpc = metadataDef ? getMetadataFromDef(metadataDef) : undefined
+  const userExtensions = metadataDef?.userExtensions
 
-  if (metadataDef) {
-    const metadataValue = getMetadataFromDef(metadataDef)
-    if (metadataValue) {
-      const metadata: Metadata = new Metadata(registry, metadataValue)
-      registry.setMetadata(metadata)
-    }
-
-    if (signedExtensions || metadataDef.userExtensions)
-      registry.setSignedExtensions(signedExtensions, metadataDef.userExtensions)
-    if (metadataDef.types) registry.register(metadataDef.types)
-  } else {
-    if (signedExtensions) registry.setSignedExtensions(signedExtensions)
-  }
+  // for chains using metadata < v14, we need a registry which has been loaded with the legacy typesBundle
+  // for chains using metadata >= v14, we need a registry which has been loaded with the metadataRpc/metaCalls types
+  const registry = metadataRpc
+    ? getRegistry({
+        chainName: chain?.chainName ?? "",
+        specName: chain?.specName ?? "",
+        specVersion: parseInt(chain?.specVersion ?? "0") ?? 0,
+        metadataRpc,
+        signedExtensions,
+        userExtensions,
+      })
+    : new TypeRegistry()
 
   return { registry, metadataRpc }
 }
+
+/**
+ * Create a registry based on specName, chainName, specVersion and metadataRpc. This should work for
+ * Polkadot, Kusama, Westend and any chain which has up-to-date types in @polkadot/apps-config.
+ *
+ * @param GetRegistryOptions specName, chainName, specVersion, and metadataRpc of the current runtime
+ */
+function getRegistry({
+  chainName,
+  specName,
+  specVersion,
+  metadataRpc,
+  properties,
+  asCallsOnlyArg,
+  signedExtensions,
+  userExtensions,
+}: GetRegistryOptsCore): TypeRegistry {
+  const registry = new TypeRegistry()
+  registry.setKnownTypes({ typesBundle })
+
+  return getRegistryBase({
+    chainProperties: properties ?? knownChainProperties[specName],
+    // `getSpecTypes` is used to extract the chain specific types from the registry's `knownTypes`
+    specTypes: getSpecTypes(registry, chainName, specName, specVersion),
+    metadataRpc,
+    asCallsOnlyArg,
+    signedExtensions,
+    userExtensions,
+  })
+}
+
+/**
+ * Known chain properties based on the substrate ss58 registry.
+ * Chain properties are derived from the substrate ss58 registry:
+ * https://raw.githubusercontent.com/paritytech/substrate/master/ss58-registry.json
+ *
+ * Alternatively, chain properties can be dynamically fetched through the
+ * `system_properties` RPC call.
+ */
+const knownChainProperties = Object.fromEntries(
+  substrateSS58Registry
+    .filter(({ network }) => network !== null)
+    .map<[string, ChainProperties]>(({ network, decimals, symbols, prefix }) => [
+      network,
+      { tokenDecimals: decimals, tokenSymbol: symbols, ss58Format: prefix },
+    ])
+)


### PR DESCRIPTION
While working on the picasso bug I got a bit more familiar with the `@substrate/txwrapper-core` codebase.

I found that they have a function, `getRegistry`, which handles initializing a polkadot.js typeregistry based on the metadatarpc, the signed extensions, the user extensions, and the legacy typesBundle (if it applies for this chain).

Imo it's a bit more neat if we depend upon their implementation because it'll then be their responsibility to fix any bugs we don't yet know about or to support any new things the chains want to do in the future.

If we decide to go with this, I think we should merge it after we do a release and then expect to test it out in development for a week or two before releasing this.  
In theory it's doing all the same stuff as our own implementation which it replaces, but it'd be good to make sure everything (signing, send funds, every chain, etc) still works in practise.