### PR TITLE
feat: error message if ledger app is not found

### DIFF
--- a/apps/extension/src/ui/hooks/ledger/common.ts
+++ b/apps/extension/src/ui/hooks/ledger/common.ts
@@ -142,6 +142,13 @@ export const getLedgerErrorProps = (err: Error, appName = "Unknown App"): Ledger
         message: `Connecting to Ledger...`,
         requiresManualRetry: false,
       }
+
+    case "There is no Ledger app available for this network.":
+      return {
+        status: "error",
+        message: "There is no Ledger app available for this network.",
+        requiresManualRetry: false,
+      }
   }
 
   // eslint-disable-next-line no-console

--- a/apps/extension/src/ui/hooks/ledger/useLedgerSubstrate.ts
+++ b/apps/extension/src/ui/hooks/ledger/useLedgerSubstrate.ts
@@ -22,7 +22,6 @@ export const useLedgerSubstrate = (genesis?: string | null) => {
 
   const connectLedger = useCallback(
     async (resetError?: boolean) => {
-      if (!app) return
       if (refConnecting.current) return
       refConnecting.current = true
 


### PR DESCRIPTION
This should help the user understand he can't use his EVM leger account with substrate API

![image](https://user-images.githubusercontent.com/26880866/227449545-26e599cd-a5f7-4ffa-875c-81e1945c0171.png)
