### PR TITLE
fix: allow 0 gasprice on legacy custom settings

### DIFF
--- a/apps/extension/src/ui/domains/Ethereum/GasSettings/CustomGasSettingsFormLegacy.tsx
+++ b/apps/extension/src/ui/domains/Ethereum/GasSettings/CustomGasSettingsFormLegacy.tsx
@@ -37,7 +37,7 @@ const gasSettingsFromFormData = (formData: FormData): EthGasSettingsLegacy => ({
 
 const schema = yup
   .object({
-    gasPrice: yup.number().required().moreThan(0),
+    gasPrice: yup.number().required().min(0), // 0 is sometimes necessary (ex: claiming bridged assets on polygon zkEVM)
     gasLimit: yup.number().required().integer().min(21000),
   })
   .required()


### PR DESCRIPTION
This allows claiming funds bridged to Polygon zkEVM network.
At this point, it still requires the user to go to custom gas settings.

To go further, we'd have to add a 3rd option to the legacy gas settings, called "site recommended", which would use the gas settings sent from the dapp "as-is". 
I think we need a meeting to discuss this.