### PR TITLE
feat: copy transferInfo for replacement txs

### DIFF
--- a/apps/extension/src/core/domains/ethereum/handler.extension.ts
+++ b/apps/extension/src/core/domains/ethereum/handler.extension.ts
@@ -131,6 +131,7 @@ export class EthHandler extends ExtensionHandler {
   private sendSigned: MessageHandler<"pri(eth.signing.sendSigned)"> = async ({
     unsigned,
     signed,
+    transferInfo,
   }) => {
     assert(unsigned.chainId, "chainId is not defined")
     const evmNetworkId = unsigned.chainId.toString()
@@ -147,6 +148,7 @@ export class EthHandler extends ExtensionHandler {
       // long running operation, we do not want this inside getPairForAddressSafely
       watchEthereumTransaction(evmNetworkId, hash, tx, {
         notifications: true,
+        transferInfo,
       })
 
       talismanAnalytics.captureDelayed("sign transaction approve", {
@@ -161,7 +163,10 @@ export class EthHandler extends ExtensionHandler {
     }
   }
 
-  private signAndSend: MessageHandler<"pri(eth.signing.signAndSend)"> = async ({ unsigned }) => {
+  private signAndSend: MessageHandler<"pri(eth.signing.signAndSend)"> = async ({
+    unsigned,
+    transferInfo,
+  }) => {
     assert(unsigned.chainId, "chainId is not defined")
     assert(unsigned.from, "from is not defined")
     const evmNetworkId = unsigned.chainId.toString()
@@ -187,6 +192,7 @@ export class EthHandler extends ExtensionHandler {
       // long running operation, we do not want this inside getPairForAddressSafely
       watchEthereumTransaction(evmNetworkId, result.val, tx, {
         notifications: true,
+        transferInfo,
       })
 
       talismanAnalytics.captureDelayed("sign transaction approve", {

--- a/apps/extension/src/core/domains/ethereum/types.ts
+++ b/apps/extension/src/core/domains/ethereum/types.ts
@@ -6,6 +6,8 @@ import { HexString } from "@polkadot/util/types"
 import { EvmNetworkId } from "@talismn/chaindata-provider"
 import { BigNumberish, ethers } from "ethers"
 
+import { WalletTransactionTransferInfo } from "../transactions"
+
 export type {
   EvmNetwork,
   CustomEvmNetwork,
@@ -32,10 +34,12 @@ export type AddEthereumChainParameter = {
 
 export type EthTxSignAndSend = {
   unsigned: ethers.providers.TransactionRequest
+  transferInfo?: WalletTransactionTransferInfo
 }
 export type EthTxSendSigned = {
   unsigned: ethers.providers.TransactionRequest
   signed: `0x${string}`
+  transferInfo?: WalletTransactionTransferInfo
 }
 
 export declare type EthApproveSignAndSend = KnownSigningRequestIdOnly<ETH_SEND> & {

--- a/apps/extension/src/core/domains/transactions/helpers.ts
+++ b/apps/extension/src/core/domains/transactions/helpers.ts
@@ -1,4 +1,5 @@
 import { db } from "@core/db"
+import { log } from "@core/log"
 import { TypeRegistry } from "@polkadot/types"
 import { HexString } from "@polkadot/util/types"
 import { SignerPayloadJSON } from "@substrate/txwrapper-core"
@@ -61,6 +62,7 @@ export const addEvmTransaction = async (
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error("addEvmTransaction", { err })
+    log.error("addEvmTransaction", { err, hash, unsigned, options })
   }
 }
 
@@ -94,6 +96,7 @@ export const addSubstrateTransaction = async (
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error("addSubstrateTransaction", { err })
+    log.error("addSubstrateTransaction", { err, hash, payload, options })
   }
 }
 

--- a/apps/extension/src/ui/api/api.ts
+++ b/apps/extension/src/ui/api/api.ts
@@ -221,10 +221,10 @@ export const api: MessageTypes = {
     }),
 
   // eth related messages
-  ethSignAndSend: (unsigned) =>
-    messageService.sendMessage("pri(eth.signing.signAndSend)", { unsigned }),
-  ethSendSigned: (unsigned, signed) =>
-    messageService.sendMessage("pri(eth.signing.sendSigned)", { unsigned, signed }),
+  ethSignAndSend: (unsigned, transferInfo) =>
+    messageService.sendMessage("pri(eth.signing.signAndSend)", { unsigned, transferInfo }),
+  ethSendSigned: (unsigned, signed, transferInfo) =>
+    messageService.sendMessage("pri(eth.signing.sendSigned)", { unsigned, signed, transferInfo }),
   ethApproveSign: (id) =>
     messageService.sendMessage("pri(eth.signing.approveSign)", {
       id,

--- a/apps/extension/src/ui/api/types.ts
+++ b/apps/extension/src/ui/api/types.ts
@@ -224,10 +224,14 @@ export default interface MessageTypes {
   ) => Promise<ResponseAssetTransfer>
 
   // eth related messages
-  ethSignAndSend: (unsigned: ethers.providers.TransactionRequest) => Promise<HexString>
+  ethSignAndSend: (
+    unsigned: ethers.providers.TransactionRequest,
+    transferInfo?: WalletTransactionTransferInfo
+  ) => Promise<HexString>
   ethSendSigned: (
     unsigned: ethers.providers.TransactionRequest,
-    signed: HexString
+    signed: HexString,
+    transferInfo?: WalletTransactionTransferInfo
   ) => Promise<HexString>
   ethApproveSign: (id: SigningRequestID<"eth-sign">) => Promise<boolean>
   ethApproveSignHardware: (

--- a/apps/extension/src/ui/domains/Transactions/TxReplaceDrawer.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxReplaceDrawer.tsx
@@ -92,6 +92,12 @@ export const EvmEstimatedFeeTooltip: FC<{
   )
 }
 
+const getTransferInfo = (tx: EvmWalletTransaction) => {
+  return tx.value && tx.tokenId && tx.to
+    ? { value: tx.value, tokenId: tx.tokenId, to: tx.to }
+    : undefined
+}
+
 const EvmDrawerContent: FC<{
   tx: EvmWalletTransaction
   type: TxReplaceType
@@ -128,7 +134,8 @@ const EvmDrawerContent: FC<{
     if (!transaction) return
     setIsProcessing(true)
     try {
-      const newHash = await api.ethSignAndSend(transaction)
+      const transferInfo = getTransferInfo(tx)
+      const newHash = await api.ethSignAndSend(transaction, transferInfo)
       api.analyticsCapture({
         eventName: `transaction ${type}`,
         options: {
@@ -150,14 +157,15 @@ const EvmDrawerContent: FC<{
       })
     }
     setIsProcessing(false)
-  }, [onClose, transaction, type])
+  }, [onClose, transaction, tx, type])
 
   const handleSendSigned = useCallback(
     async ({ signature }: { signature: `0x${string}` }) => {
       if (!transaction) return
       setIsProcessing(true)
       try {
-        const newHash = await api.ethSendSigned(transaction, signature)
+        const transferInfo = getTransferInfo(tx)
+        const newHash = await api.ethSendSigned(transaction, signature, transferInfo)
         api.analyticsCapture({
           eventName: `transaction ${type}`,
           options: {
@@ -180,7 +188,7 @@ const EvmDrawerContent: FC<{
       }
       setIsProcessing(false)
     },
-    [onClose, transaction, type]
+    [onClose, transaction, tx, type]
   )
 
   const handleSendToLedger = useCallback(() => {


### PR DESCRIPTION
in recent activity drawer, replacement (cancel/speed-up) transactions will now have the same network badge as the tx beeing replaced