### PR TITLE
fix: chain encryption in network specs QR

### DIFF
--- a/apps/extension/src/core/libs/QrGenerator.ts
+++ b/apps/extension/src/core/libs/QrGenerator.ts
@@ -9,11 +9,7 @@ import { Chain } from "@talismn/chaindata-provider"
 import * as $ from "scale-codec"
 
 const getEncryptionForChain = (chain: Chain) => {
-  //     Ed25519 = 0,
-  //     Sr25519 = 1,
-  //     Ecdsa = 2,
-  //     Ethereum = 3,
-
+  // Ed25519=0, Sr25519=1, Ecdsa=2, ethereum=3
   switch (chain.account) {
     case "secp256k1":
       return 3


### PR DESCRIPTION
Polkadot Vault should soon provide support for EVM accounts, they got a pending PR for that.

This PR sets the encryption field of the network specs QR according to the account type for the chain, which should prevent bugs once EVM accounts are available.

