### PR TITLE
fix: show nompool unbonding funds

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardAssetDetails.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardAssetDetails.tsx
@@ -67,23 +67,24 @@ const SpacerRow = styled(({ className }) => {
 
 const AssetState = ({
   title,
+  description,
   render,
   address,
-  meta,
 }: {
   title: string
+  description?: string
   render: boolean
   address?: Address
-  meta?: string
 }) => {
   if (!render) return null
   return (
     <div className="flex h-[6.6rem] flex-col justify-center gap-2 p-8">
       <div className="flex items-baseline gap-4">
         <div className="whitespace-nowrap font-bold text-white">{title}</div>
-        {meta && address && (
+        {/* show description next to title when address is set */}
+        {description && address && (
           <div className="max-w-sm flex-shrink-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm">
-            {meta}
+            {description}
           </div>
         )}
       </div>
@@ -92,9 +93,10 @@ const AssetState = ({
           <PortfolioAccount address={address} />
         </div>
       )}
-      {meta && !address && (
+      {/* show description below title when address is not set */}
+      {description && !address && (
         <div className="flex-shrink-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm">
-          {meta}
+          {description}
         </div>
       )}
     </div>
@@ -164,7 +166,12 @@ const ChainTokenBalances = ({ chainId, balances }: AssetRowProps) => {
         .map((row, i, rows) => (
           <tr key={row.key} className={classNames("details", rows.length === i + 1 && "stop-row")}>
             <td className="al-main" valign="top">
-              <AssetState title={row.title} render address={row.address} meta={row.meta} />
+              <AssetState
+                title={row.title}
+                description={row.description}
+                render
+                address={row.address}
+              />
             </td>
             {!row.locked && <td align="right" valign="top"></td>}
             <td align="right" valign="top">
@@ -180,7 +187,28 @@ const ChainTokenBalances = ({ chainId, balances }: AssetRowProps) => {
                 )}
               />
             </td>
-            {!!row.locked && <td align="right" valign="top"></td>}
+            {!!row.locked && (
+              <td align="right" valign="top">
+                {
+                  // Show `Unbonding` next to nompool staked balances which are unbonding
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  (row.meta as any)?.type === "nompool" && !!(row.meta as any)?.unbonding && (
+                    <div
+                      className={classNames(
+                        "flex h-[6.6rem] flex-col justify-center gap-2 whitespace-nowrap p-8 text-right",
+                        status.status === "fetching" && "animate-pulse transition-opacity"
+                      )}
+                    >
+                      <div className="text-body flex items-center justify-end gap-2">
+                        <div>Unbonding</div>
+                      </div>
+                      {/* TODO: Show time until funds are unbonded */}
+                      {/* <div>4d 14hr 11min</div> */}
+                    </div>
+                  )
+                }
+              </td>
+            )}
           </tr>
         ))}
     </>

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupAssetDetails.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupAssetDetails.tsx
@@ -81,9 +81,9 @@ const ChainTokenBalances = ({ chainId, balances }: AssetRowProps) => {
                   <PortfolioAccount address={row.address} />
                 </div>
               )}
-              {!row.address && row.meta && (
+              {!row.address && row.description && (
                 <div className="overflow-hidden text-ellipsis whitespace-nowrap text-xs">
-                  {row.meta}
+                  {row.description}
                 </div>
               )}
             </div>

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/useChainTokenBalances.ts
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/useChainTokenBalances.ts
@@ -15,11 +15,12 @@ import { useTokenBalancesSummary } from "../useTokenBalancesSummary"
 type DetailRow = {
   key: string | BalanceLockType
   title: string
+  description?: string
   tokens: BigNumber
   fiat: number | null
   locked: boolean
   address?: Address
-  meta?: string
+  meta?: any // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 type ChainTokenBalancesParams = {
@@ -74,13 +75,14 @@ export const useChainTokenBalances = ({ chainId, balances }: ChainTokenBalancesP
       b.reserves.map((reserve, index) => ({
         key: `${b.id}-reserved-${index}`,
         title: getLockTitle(reserve, { balance: b }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        description: (reserve.meta as any)?.description ?? undefined,
         tokens: BigNumber(reserve.amount.tokens),
         fiat: reserve.amount.fiat("usd"),
         locked: true,
         // only show address when we're viewing balances for all accounts
         address: account ? undefined : b.address,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        meta: (reserve.meta as any)?.description ?? undefined,
+        meta: reserve.meta,
       }))
     )
 

--- a/packages/balances-substrate-native/src/helpers.ts
+++ b/packages/balances-substrate-native/src/helpers.ts
@@ -75,6 +75,7 @@ export type BalanceLockType =
   | "crowdloan"
   | "staking"
   | "nompools-staking"
+  | "nompools-unbonding"
   | "vesting"
   | "dapp-staking"
   | "other"
@@ -150,6 +151,7 @@ export const getLockTitle = (
     return `${name ? name : `Parachain ${paraId}`} Crowdloan`
   }
   if (lock.label === "nompools-staking") return "Pooled Staking"
+  if (lock.label === "nompools-unbonding") return "Pooled Staking"
   if (lock.label === "dapp-staking") return "DApp Staking"
   if (lock.label === "fees") return "Locked (Fees)"
   if (lock.label === "misc") return "Locked"


### PR DESCRIPTION
I was messing around with nompools and realised that when I unbond some funds from a pool they disappear from the wallet!

Turns out those are retrieved separately.

~Depends on https://github.com/TalismanSociety/talisman/pull/707 to be merged first because both PRs affect the `useChainTokenBalances` hook~ #707 has been merged!