### PR TITLE
Prevent webpack watching dist and node_modules folders

### DIFF
--- a/apps/extension/webpack/webpack.dev.js
+++ b/apps/extension/webpack/webpack.dev.js
@@ -15,6 +15,9 @@ const config = (env) =>
   merge(common(env), {
     devtool: "eval-cheap-module-source-map",
     mode: "development",
+    watchOptions: {
+      ignored: [distDir, path.join(__dirname, "..", "node_modules")],
+    },
     plugins: [
       new CopyPlugin({
         patterns: [


### PR DESCRIPTION
Solves problem with infinite reloading loop on slower computer