### PR TITLE
fix: evm switch network comprehensive error message

### DIFF
--- a/apps/extension/src/core/domains/ethereum/handler.tabs.ts
+++ b/apps/extension/src/core/domains/ethereum/handler.tabs.ts
@@ -362,7 +362,7 @@ export class EthTabsHandler extends TabsHandler {
     const ethereumNetwork = await chaindataProvider.getEvmNetwork(ethChainId.toString())
     if (!ethereumNetwork)
       throw new EthProviderRpcError(
-        `Unknown network ${ethChainId}. Try adding the chain using wallet_addEthereumChain first.`,
+        `Unknown network ${ethChainId}, try adding the chain using wallet_addEthereumChain first`,
         ETH_ERROR_UNKNOWN_CHAIN_NOT_CONFIGURED
       )
 


### PR DESCRIPTION
When trying to switch to BSC testnet on playground I got misleaded by our previous error message thinking the network wasn't registered, but it was just the RPC that was down.

This PR updates error messages to allow dapp to know what's wrong if attempting to switch to a network. We can now tell the difference between an unregistered network and a network with unresponsive RPC.

