### PR TITLE
fix: ci extension prod builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
           npm_package_version=$(cat apps/extension/package.json | jq -r .version)
           echo "npm_package_version=$npm_package_version" >> $GITHUB_OUTPUT
       - name: Build
-        run: PORT_PREFIX=talisman EXTENSION_PREFIX=talisman yarn run build:extension:production
+        run: PORT_PREFIX=talisman EXTENSION_PREFIX=talisman yarn run build:extension:prod
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
`build:extension:production` should be `build:extension:prod`