### PR TITLE
fix: dont show empty default token balances for accounts with non-zero balance

### DIFF
--- a/apps/extension/src/core/constants.ts
+++ b/apps/extension/src/core/constants.ts
@@ -4,10 +4,16 @@ export const DEBUG = process.env.BUILD !== "production" && process.env.NODE_ENV 
 export const TEST = process.env.NODE_ENV === "test"
 export const DEFAULT_ETH_CHAIN_ID = 1 //Ethereum mainnet
 
+/**
+ * A list of tokens to show by default for empty substrate accounts
+ */
 export const DEFAULT_PORTFOLIO_TOKENS_SUBSTRATE = [
   "polkadot-substrate-native-dot",
   "kusama-substrate-native-ksm",
 ]
+/**
+ * A list of tokens to show by default for empty ethereum accounts
+ */
 export const DEFAULT_PORTFOLIO_TOKENS_ETHEREUM = [
   "1-evm-native-eth",
   "1284-evm-native-glmr",

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/usePortfolioSymbolBalances.ts
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/usePortfolioSymbolBalances.ts
@@ -163,12 +163,18 @@ export const usePortfolioSymbolBalances = (balances: Balances) => {
           (hasEthereumAccount ? DEFAULT_PORTFOLIO_TOKENS_ETHEREUM.length : 0)
         )
       if (account.genesisHash) return 1
+
+      // DEFAULT_TOKENS are only shown for accounts with no balance
+      const accountHasSomeBalance =
+        balances.find({ address: account?.address }).sum.planck.total > 0n
+      if (accountHasSomeBalance) return 0
+
       if (account.type === "ethereum") return DEFAULT_PORTFOLIO_TOKENS_ETHEREUM.length
       return DEFAULT_PORTFOLIO_TOKENS_SUBSTRATE.length
     })()
 
     return symbolBalances.length < expectedRows ? expectedRows - symbolBalances.length : 0
-  }, [account, hasEthereumAccount, networkFilter, symbolBalances.length])
+  }, [account, hasEthereumAccount, networkFilter, balances, symbolBalances.length])
 
   return { symbolBalances, availableSymbolBalances, lockedSymbolBalances, skeletons }
 }

--- a/apps/extension/src/ui/domains/Portfolio/useDisplayBalances.ts
+++ b/apps/extension/src/ui/domains/Portfolio/useDisplayBalances.ts
@@ -8,31 +8,36 @@ import { useSelectedAccount } from "@ui/domains/Portfolio/SelectedAccountContext
 import { useMemo } from "react"
 
 // TODO: default tokens should be controlled from chaindata
-const shouldDisplayBalance =
-  (account?: AccountJsonAny) =>
-  (balance: Balance): boolean => {
+const shouldDisplayBalance = (account: AccountJsonAny | undefined, balances: Balances) => {
+  const accountHasSomeBalance = balances.find({ address: account?.address }).sum.planck.total > 0n
+
+  return (balance: Balance): boolean => {
     // don't show substrate balances for ledger ethereum accounts (MOVR, GLMR etc exist on both sides)
     if (account?.type === "ethereum" && account.isHardware && !balance.evmNetworkId) return false
 
     const hasNonZeroBalance = balance.total.planck > 0
     if (hasNonZeroBalance) return true
 
-    const isSubstrateAccount = account?.type !== "ethereum"
-    const isSubstrateToken = DEFAULT_PORTFOLIO_TOKENS_SUBSTRATE.includes(balance.tokenId)
-    if (isSubstrateAccount && isSubstrateToken) return true
+    // only show DEFAULT_TOKENS if account has no balance
+    if (!accountHasSomeBalance) {
+      const isSubstrateAccount = account?.type !== "ethereum"
+      const isSubstrateToken = DEFAULT_PORTFOLIO_TOKENS_SUBSTRATE.includes(balance.tokenId)
+      if (isSubstrateAccount && isSubstrateToken) return true
 
-    const isEthereumAccount = !account || account?.type === "ethereum"
-    const isEthereumToken = DEFAULT_PORTFOLIO_TOKENS_ETHEREUM.includes(balance.tokenId)
-    if (isEthereumAccount && isEthereumToken) return true
+      const isEthereumAccount = !account || account?.type === "ethereum"
+      const isEthereumToken = DEFAULT_PORTFOLIO_TOKENS_ETHEREUM.includes(balance.tokenId)
+      if (isEthereumAccount && isEthereumToken) return true
+    }
 
     if (account?.genesisHash && account.genesisHash === balance.chain?.genesisHash)
       return balance.token?.type === "substrate-native" || balance.total.planck > 0n
 
     return false
   }
+}
 
 export const useDisplayBalances = (balances: Balances) => {
   const { account } = useSelectedAccount()
 
-  return useMemo(() => balances.find(shouldDisplayBalance(account)), [account, balances])
+  return useMemo(() => balances.find(shouldDisplayBalance(account, balances)), [account, balances])
 }


### PR DESCRIPTION
Some before & after shots:

| Before  | After |
| ------------- | ------------- |
| ![](https://media.discordapp.net/attachments/940179502384939079/1110143941849927741/Screenshot_2023-05-22_at_19.55.14.png)  | ![](https://media.discordapp.net/attachments/940179502384939079/1110143942088986684/Screenshot_2023-05-22_at_19.55.37.png)  |
| ![](https://media.discordapp.net/attachments/940179502384939079/1110144805490663424/Screenshot_2023-05-22_at_19.58.42.png)  | ![](https://media.discordapp.net/attachments/940179502384939079/1110144805863960657/Screenshot_2023-05-22_at_19.59.02.png)  |

To test:
- [ ] Check that empty accounts (with no balances at all!) still show all the default networks
- [ ] Check that PV/Ledger accounts (locked to a genesisHash) behave as expected
- [ ] Check that skeleton loaders behave as expected for genesisHash-locked & unlocked accounts from an empty balances DB