### PR TITLE
fix: 🐛 support slash in token symbol

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
@@ -121,9 +121,12 @@ const AssetRow = ({ balances }: AssetRowProps) => {
 
   const navigate = useNavigate()
   const handleClick = useCallback(() => {
-    navigate(`/portfolio/${token?.symbol}${token?.isTestnet ? "?testnet=true" : ""}`)
-    genericEvent("goto portfolio asset", { from: "dashboard", symbol: token?.symbol })
-  }, [genericEvent, navigate, token?.isTestnet, token?.symbol])
+    if (!token) return
+    navigate(
+      `/portfolio/${encodeURIComponent(token.symbol)}${token.isTestnet ? "?testnet=true" : ""}`
+    )
+    genericEvent("goto portfolio asset", { from: "dashboard", symbol: token.symbol })
+  }, [genericEvent, navigate, token])
 
   const handleClickStakingBanner = useCallback(() => {
     window.open("https://app.talisman.xyz/staking")

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
@@ -131,9 +131,12 @@ const AssetRow = ({ balances, locked }: AssetRowProps) => {
   })
   const navigate = useNavigate()
   const handleClick = useCallback(() => {
-    navigate(`/portfolio/${token?.symbol}${token?.isTestnet ? "?testnet=true" : ""}`)
-    genericEvent("goto portfolio asset", { from: "popup", symbol: token?.symbol })
-  }, [genericEvent, navigate, token?.isTestnet, token?.symbol])
+    if (!token) return
+    navigate(
+      `/portfolio/${encodeURIComponent(token.symbol)}${token.isTestnet ? "?testnet=true" : ""}`
+    )
+    genericEvent("goto portfolio asset", { from: "popup", symbol: token.symbol })
+  }, [genericEvent, navigate, token])
 
   const handleClickStakingBanner = useCallback(() => {
     window.open("https://app.talisman.xyz/staking")


### PR DESCRIPTION
:jean:

to test : 
token address **on Optimism** : 0xcdd41009E74bD1AE4F7B2EeCF892e4bC718b9302
account address : **DELETED**