### PR TITLE
feat: 🔒 prevent running scripts on pkg install

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -11,3 +11,5 @@ plugins:
     spec: "@yarnpkg/plugin-workspace-tools"
 
 yarnPath: .yarn/releases/yarn-3.2.1.cjs
+
+enableScripts: false


### PR DESCRIPTION
- [x] Fixes #852 

Uses the simple .yarnrc.yml approach

Tested with a fresh clone of the repo, no issue.
Wallet builds and resulting dist works fine.

When running `yarn` we now see all the packages which have scripts that will be ignored : 
![image](https://github.com/TalismanSociety/talisman/assets/26880866/0d124ab6-8205-4649-b133-1fef05978dff)
