### PR TITLE
Allow signing substrate tx for moonbeam with evm account

### DIFF
--- a/apps/extension/src/core/domains/signing/handler.ts
+++ b/apps/extension/src/core/domains/signing/handler.ts
@@ -14,10 +14,10 @@ import type { MessageTypes, RequestType, ResponseType } from "@core/types"
 import { Port } from "@core/types/base"
 import { getTypeRegistry } from "@core/util/getTypeRegistry"
 import { isJsonPayload } from "@core/util/isJsonPayload"
-import { encodeAddress } from "@polkadot/keyring"
 import { TypeRegistry } from "@polkadot/types"
 import keyring from "@polkadot/ui-keyring"
 import { assert } from "@polkadot/util"
+import { encodeAnyAddress } from "@talismn/util"
 
 import { getHostName } from "../app/helpers"
 
@@ -29,7 +29,7 @@ export default class SigningHandler extends ExtensionHandler {
 
     const { reject, request, resolve, url } = queued
 
-    const address = encodeAddress(queued.account.address)
+    const address = encodeAnyAddress(queued.account.address)
 
     const result = await getPairForAddressSafely(address, async (pair) => {
       const { payload } = request


### PR DESCRIPTION
Fixes bug when attempting to sign Substrate transactions on Moonbeam on Polkadot JS Apps 