### PR TITLE
fix: allow extension builds with no SimpleLocalize api key

### DIFF
--- a/apps/extension/i18next-parser.config.cjs
+++ b/apps/extension/i18next-parser.config.cjs
@@ -2,7 +2,10 @@
 
 // The key is the `locale` as passed to i18next.
 // The value is the `human-readable name` as passed to the language settings UI in the wallet.
-const languages = process.env.SUPPORTED_LANGUAGES || { en: "English" }
+// This config is only used for generating translations for development builds
+// Production builds will pull translations from SimpleLocalize, and then set the
+//`process.env.SUPPORTED_LANGUAGES` variable as used by the extension i18n config
+const languages = { en: "English" }
 
 module.exports = {
   // use `common` instead of `translation` as the default namespace

--- a/apps/extension/src/core/i18nConfig.ts
+++ b/apps/extension/src/core/i18nConfig.ts
@@ -7,8 +7,13 @@ import { initReactI18next } from "react-i18next"
 import i18nextParserConfig from "../../i18next-parser.config.cjs"
 
 // juicy human-readable names
-export const languages = i18nextParserConfig.languages as Record<string, string>
-const locales = Object.keys(i18nextParserConfig.languages)
+export const languages: Record<string, string> = process.env.SUPPORTED_LANGUAGES
+  ? // prod builds (fetched from SimpleLocalize)
+    JSON.parse(process.env.SUPPORTED_LANGUAGES)
+  : // dev builds (just English)
+    i18nextParserConfig.languages
+
+const locales = Object.keys(languages)
 
 i18next
   .use(LanguageDetector)
@@ -34,7 +39,8 @@ i18next
       "dev",
 
       // the actual languages
-      // imported from i18next-parser.config.cjs so that these two files are kept in sync
+      // imported from i18next-parser.config.cjs in development so that these two files are kept in sync
+      // fetched from SimpleLocalize as part of the build process for production builds
       ...locales,
     ],
     // use natural language 'en' keys as fallback for languages with no

--- a/apps/extension/webpack/SimpleLocalizeDownloadPlugin.js
+++ b/apps/extension/webpack/SimpleLocalizeDownloadPlugin.js
@@ -7,6 +7,121 @@ const apiKey = process.env.SIMPLE_LOCALIZE_API_KEY
 const projectToken = process.env.SIMPLE_LOCALIZE_PROJECT_TOKEN
 const endpoint = `https://api.simplelocalize.io/api/v4/export?downloadFormat=single-language-json&downloadOptions=SPLIT_BY_NAMESPACES`
 
+module.exports = class SimpleLocalizeDownloadPlugin {
+  constructor(
+    options = {
+      /**
+       * If false (the default), this plugin will attempt to download translations from SimpleLocalize.
+       * Following this, this plugin will substitute `process.env.SUPPORTED_LANGUAGES` for a map of downloaded languages.
+       *
+       * If true, this plugin will simply substitute `process.env.SUPPORTED_LANGUAGES` for `'{"en":"English"}'`.
+       */
+      devMode: false,
+    }
+  ) {
+    this.options = options
+  }
+
+  apply(compiler) {
+    const {
+      webpack: {
+        sources: { RawSource },
+      },
+    } = compiler
+
+    const { devMode } = this.options
+    const hasKeys = apiKey && projectToken
+
+    // only fetch translations for prod builds,
+    // and only when the developer has SimpleLocalize keys available
+    const fetchTranslations = !devMode && hasKeys
+
+    if (!devMode && !hasKeys)
+      console.warn(
+        `No SimpleLocalize API key has been configured. This build will use the existing i18n translations at apps/extension/public/locales`
+      )
+
+    compiler.hooks.beforeRun.tapAsync(
+      "SimpleLocalizeDownloadPlugin",
+      async ({ options }, callback) => {
+        const definePlugin = options.plugins.find((plugin) => plugin instanceof DefinePlugin)
+        if (!definePlugin) return
+
+        const languages = await (async () => {
+          if (!fetchTranslations) return []
+
+          try {
+            return await simpleLocalizeFetch(
+              `https://cdn.simplelocalize.io/${projectToken}/_latest/_languages`
+            )
+          } catch (error) {
+            console.error("Failed to fetch languages list:", error)
+            return []
+          }
+        })()
+
+        const supportedLanguages =
+          languages.length > 0
+            ? Object.fromEntries(languages.map((lang) => [lang.key, lang.name]))
+            : { en: "English" }
+
+        console.log("Setting supported languages", supportedLanguages)
+        // Explanation for the double JSON.stringify:
+        //
+        // - first stringify turns JSON into a string e.g. `{ en: "English" }` -> `'{"en":"English"}'`
+        // - second stringify puts string quotes around the string, e.g. `'{"en":"English"}'` -> `'"{\\"en\\":\\"English\\"}"'`
+        //
+        // The first stringify is necessary because process.env['key'] should be of type string, not object.
+        //
+        // The second stringify is necessary because DefinePlugin expects a code fragment, not a string.
+        // From the DefinePlugin docs:
+        // > Note that because the plugin does a direct text replacement,
+        // > the value given to it must include actual quotes inside of the string itself.
+        // >
+        // > Typically, this is done either with either alternate quotes, such as '"production"',
+        // > or by using JSON.stringify('production').
+        definePlugin.definitions["process.env.SUPPORTED_LANGUAGES"] = JSON.stringify(
+          JSON.stringify(supportedLanguages)
+        )
+
+        callback()
+      }
+    )
+
+    // if we're not fetching translations, stop here (don't tap into compiler.hooks.make)
+    if (!fetchTranslations) return
+
+    compiler.hooks.make.tapAsync("SimpleLocalizeDownloadPlugin", async (compilation, callback) => {
+      console.log(`Getting translations from ${endpoint}`)
+      const namespaces = await getNamespaceUrls()
+      const namespaceJson = await Promise.all(
+        namespaces.flatMap(({ url, namespace, language }) =>
+          simpleLocalizeFetch(url)
+            .then((json) => ({ namespace, language, json }))
+            .catch((error) => {
+              console.error(`Unable to get ${language} file for namespace ${namespace}:`, error)
+              return []
+            })
+        )
+      )
+
+      namespaceJson.forEach(({ namespace, language, json }) =>
+        compilation.emitAsset(
+          `locales/${language}/${namespace}.json`,
+          new RawSource(JSON.stringify(json))
+        )
+      )
+
+      const languages = namespaceJson
+        .map(({ language }) => language)
+        .sort()
+        .filter((language, index, all) => all.indexOf(language) === index)
+      console.log(`Translations fetched for ${languages.join(", ")}`)
+      callback()
+    })
+  }
+}
+
 const simpleLocalizeFetch = (url) =>
   nodeFetch(url, {
     method: "GET",
@@ -16,11 +131,12 @@ const simpleLocalizeFetch = (url) =>
     },
   }).then((response) => response.json())
 
-/*
-* Fetch languages from CDN
-* returns shape:
-  { url:string, namespace:string, language: string }[]
-*/
+/**
+ * Fetch languages from CDN.
+ * Returns shape:
+ *
+ *     Array<{ url: string, namespace: string, language: string }>
+ */
 const getNamespaceUrls = () =>
   simpleLocalizeFetch(endpoint)
     .then((data) => {
@@ -32,71 +148,5 @@ const getNamespaceUrls = () =>
       return content
     })
     .catch((error) => {
-      console.error("Error:", error)
+      console.error("Failed to get namespace urls:", error)
     })
-
-class SimpleLocalizeDownloadPlugin {
-  apply(compiler) {
-    // Do nothing if dev hasn't configured an api key for simplelocalize
-    if (!apiKey || !projectToken) {
-      console.warn(
-        `No SimpleLocalize API key has been configured. This build will use the existing i18n translations at apps/extension/public/locales`
-      )
-      return
-    }
-
-    const {
-      webpack: {
-        sources: { RawSource },
-      },
-    } = compiler
-
-    compiler.hooks.afterPlugins.tap("SimpleLocalizeDownloadPlugin", async ({ options }) => {
-      const definePlugin = options.plugins.find((plugin) => plugin instanceof DefinePlugin)
-      if (definePlugin) {
-        const languages = await simpleLocalizeFetch(
-          `https://cdn.simplelocalize.io/${projectToken}/_latest/_languages`
-        )
-        const supportedLanguages = languages.reduce((result, lang) => {
-          result[lang.key] = lang.name
-          return result
-        }, {})
-
-        console.log("Setting supported languages", supportedLanguages)
-        definePlugin.definitions["process.env.SUPPORTED_LANGUAGES"] =
-          JSON.stringify(supportedLanguages)
-      }
-    })
-
-    compiler.hooks.make.tapAsync("SimpleLocalizeDownloadPlugin", async (compilation, callback) => {
-      console.log("Getting translations from ", endpoint)
-      const namespaces = await getNamespaceUrls()
-      const namespaceJson = await Promise.all(
-        namespaces.map(({ url, namespace, language }) =>
-          simpleLocalizeFetch(url)
-            .then((json) => {
-              return { namespace, language, json }
-            })
-            .catch((error) => {
-              console.error(`Unable to get ${language} file for namespace ${namespace}`)
-              console.error(error)
-              return undefined
-            })
-        )
-      )
-
-      namespaceJson.forEach((item) => {
-        if (!item) return
-        const { namespace, language, json } = item
-        compilation.emitAsset(
-          `locales/${language}/${namespace}.json`,
-          new RawSource(JSON.stringify(json))
-        )
-      })
-
-      callback()
-    })
-  }
-}
-
-module.exports = SimpleLocalizeDownloadPlugin

--- a/apps/extension/webpack/SimpleLocalizeDownloadPlugin.js
+++ b/apps/extension/webpack/SimpleLocalizeDownloadPlugin.js
@@ -37,6 +37,14 @@ const getNamespaceUrls = () =>
 
 class SimpleLocalizeDownloadPlugin {
   apply(compiler) {
+    // Do nothing if dev hasn't configured an api key for simplelocalize
+    if (!apiKey || !projectToken) {
+      console.warn(
+        `No SimpleLocalize API key has been configured. This build will use the existing i18n translations at apps/extension/public/locales`
+      )
+      return
+    }
+
     const {
       webpack: {
         sources: { RawSource },

--- a/apps/extension/webpack/webpack.dev.js
+++ b/apps/extension/webpack/webpack.dev.js
@@ -2,12 +2,12 @@
 
 const { merge } = require("webpack-merge")
 const common = require("./webpack.common.js")
-const webpack = require("webpack")
 const path = require("path")
 const distDir = path.join(__dirname, "..", "dist")
 const CopyPlugin = require("copy-webpack-plugin")
 const ExtensionReloader = require("@alectalisman/webpack-ext-reloader")
 const CircularDependencyPlugin = require("circular-dependency-plugin")
+const SimpleLocalizeDownloadPlugin = require("./SimpleLocalizeDownloadPlugin")
 const { getManifestVersionName } = require("./utils.js")
 
 const manifestPath = path.join(__dirname, "..", "public", "manifest.json")
@@ -20,11 +20,7 @@ const config = (env) =>
       ignored: [distDir, path.join(__dirname, "..", "node_modules")],
     },
     plugins: [
-      new webpack.DefinePlugin({
-        "process.env.SUPPORTED_LANGUAGES": JSON.stringify(
-          process.env.SUPPORTED_LANGUAGES || { en: "English" }
-        ),
-      }),
+      new SimpleLocalizeDownloadPlugin({ devMode: true }),
       new CopyPlugin({
         patterns: [
           {


### PR DESCRIPTION
Previously:
- Dev builds would fail (`process` is not defined errors in frontend and background script)
- Builds with no api key would fail (unable to fetch translations)
- Production builds with an api key would fail (`process` is not defined errors in frontend & background script)

I suspect the `process` is not defined errors might have been a race condition in the `SimpleLocalizeDownloadPlugin`, and is the reason I moved the download logic from the sync `afterPlugins` hook to the async `beforeRun` hook

After this PR:
- Dev builds / prod builds with no api key use english fallbacks
- Prod builds with api key have no `process` is not defined errors