### PR TITLE
fix: sign substrate stuck analysing

### DIFF
--- a/apps/extension/src/ui/hooks/useExtrinsic.ts
+++ b/apps/extension/src/ui/hooks/useExtrinsic.ts
@@ -110,6 +110,7 @@ export const useExtrinsic = (payload?: SignerPayloadJSON | SignerPayloadRaw) => 
     refetchInterval: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: true,
+    retryOnMount: false,
     retry: 2,
   })
 }


### PR DESCRIPTION
- Fixes #923 

We had an infinite loop situation because of nested components using the same useQuery hook.
Result is cached and shared properly, but errors weren't, prior to this PR.