### PR TITLE
feat: account colors on popup home page

### DIFF
--- a/.changeset/large-laws-relax.md
+++ b/.changeset/large-laws-relax.md
@@ -1,0 +1,5 @@
+---
+"talisman-ui": minor
+---
+
+colors property on BackgroundV3 config

--- a/apps/extension/src/ui/apps/popup/pages/Login.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Login.tsx
@@ -1,15 +1,13 @@
-import { AccountJsonAny, AccountType, storedSeedAccountTypes } from "@core/domains/accounts/types"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { SuspenseTracker } from "@talisman/components/SuspenseTracker"
 import { HandMonoTransparentLogo } from "@talisman/theme/logos"
-import { useTalismanOrb } from "@talismn/orb"
 import { classNames } from "@talismn/util"
 import { api } from "@ui/api"
 import { useAnalytics } from "@ui/hooks/useAnalytics"
-import { Suspense, useCallback, useEffect, useMemo, useState } from "react"
+import { useFirstAccountColors } from "@ui/hooks/useFirstAccountColors"
+import { Suspense, useCallback, useEffect, useState } from "react"
 import { SubmitHandler, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { atom, useRecoilValue } from "recoil"
 import { Button, FormFieldInputText } from "talisman-ui"
 import { LoginBackground } from "talisman-ui"
 import * as yup from "yup"
@@ -29,63 +27,14 @@ const schema = yup
 
 const INPUT_CONTAINER_PROPS = { className: "bg-white/10" }
 
-const useAccountColors = ({ account }: { account: AccountJsonAny }): [string, string] => {
-  const { bgColor1, bgColor2 } = useTalismanOrb(account.address)
-
-  return [bgColor1, bgColor2]
-}
-
-// do not use this atom outside of this screen as it may cause performance issues because of suspense
-const accountsState = atom<AccountJsonAny[]>({
-  key: "accountsState",
-  effects: [
-    ({ setSelf }) => {
-      const unsubscribe = api.accountsSubscribe(setSelf)
-      return () => unsubscribe()
-    },
-  ],
-})
-
-/**
- * @param storedSeedOnly causes the function to return only accounts derived from a seed stored in Talisman. Returns that account if it
- * exists, or the first account present if not, by default
- * @returns an Account
- */
-export const useBackgroundLoginAccount = (storedSeedOnly?: boolean) => {
-  const accounts = useRecoilValue(accountsState)
-
-  const storedSeedAccount = useMemo(
-    () => accounts.find(({ origin }) => storedSeedAccountTypes.includes(origin as AccountType)),
-    [accounts]
-  )
-  if (storedSeedOnly) return storedSeedAccount
-  if (accounts.length > 0) return accounts[0]
-  return
-}
-
-const LoginBackgroundWithAccount = ({ account }: { account: AccountJsonAny }) => {
-  const accountColors = useAccountColors({ account })
+const Background = () => {
+  const colors = useFirstAccountColors()
 
   return (
     <LoginBackground
       width={400}
       height={600}
-      colors={accountColors}
-      className="absolute left-0 top-0 m-0 block h-full w-full overflow-hidden "
-    />
-  )
-}
-
-const Background = () => {
-  const account = useBackgroundLoginAccount()
-
-  return account ? (
-    <LoginBackgroundWithAccount account={account} />
-  ) : (
-    <LoginBackground
-      width={400}
-      height={600}
-      colors={["#fd4848", "#d5ff5c"]}
+      colors={colors}
       className="absolute left-0 top-0 m-0 block h-full w-full overflow-hidden "
     />
   )

--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAccounts.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAccounts.tsx
@@ -3,6 +3,7 @@ import { AccountType, AccountsCatalogTree } from "@core/domains/accounts/types"
 import { isEthereumAddress } from "@polkadot/util-crypto"
 import { FadeIn } from "@talisman/components/FadeIn"
 import { IconButton } from "@talisman/components/IconButton"
+import { SuspenseTracker } from "@talisman/components/SuspenseTracker"
 import { ChevronLeftIcon, ChevronRightIcon, CopyIcon, EyeIcon } from "@talisman/theme/icons"
 import { Balance, Balances } from "@talismn/balances"
 import { classNames } from "@talismn/util"
@@ -19,8 +20,9 @@ import useAccounts from "@ui/hooks/useAccounts"
 import useAccountsCatalog from "@ui/hooks/useAccountsCatalog"
 import { useAnalytics } from "@ui/hooks/useAnalytics"
 import useBalances from "@ui/hooks/useBalances"
+import { useFirstAccountColors } from "@ui/hooks/useFirstAccountColors"
 import { useSearchParamsSelectedFolder } from "@ui/hooks/useSearchParamsSelectedFolder"
-import { MouseEventHandler, useCallback, useEffect, useMemo, useState } from "react"
+import { MouseEventHandler, Suspense, useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { MYSTICAL_PHYSICS_V3, MysticalBackground } from "talisman-ui"
@@ -200,6 +202,18 @@ const Accounts = ({
   )
 }
 
+const AllAccountsHeaderBackground = () => {
+  const colors = useFirstAccountColors()
+  const config = useMemo(() => ({ ...AccountsBgConfig, colors }), [colors])
+
+  return (
+    <MysticalBackground
+      className="absolute left-0 top-0 h-full w-full backdrop-blur-3xl"
+      config={config}
+    />
+  )
+}
+
 const AllAccountsHeader = () => {
   const navigate = useNavigate()
   const handleClick = useCallback(() => navigate("/portfolio/assets"), [navigate])
@@ -214,10 +228,10 @@ const AllAccountsHeader = () => {
       onMouseOut={() => setMouseOver(false)}
       onBlur={() => setMouseOver(false)}
     >
-      <MysticalBackground
-        className="absolute left-0 top-0 h-full w-full backdrop-blur-3xl"
-        config={AccountsBgConfig}
-      />
+      <Suspense fallback={<SuspenseTracker name="AllAccountsHeaderBackground" />}>
+        <AllAccountsHeaderBackground />
+      </Suspense>
+
       <TotalFiatBalance className="relative" mouseOver={mouseOver} />
     </button>
   )

--- a/apps/extension/src/ui/hooks/useFirstAccountColors.ts
+++ b/apps/extension/src/ui/hooks/useFirstAccountColors.ts
@@ -1,0 +1,29 @@
+import { AccountJsonAny } from "@core/domains/accounts/types"
+import { useTalismanOrb } from "@talismn/orb"
+import { api } from "@ui/api"
+import { useMemo } from "react"
+import { atom, useRecoilValue } from "recoil"
+
+const TALISMAN_COLORS = ["#fd4848", "#d5ff5c"] as const
+
+const accountsState = atom<AccountJsonAny[]>({
+  key: "accountsState",
+  effects: [
+    ({ setSelf }) => {
+      const unsubscribe = api.accountsSubscribe(setSelf)
+      return () => unsubscribe()
+    },
+  ],
+})
+
+export const useFirstAccountColors = () => {
+  // pick first account and apply it's colors to background
+  const [account] = useRecoilValue(accountsState)
+
+  const { bgColor1, bgColor2 } = useTalismanOrb(account?.address ?? "")
+
+  return useMemo(
+    () => (account ? [bgColor1, bgColor2] : TALISMAN_COLORS) as [string, string],
+    [account, bgColor1, bgColor2]
+  )
+}

--- a/packages/talisman-ui/src/components/MysticalBackgroundV3/MysticalBackgroundV3.tsx
+++ b/packages/talisman-ui/src/components/MysticalBackgroundV3/MysticalBackgroundV3.tsx
@@ -12,6 +12,7 @@ const CelestialArtifact = memo(
     config,
     x,
     y,
+    color,
   }: {
     parentSize: ParentSize
     config: MysticalPhysicsV3
@@ -19,9 +20,12 @@ const CelestialArtifact = memo(
     // force target position if this artifact is an acolyte
     x?: number
     y?: number
+
+    // force color
+    color?: string
   }) => {
     const [id] = useState(() => crypto.randomUUID())
-    const artifact = useCelestialArtifact(config, parentSize, x, y)
+    const artifact = useCelestialArtifact(config, parentSize, x, y, color)
 
     const refInitialized = useRef(false)
 
@@ -71,15 +75,26 @@ const CelestialArtifacts: FC<{
   acolyte?: { x: number; y: number }
 }> = ({ size, config, acolyte }) => {
   const artifactKeys = useMemo(() => Array.from(Array(config.artifacts).keys()), [config.artifacts])
-
   if (!size.width || !size.height) return null
 
   return (
     <>
       {artifactKeys.map((i) => (
-        <CelestialArtifact key={i} parentSize={size} config={config} />
+        <CelestialArtifact
+          key={i}
+          parentSize={size}
+          config={config}
+          color={config.colors?.[i % config.colors.length]}
+        />
       ))}
-      {config.withAcolyte && <CelestialArtifact parentSize={size} config={config} {...acolyte} />}
+      {config.withAcolyte && (
+        <CelestialArtifact
+          parentSize={size}
+          config={config}
+          {...acolyte}
+          color={config.colors?.[artifactKeys.length % config.colors.length]}
+        />
+      )}
     </>
   )
 }

--- a/packages/talisman-ui/src/components/MysticalBackgroundV3/MysticalPhysicsV3.ts
+++ b/packages/talisman-ui/src/components/MysticalBackgroundV3/MysticalPhysicsV3.ts
@@ -9,6 +9,7 @@ export type MysticalPhysicsV3 = {
   radiusMin: number
   radiusMax: number
   ellipsisRatio: number
+  colors?: string[]
 }
 
 export const MYSTICAL_PHYSICS_V3: MysticalPhysicsV3 = {

--- a/packages/talisman-ui/src/components/MysticalBackgroundV3/useCelestialArtifact.ts
+++ b/packages/talisman-ui/src/components/MysticalBackgroundV3/useCelestialArtifact.ts
@@ -20,9 +20,10 @@ const generateCharacteristics = (
   duration: number,
   initialized: boolean,
   targetX: number,
-  targetY: number
+  targetY: number,
+  forceColor?: string
 ): ArtifactCharacteristics => {
-  const color = Color.hsv(Math.random() * 360, 100, 100).hex()
+  const color = forceColor || Color.hsv(Math.random() * 360, 100, 100).hex()
   const maxSize = Math.min(parentSize.width, parentSize.height)
   const rx = Math.round(
     maxSize * (config.radiusMin + Math.random() * (config.radiusMax - config.radiusMin))
@@ -65,7 +66,8 @@ export const useCelestialArtifact = (
   config: MysticalPhysicsV3,
   parentSize: ParentSize,
   x = 0,
-  y = 0
+  y = 0,
+  color?: string
 ) => {
   const refInitialized = useRef(false)
   const duration = useMemo(
@@ -75,7 +77,7 @@ export const useCelestialArtifact = (
   )
 
   const [characteristics, setCharacteristics] = useState<ArtifactCharacteristics>(
-    generateCharacteristics(config, parentSize, duration, refInitialized.current, x, y)
+    generateCharacteristics(config, parentSize, duration, refInitialized.current, x, y, color)
   )
 
   const refTarget = useRef<[number, number]>([x, y])
@@ -91,7 +93,8 @@ export const useCelestialArtifact = (
           parentSize,
           duration,
           refInitialized.current,
-          ...refTarget.current
+          ...refTarget.current,
+          color
         )
       )
       refInitialized.current = true
@@ -105,7 +108,7 @@ export const useCelestialArtifact = (
     return () => {
       clearInterval(interval)
     }
-  }, [config, duration, parentSize])
+  }, [config, duration, parentSize, color])
 
   // acolyte must update it's position every 500ms
   const isAcolyte = useMemo(() => !!x && !!y, [x, y])


### PR DESCRIPTION
- optional `colors property` on MysticalAccountV3's config, to force colors
- useFirstAccountColor hook that returns colors of first account (since now we can sort accounts, user can control which one it is)
- leverage useFirstAccountColor hook on both Login & TotalPortfolio