### PR TITLE
fix: instruct vscode to ignore PR for dev branch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   // defaults to 1rem=16px, but we use 1rem=10px in the extension
   // this setting will provide accurate intellisense values
-  "tailwindCSS.rootFontSize": 10
+  "tailwindCSS.rootFontSize": 10,
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "dev"
+  ]
 }


### PR DESCRIPTION
Leverage a vscode setting that "Prevents branches that are associated with a pull request from being automatically detected. This will prevent review mode from being entered on these branches."

Since dev was branched off main, vscode keeps thinking that we intend to make a PR from it. This setting fixes that.