### PR TITLE
fix: update balance subscriptions on metadata changes

### DIFF
--- a/.changeset/clean-cars-drive.md
+++ b/.changeset/clean-cars-drive.md
@@ -1,0 +1,7 @@
+---
+"@talismn/chaindata-provider-extension": patch
+"@talismn/balances-substrate-native": patch
+"@talismn/balances": patch
+---
+
+fix: balance subscriptions never update registry cache with new metadata

--- a/apps/extension/src/core/domains/balances/store.ts
+++ b/apps/extension/src/core/domains/balances/store.ts
@@ -33,9 +33,7 @@ export const balanceModules = defaultBalanceModules.map((mod) =>
   mod({ chainConnectors, chaindataProvider })
 )
 
-type ChainIdAndHealth = Pick<Chain, "id" | "isHealthy" | "genesisHash" | "account"> & {
-  balanceMetadataHash: string
-}
+type ChainIdAndHealth = Pick<Chain, "id" | "isHealthy" | "genesisHash" | "account">
 type EvmNetworkIdAndHealth = Pick<
   EvmNetwork,
   "id" | "isHealthy" | "nativeToken" | "substrateChain"
@@ -111,15 +109,7 @@ export class BalanceStore {
           // substrate chains
           Object.values(chains ?? {})
             .filter((chain) => (settings.useTestnets ? true : !chain.isTestnet))
-            .map((chain) => ({
-              ...pick(chain, ["id", "isHealthy", "genesisHash", "account"]),
-
-              // We include this field to force the balance subscriptions to be recreated in
-              // the event that the balance metadata has changed.
-              //
-              // Should fix https://github.com/TalismanSociety/talisman/issues/847
-              balanceMetadataHash: JSON.stringify(chain.balanceMetadata),
-            })),
+            .map((chain) => pick(chain, ["id", "isHealthy", "genesisHash", "account"])),
 
           // evm chains
           Object.values(evmNetworks ?? {})

--- a/packages/balances/src/helpers.ts
+++ b/packages/balances/src/helpers.ts
@@ -73,12 +73,14 @@ export async function balances<
 export type GetOrCreateTypeRegistry = (chainId: ChainId, metadataRpc?: `0x${string}`) => Registry
 
 export const createTypeRegistryCache = () => {
-  const typeRegistryCache: Map<ChainId, TypeRegistry> = new Map()
+  const typeRegistryCache: Map<
+    ChainId,
+    { metadataRpc: `0x${string}` | undefined; typeRegistry: Registry }
+  > = new Map()
 
   const getOrCreateTypeRegistry: GetOrCreateTypeRegistry = (chainId, metadataRpc) => {
-    // TODO: Delete cache when metadataRpc is different from last time
     const cached = typeRegistryCache.get(chainId)
-    if (cached) return cached
+    if (cached && cached.metadataRpc === metadataRpc) return cached.typeRegistry
 
     const typeRegistry = new TypeRegistry()
     if (typeof metadataRpc === "string") {
@@ -90,7 +92,7 @@ export const createTypeRegistryCache = () => {
       }
     }
 
-    typeRegistryCache.set(chainId, typeRegistry)
+    typeRegistryCache.set(chainId, { metadataRpc, typeRegistry })
 
     return typeRegistry
   }


### PR DESCRIPTION
Following on from https://github.com/TalismanSociety/talisman/pull/848, which totally didn't fix the problem.

![thats-not-a-bugfix](https://github.com/TalismanSociety/talisman/assets/2741569/321d8469-7530-460e-a965-962c984a6a2f)

This time we have a test case!

Step 1: Check out this branch:

```
git checkout fix/update-balance-subscriptions-on-metadata-changes
```

Step 2: Check out some older init files  
(commit b1958e01 has the polkadot relay chain back as it was on specVersion 9370)

```
git checkout b1958e01 -- packages/chaindata-provider-extension/src/init/chains.json
```

You'll also need to add this to appease typescript:
```diff
diff --git a/packages/chaindata-provider-extension/src/init/index.ts b/packages/chaindata-provider-extension/src/init/index.ts
index e28cfc19..f4df464d 100644
--- a/packages/chaindata-provider-extension/src/init/index.ts
+++ b/packages/chaindata-provider-extension/src/init/index.ts
@@ -7,6 +7,6 @@ import initChainsResponse from "./chains.json"
 import initEvmNetworksResponse from "./evm-networks.json"
 import initTokensResponse from "./tokens.json"
 
-export const fetchInitChains = async () => initChainsResponse as Chain[]
+export const fetchInitChains = async () => initChainsResponse as unknown as Chain[]
 export const fetchInitEvmNetworks = async () => initEvmNetworksResponse
 export const fetchInitTokens = async () => initTokensResponse
```

Step 3: Delete the `TalismanChaindata` IndexedDB in your browser's devtools

Step 4: Break the subsquid URL so that the wallet loads in the init files when it fails to connect
```diff
diff --git a/packages/chaindata-provider-extension/src/constants.ts b/packages/chaindata-provider-extension/src/constants.ts
index 0b5d7bfc..9275bd06 100644
--- a/packages/chaindata-provider-extension/src/constants.ts
+++ b/packages/chaindata-provider-extension/src/constants.ts
@@ -1 +1 @@
-export const graphqlUrl = "https://squid.subsquid.io/chaindata/v/v4/graphql"
+export const graphqlUrl = "https://squid.subsquid.io/chaindata/v/v0/graphql"
```

Step 5: Reload the extension

Step 6: Open the dashboard and observe your big (but unfortunately inaccurate) bags 💰💰💰

Step 7: Revert the subsquid URL back to the working version

Step 8: Reload the extension **ONCE**
(also, don't rely on the dev-mode auto-reload - I recommend stopping webpack, disabling the wallet, starting webpack, then enabling the wallet)

In `dev` the above steps would still show big bags 💰💰💰
In this branch, the new metadata is loaded into the balances subscriptions and an accurate balance is shown instead!

---

For review:
- https://github.com/TalismanSociety/talisman/pull/971/commits/249ebc4ee22d58c04bd2f0b6da1801704ee430c1 is the actual bugfix
- https://github.com/TalismanSociety/talisman/pull/971/commits/c755ca850509bffdf9a8c25a68fca04d0e35656e is a small refactor to use the more reliable `StorageHelper` from the recently built balance modules in the older SubstrateNativeModule