### PR TITLE
fix: popup size issues

### DIFF
--- a/.changeset/quiet-ears-remain.md
+++ b/.changeset/quiet-ears-remain.md
@@ -1,0 +1,5 @@
+---
+"talisman-ui": patch
+---
+
+popup borders

--- a/apps/extension/src/core/domains/app/store.app.ts
+++ b/apps/extension/src/core/domains/app/store.app.ts
@@ -29,6 +29,7 @@ export type AppStoreData = {
   hasSpiritKey: boolean
   showDotNomPoolStakingBanner: boolean
   needsSpiritKeyUpdate: boolean
+  popupSizeDelta: [number, number]
 }
 
 const ANALYTICS_VERSION = "1.5.0"
@@ -44,6 +45,7 @@ export const DEFAULT_APP_STATE: AppStoreData = {
   hasSpiritKey: false,
   needsSpiritKeyUpdate: false,
   showDotNomPoolStakingBanner: true,
+  popupSizeDelta: [0, 0],
 }
 
 export class AppStore extends SubscribableStorageProvider<

--- a/apps/extension/src/core/libs/WindowManager.ts
+++ b/apps/extension/src/core/libs/WindowManager.ts
@@ -1,3 +1,4 @@
+import { IS_FIREFOX } from "@core/constants"
 import { appStore } from "@core/domains/app"
 import { RequestRoute } from "@core/domains/app/types"
 import { sleep } from "@talismn/util"
@@ -125,7 +126,7 @@ class WindowManager {
     if (typeof popup?.id !== "undefined") {
       this.#windows.push(popup.id || 0)
       // firefox compatibility (cannot be set at creation)
-      if (popup.left !== left && popup.state !== "fullscreen") {
+      if (IS_FIREFOX && popup.left !== left && popup.state !== "fullscreen") {
         await Browser.windows.update(popup.id, { left, top })
       }
     }

--- a/apps/extension/src/core/libs/WindowManager.ts
+++ b/apps/extension/src/core/libs/WindowManager.ts
@@ -3,13 +3,11 @@ import { RequestRoute } from "@core/domains/app/types"
 import { sleep } from "@talismn/util"
 import Browser from "webextension-polyfill"
 
-const WINDOW_OPTS: Browser.Windows.CreateCreateDataType = {
-  // This is not allowed on FF, only on Chrome - disable completely
-  // focused: true,
-  height: 630,
+const WINDOW_OPTS: Browser.Windows.CreateCreateDataType & { width: number; height: number } = {
   type: "popup",
   url: Browser.runtime.getURL("popup.html"),
   width: 400,
+  height: 600,
 }
 
 class WindowManager {
@@ -106,6 +104,7 @@ class WindowManager {
 
   async popupOpen(argument?: string, onClose?: () => void) {
     const currWindow = await Browser.windows.getLastFocused()
+    const [widthDelta, heightDelta] = await appStore.get("popupSizeDelta")
 
     const { left, top } = {
       top: 100 + (currWindow?.top ?? 0),
@@ -116,9 +115,11 @@ class WindowManager {
 
     const popup = await Browser.windows.create({
       ...WINDOW_OPTS,
+      url: Browser.runtime.getURL(`popup.html${argument ? argument : ""}`),
       top,
       left,
-      url: Browser.runtime.getURL(`popup.html${argument ? argument : ""}`),
+      width: WINDOW_OPTS.width + widthDelta,
+      height: WINDOW_OPTS.height + heightDelta,
     })
 
     if (typeof popup?.id !== "undefined") {

--- a/apps/extension/src/core/libs/WindowManager.ts
+++ b/apps/extension/src/core/libs/WindowManager.ts
@@ -110,7 +110,7 @@ class WindowManager {
       top: 100 + (currWindow?.top ?? 0),
       left:
         (currWindow?.width ? (currWindow.left ?? 0) + currWindow.width : window.screen.availWidth) -
-        410,
+        500,
     }
 
     const popup = await Browser.windows.create({

--- a/apps/extension/src/index.popup.tsx
+++ b/apps/extension/src/index.popup.tsx
@@ -1,20 +1,46 @@
 import "@core/util/enableLogsInDevelopment"
 import "@core/i18nConfig"
 
+import { appStore } from "@core/domains/app"
 import { log } from "@core/log"
 import { renderTalisman } from "@ui"
 import Popup from "@ui/apps/popup"
 import Browser from "webextension-polyfill"
 
-// append a class on root HTML element if popup was opened from extension button
-if (window.location.search === "?embedded") document.documentElement.classList.add("embedded")
+const adjustPopupSize = async () => {
+  // on embedded popup, zoom is disabled and the frame automatically syncs with the size of content
+  if (window.location.search === "?embedded") return
 
-// reset zoom level to ensure content fits in popup window
-Browser.tabs
-  .getZoom()
-  .then((zoom) => {
-    if (zoom !== 1) Browser.tabs.setZoom(undefined, 1).catch(log.error)
-  })
-  .catch(log.error)
+  try {
+    const currentZoom = await Browser.tabs.getZoom()
+
+    // make sure zoom is reset before adjusting size or size will be incorrect
+    // test the necessity to apply the zoom settings, otherwise a zoom update message would appear
+    if (currentZoom !== 1)
+      await Browser.tabs.setZoomSettings(undefined, {
+        defaultZoomFactor: 1,
+        mode: "disabled",
+        scope: "per-tab",
+      })
+
+    const { innerHeight, innerWidth, outerHeight, outerWidth } = window
+
+    // check if adjusting the size is needed
+    if (innerWidth === 400 && innerHeight === 600) return
+
+    const deltaWidth = outerWidth - innerWidth
+    const deltaHeight = outerHeight - innerHeight
+
+    if (deltaWidth || deltaHeight) {
+      window.resizeTo(400 + deltaWidth, 600 + deltaHeight)
+
+      // store delta to open next popups at the right size
+      appStore.set({ popupSizeDelta: [deltaWidth, deltaHeight] })
+    }
+  } catch (err) {
+    log.error("Failed to adjust popup size", { err })
+  }
+}
 
 renderTalisman(<Popup />)
+adjustPopupSize()

--- a/apps/extension/src/index.popup.tsx
+++ b/apps/extension/src/index.popup.tsx
@@ -1,6 +1,7 @@
 import "@core/util/enableLogsInDevelopment"
 import "@core/i18nConfig"
 
+import { IS_FIREFOX } from "@core/constants"
 import { appStore } from "@core/domains/app"
 import { log } from "@core/log"
 import { renderTalisman } from "@ui"
@@ -16,12 +17,15 @@ const adjustPopupSize = async () => {
 
     // make sure zoom is reset before adjusting size or size will be incorrect
     // test the necessity to apply the zoom settings, otherwise a zoom update message would appear
-    if (currentZoom !== 1)
-      await Browser.tabs.setZoomSettings(undefined, {
-        defaultZoomFactor: 1,
-        mode: "disabled",
-        scope: "per-tab",
-      })
+    if (currentZoom !== 1) {
+      if (IS_FIREFOX) await Browser.tabs.setZoom(1)
+      else
+        await Browser.tabs.setZoomSettings(undefined, {
+          defaultZoomFactor: 1,
+          mode: "disabled",
+          scope: "per-tab",
+        })
+    }
 
     const { innerHeight, innerWidth, outerHeight, outerWidth } = window
 

--- a/apps/extension/src/index.popup.tsx
+++ b/apps/extension/src/index.popup.tsx
@@ -35,11 +35,14 @@ const adjustPopupSize = async () => {
     const deltaWidth = outerWidth - innerWidth
     const deltaHeight = outerHeight - innerHeight
 
-    if (deltaWidth || deltaHeight) {
-      window.resizeTo(400 + deltaWidth, 600 + deltaHeight)
+    const width = 400 + deltaWidth
+    const height = 600 + deltaHeight
+
+    if (width !== window.outerWidth || height !== window.outerHeight) {
+      window.resizeTo(width, height)
 
       // store delta to open next popups at the right size
-      appStore.set({ popupSizeDelta: [deltaWidth, deltaHeight] })
+      await appStore.set({ popupSizeDelta: [deltaWidth, deltaHeight] })
     }
   } catch (err) {
     log.error("Failed to adjust popup size", { err })

--- a/apps/extension/src/template.popup.html
+++ b/apps/extension/src/template.popup.html
@@ -28,8 +28,8 @@
       }
       #root {
         margin: 0 auto;
-        width: 400px;
-        height: 600px;
+        width: 40rem;
+        height: 60rem;
         overflow: hidden;
       }
     </style>

--- a/apps/extension/src/template.popup.html
+++ b/apps/extension/src/template.popup.html
@@ -28,8 +28,9 @@
       }
       #root {
         margin: 0 auto;
-        width: 40rem;
-        height: 60rem;
+        width: 400px;
+        height: 600px;
+        overflow: hidden;
       }
     </style>
   </head>

--- a/packages/talisman-ui/src/styles/styles.css
+++ b/packages/talisman-ui/src/styles/styles.css
@@ -50,14 +50,8 @@
   }
 
   /* popup borders */
-  html.popup {
-    @apply border-grey-700 border;
-  }
-  html.popup.embedded {
-    @apply border-none;
-  }
-  html.popup.embedded #main {
-    @apply border-grey-700 border;
+  .popup #root {
+    @apply border-grey-750 box-border border;
   }
 
   /* number inputs */


### PR DESCRIPTION
- Fixes #963 

#963 was due to the fact that there may be a delta between window.innerWidth and window.outerWidth on some OS/browsers. This is also true for height.

Details :
- This PR will resize the popup when it loads to take the size delta into account, if and only if necessary.
- Since this delta is always the same for a given OS/browser, it will be stored in app state so next popups can be open directly with the perfect size
- Also found a way to reset zoom only for the popup, without touching dashboard's zoom level. this works only on chromium browsers though.

Note : zoom still has to be reset, otherwise the size delta cannot be adjusted accurately. tried with a lot of formulas, and sadly i didn't find one that works.

Tested on : 
- [x] Windows chrome, brave and firefox - all with & without OS custom scale
- [x] Linux chrome, brave and firefox
- [ ] MacOS chrome, brave, direfox and Arc

Could anyone test & if necessary adjust this for Arc please ?