### PR TITLE
Make initial popup height delta 30 when IS_FIREFOX true

### DIFF
--- a/apps/extension/src/core/domains/app/store.app.ts
+++ b/apps/extension/src/core/domains/app/store.app.ts
@@ -1,4 +1,4 @@
-import { DEBUG } from "@core/constants"
+import { DEBUG, IS_FIREFOX } from "@core/constants"
 import { SubscribableStorageProvider } from "@core/libs/Store"
 import { assert } from "@polkadot/util"
 import { gt } from "semver"
@@ -45,7 +45,7 @@ export const DEFAULT_APP_STATE: AppStoreData = {
   hasSpiritKey: false,
   needsSpiritKeyUpdate: false,
   showDotNomPoolStakingBanner: true,
-  popupSizeDelta: [0, 0],
+  popupSizeDelta: [0, IS_FIREFOX ? 30 : 0],
 }
 
 export class AppStore extends SubscribableStorageProvider<

--- a/apps/extension/src/index.popup.tsx
+++ b/apps/extension/src/index.popup.tsx
@@ -39,7 +39,10 @@ const adjustPopupSize = async () => {
     const height = 600 + deltaHeight
 
     if (width !== window.outerWidth || height !== window.outerHeight) {
-      window.resizeTo(width, height)
+      Browser.windows.update(Browser.windows.WINDOW_ID_CURRENT, {
+        width,
+        height,
+      })
 
       // store delta to open next popups at the right size
       await appStore.set({ popupSizeDelta: [deltaWidth, deltaHeight] })


### PR DESCRIPTION
Fixes some sizing quirks:
- Some browser/OS combinations include browser title bar as part of 'window.outerHeight'
- Firefox does not allow you to resize a window unless created by the `window.open` method, which it doesn't allow in extensions. This PR users the `Browser.windows.update` api to get around this .