### PR TITLE
fix: don't resize popup in normal window

### DIFF
--- a/apps/extension/src/index.popup.tsx
+++ b/apps/extension/src/index.popup.tsx
@@ -13,7 +13,13 @@ const adjustPopupSize = async () => {
   if (window.location.search === "?embedded") return
 
   try {
-    const currentZoom = await Browser.tabs.getZoom()
+    const [currentWindow, currentZoom] = await Promise.all([
+      Browser.windows.getCurrent(),
+      Browser.tabs.getZoom(),
+    ])
+
+    // exit if popup is opened in a normal window (common for devs)
+    if (currentWindow.type !== "popup") return
 
     // make sure zoom is reset before adjusting size or size will be incorrect
     // test the necessity to apply the zoom settings, otherwise a zoom update message would appear


### PR DESCRIPTION
- don't resize the popup if open in a normal window (useful for devs)
- if opening a popup breaks, most likely because of invalid size deltas, retry with default size