### PR TITLE
fix: some wallet QOL fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+
+# Don't render text diffs for yarn plugins and releases
+/.yarn/plugins/** binary
+/.yarn/releases/** binary

--- a/apps/extension/src/core/constants.ts
+++ b/apps/extension/src/core/constants.ts
@@ -31,9 +31,14 @@ export const API_KEY_ONFINALITY = process.env.API_KEY_ONFINALITY
 
 export const IPFS_GATEWAY = "https://talisman.mypinata.cloud/ipfs/"
 
-export const TALISMAN_WEB_APP_DOMAIN = "app.talisman.xyz"
-export const TALISMAN_WEB_APP_NFTS_URL = "https://app.talisman.xyz/nfts"
 export const TALISMAN_CONFIG_URL = "https://talismansociety.github.io/talisman-config/config.toml"
+
+export const TALISMAN_WEB_APP_DOMAIN = "app.talisman.xyz"
+export const TALISMAN_WEB_APP_URL = "https://app.talisman.xyz"
+export const TALISMAN_WEB_APP_TX_HISTORY_URL = "https://app.talisman.xyz/portfolio/history"
+export const TALISMAN_WEB_APP_NFTS_URL = "https://app.talisman.xyz/nfts"
+export const TALISMAN_WEB_APP_STAKING_URL = "https://app.talisman.xyz/staking"
+export const TALISMAN_WEB_APP_CROWDLOANS_URL = "https://app.talisman.xyz/crowdloans"
 
 // Used for testing the full buying flow
 // The tokens available at this endpoint are not in sync with the production endpoint

--- a/apps/extension/src/core/domains/app/handler.ts
+++ b/apps/extension/src/core/domains/app/handler.ts
@@ -131,7 +131,7 @@ export default class AppHandler extends ExtensionHandler {
         pair.lock()
 
         // we can now set up the auth secret
-        await this.stores.password.setPassword(transformedPassword)
+        this.stores.password.setPassword(transformedPassword)
         await this.stores.password.setupAuthSecret(transformedPassword)
       } else {
         await this.stores.password.authenticate(pass)

--- a/apps/extension/src/core/domains/app/handler.ts
+++ b/apps/extension/src/core/domains/app/handler.ts
@@ -111,14 +111,13 @@ export default class AppHandler extends ExtensionHandler {
   }
 
   private async authenticate({ pass }: RequestLogin): Promise<boolean> {
-    await new Promise((resolve) =>
-      setTimeout(resolve, process.env.NODE_ENV === "production" ? 1000 : 0)
-    )
+    if (!(DEBUG || TEST)) await sleep(1000)
 
     try {
-      const transformedPassword = await this.stores.password.transformPassword(pass)
       const { secret, check } = await this.stores.password.get()
       if (!secret || !check) {
+        const transformedPassword = await this.stores.password.transformPassword(pass)
+
         // attempt to log in via the legacy method
         const primaryAccount = getPrimaryAccount(true)
         assert(primaryAccount, "No primary account, unable to authorise")
@@ -132,7 +131,7 @@ export default class AppHandler extends ExtensionHandler {
         pair.lock()
 
         // we can now set up the auth secret
-        await this.stores.password.setPlaintextPassword(pass)
+        await this.stores.password.setPassword(transformedPassword)
         await this.stores.password.setupAuthSecret(transformedPassword)
       } else {
         await this.stores.password.authenticate(pass)

--- a/apps/extension/src/core/page.ts
+++ b/apps/extension/src/core/page.ts
@@ -42,7 +42,7 @@ const enable = async (origin: string): Promise<Injected> => {
 const isTalismanHostname = (hostname: string) =>
   hostname === TALISMAN_WEB_APP_DOMAIN ||
   (DEBUG && hostname.endsWith(".talisman.pages.dev")) ||
-  (DEBUG && hostname === "localhost")
+  (DEBUG && ["localhost", "127.0.0.1"].includes(hostname))
 
 function inject() {
   // inject substrate wallet provider

--- a/apps/extension/src/ui/apps/dashboard/layout/SideBar.tsx
+++ b/apps/extension/src/ui/apps/dashboard/layout/SideBar.tsx
@@ -1,4 +1,8 @@
-import { TALISMAN_WEB_APP_NFTS_URL } from "@core/constants"
+import {
+  TALISMAN_WEB_APP_CROWDLOANS_URL,
+  TALISMAN_WEB_APP_NFTS_URL,
+  TALISMAN_WEB_APP_STAKING_URL,
+} from "@core/constants"
 import { Nav, NavItem, NavItemProps } from "@talisman/components/Nav"
 import { ScrollContainer } from "@talisman/components/ScrollContainer"
 import {
@@ -141,7 +145,7 @@ export const SideBar = () => {
 
   const handleStakingClick = useCallback(() => {
     genericEvent("open web app staking", { from: "sidebar", target: "staking" })
-    window.open("https://app.talisman.xyz/staking", "_blank")
+    window.open(TALISMAN_WEB_APP_STAKING_URL, "_blank")
     return false
   }, [genericEvent])
 
@@ -154,7 +158,7 @@ export const SideBar = () => {
 
   const handleCrowdloansClick = useCallback(() => {
     genericEvent("open web app crowdloans", { from: "sidebar", target: "crowdloans" })
-    window.open("https://app.talisman.xyz/crowdloans", "_blank")
+    window.open(TALISMAN_WEB_APP_CROWDLOANS_URL, "_blank")
   }, [genericEvent])
 
   const handleSettingsClick = useCallback(() => {

--- a/apps/extension/src/ui/apps/dashboard/routes/PhishingPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/PhishingPage.tsx
@@ -1,3 +1,4 @@
+import { TALISMAN_WEB_APP_URL } from "@core/constants"
 import { AlertTriangleIcon } from "@talisman/theme/icons"
 import { TalismanWhiteLogo } from "@talisman/theme/logos"
 import { api } from "@ui/api"
@@ -46,7 +47,7 @@ export const PhishingPage: FC<PhishingPageProps> = ({ url }) => {
                 </Trans>
               </div>
               <div className="w-full">
-                <a href="https://app.talisman.xyz">
+                <a href={TALISMAN_WEB_APP_URL}>
                   <Button className="mb-6 w-full" primary>
                     {t("Get me out of here")}
                   </Button>

--- a/apps/extension/src/ui/apps/popup/pages/Login.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Login.tsx
@@ -5,8 +5,14 @@ import { classNames } from "@talismn/util"
 import { api } from "@ui/api"
 import { useAnalytics } from "@ui/hooks/useAnalytics"
 import { useFirstAccountColors } from "@ui/hooks/useFirstAccountColors"
-import { Suspense, useCallback, useEffect, useState } from "react"
-import { SubmitHandler, useForm } from "react-hook-form"
+import { Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
+import {
+  SubmitHandler,
+  UseFormHandleSubmit,
+  UseFormSetValue,
+  UseFormWatch,
+  useForm,
+} from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { Button, FormFieldInputText } from "talisman-ui"
 import { LoginBackground } from "talisman-ui"
@@ -49,6 +55,7 @@ const Login = ({ setShowResetWallet }: { setShowResetWallet: () => void }) => {
   }, [popupOpenEvent])
 
   const {
+    watch,
     register,
     handleSubmit,
     setError,
@@ -80,19 +87,13 @@ const Login = ({ setShowResetWallet }: { setShowResetWallet: () => void }) => {
     setFocus("password")
   }, [setFocus])
 
-  // autologin, for developers only
-  useEffect(() => {
-    if (process.env.NODE_ENV !== "production" && process.env.PASSWORD) {
-      setValue("password", process.env.PASSWORD)
-      handleSubmit(submit)()
-    }
-  }, [handleSubmit, setValue, submit])
-
   useEffect(() => {
     return () => {
       setValue("password", "")
     }
   }, [setValue])
+
+  useDevModeAutologin({ watch, setValue, handleSubmit, submit })
 
   return (
     <PopupLayout>
@@ -150,4 +151,44 @@ export const LoginViewManager = () => {
 
   if (showResetWallet) return <ResetWallet closeResetWallet={() => setShowResetWallet(false)} />
   return <Login setShowResetWallet={() => setShowResetWallet(true)} />
+}
+
+/** autologin, for developers only */
+const useDevModeAutologin = ({
+  watch,
+  setValue,
+  handleSubmit,
+  submit,
+}: {
+  watch: UseFormWatch<FormData>
+  setValue: UseFormSetValue<FormData>
+  handleSubmit: UseFormHandleSubmit<FormData, undefined>
+  submit: SubmitHandler<FormData>
+}) => {
+  const [passwordField] = watch(["password"])
+
+  // set password field
+  useLayoutEffect(() => {
+    if (process.env.NODE_ENV === "production") return
+    if (!process.env.PASSWORD) return
+    setValue("password", process.env.PASSWORD)
+  }, [setValue])
+
+  // submit login form
+  //
+  // if we don't wait for the password to be set,
+  // then handleSubmit(submit)() won't show the loading state in the UI
+  //
+  // also, we want to make sure we only trigger the login once,
+  // otherwise, due to bcrypt hashing, the user will have to wait for longer than necessary
+  const autologinTriggered = useRef(false)
+  useLayoutEffect(() => {
+    if (process.env.NODE_ENV === "production") return
+    if (!process.env.PASSWORD) return
+    if (!passwordField) return
+    if (autologinTriggered.current) return
+
+    autologinTriggered.current = true
+    handleSubmit(submit)()
+  }, [handleSubmit, passwordField, submit])
 }

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
@@ -1,3 +1,4 @@
+import { TALISMAN_WEB_APP_STAKING_URL } from "@core/constants"
 import { Balances } from "@core/domains/balances/types"
 import { ExternalLinkIcon, XIcon, ZapIcon } from "@talisman/theme/icons"
 import { useBalancesStatus } from "@talismn/balances-react"
@@ -72,7 +73,7 @@ const AssetRow = ({ balances }: AssetRowProps) => {
   }, [genericEvent, navigate, token])
 
   const handleClickStakingBanner = useCallback(() => {
-    window.open("https://app.talisman.xyz/staking")
+    window.open(TALISMAN_WEB_APP_STAKING_URL)
     genericEvent("open web app staking from banner", { from: "dashboard", symbol: token?.symbol })
   }, [genericEvent, token?.symbol])
 

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
@@ -1,3 +1,4 @@
+import { TALISMAN_WEB_APP_STAKING_URL } from "@core/constants"
 import { Balances } from "@core/domains/balances/types"
 import { Accordion, AccordionIcon } from "@talisman/components/Accordion"
 import { FadeIn } from "@talisman/components/FadeIn"
@@ -105,7 +106,7 @@ const AssetRow = ({ balances, locked }: AssetRowProps) => {
   }, [account, genericEvent, navigate, token])
 
   const handleClickStakingBanner = useCallback(() => {
-    window.open("https://app.talisman.xyz/staking")
+    window.open(TALISMAN_WEB_APP_STAKING_URL)
     genericEvent("open web app staking from banner", { from: "popup", symbol: token?.symbol })
   }, [genericEvent, token?.symbol])
 

--- a/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSites.tsx
+++ b/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSites.tsx
@@ -1,3 +1,4 @@
+import { TALISMAN_WEB_APP_URL } from "@core/constants"
 import { ProviderType } from "@core/domains/sitesAuthorised/types"
 import { HeaderBlock } from "@talisman/components/HeaderBlock"
 import { Spacer } from "@talisman/components/Spacer"
@@ -61,7 +62,7 @@ export const AuthorisedSites = () => {
             <div className="bg-grey-850 w-full rounded p-8">
               <Trans t={t}>
                 You haven't connected to any sites yet. Why not start with the{" "}
-                <a href="https://app.talisman.xyz" target="_blank" className="text-primary">
+                <a href={TALISMAN_WEB_APP_URL} target="_blank" className="text-primary">
                   Talisman Web App
                 </a>
                 ?

--- a/apps/extension/src/ui/util/getTransactionHistoryUrl.ts
+++ b/apps/extension/src/ui/util/getTransactionHistoryUrl.ts
@@ -1,9 +1,9 @@
-const TX_HISTORY_PAGE_URL = "https://app.talisman.xyz/portfolio/history"
+import { TALISMAN_WEB_APP_TX_HISTORY_URL } from "@core/constants"
 
 export const getTransactionHistoryUrl = (address?: string) => {
-  if (!address) return TX_HISTORY_PAGE_URL
+  if (!address) return TALISMAN_WEB_APP_TX_HISTORY_URL
 
-  const url = new URL(TX_HISTORY_PAGE_URL)
+  const url = new URL(TALISMAN_WEB_APP_TX_HISTORY_URL)
   url.searchParams.set("address", address)
   return url.toString()
 }


### PR DESCRIPTION
Some commits which have been sitting around in my local dev env:

- https://github.com/TalismanSociety/talisman/commit/505e61b20eba2c6166494c4d20d77aa3c9a5cb35 adds 127.0.0.1 to the list of hosts we should inject `talismanSub` into for webapp development
- https://github.com/TalismanSociety/talisman/commit/ffd67e775502480d0568a208dafbb2e02bd87516 goes through and removes all hardcoded webapp URLs, moving them into the constants.ts file (which will soon be mostly offloaded to [talisman-config](https://github.com/talismansociety/talisman-config))
- https://github.com/TalismanSociety/talisman/commit/b3d8c8bb073407619b994d4769349871a0bdd06e stops github from rendering the full diff of the yarn sourcecode when we upgrade yarn / any yarn plugins
- https://github.com/TalismanSociety/talisman/commit/28d059336dc6b07baedb69460d3b528c54ce0cca fixes some performance bugs I noticed in the login flow, details below:

**In the backend**
We were hashing the password twice for every login by:
1. Calling `stores.password.transformPassword` - which we only use the result of when migrating users to the new login structure
2. Calling `stores.password.authenticate`, which internally calls `stores.password.transformPassword` as well

I ran a performance test before changing anything, and for me the double-call to the hash function caused a 2x increase in waiting before the authorisation completed (which makes sense). From approx 1000ms to 2000ms on my machine.

**In the frontend**
Only applies to the dev autologin, but annoyingly it would call the authorise backend function three times on load!
This would cause the backend to run the same hash three times in parallel - slowing the completion of all three of the authorisation calls.
On my machine this makes a 3x difference to the time spent waiting - from approx 1000ms for a single hash call, to approx 3000ms.

With the two fixes combined, this PR brings the login time from about 6000ms to 1000ms.