### PR TITLE
fix: EVM transaction gas improvements

### DIFF
--- a/apps/extension/src/core/domains/ethereum/helpers.ts
+++ b/apps/extension/src/core/domains/ethereum/helpers.ts
@@ -128,16 +128,12 @@ export const getGasLimit = (
 ) => {
   // some dapps use legacy gas field instead of gasLimit
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const suggestedGasLimit = tx?.gasLimit ?? (tx as any)?.gas
-
-  const bnSuggestedGasLimit = suggestedGasLimit
-    ? BigNumber.from(suggestedGasLimit)
-    : BigNumber.from(0)
+  const bnSuggestedGasLimit = BigNumber.from(tx?.gasLimit ?? (tx as any)?.gas ?? 0)
   const bnEstimatedGas = BigNumber.from(estimatedGas)
-  // for contract calls, cas cost can evolve overtime : add a safety margin
+  // for contract calls, gas cost can evolve overtime : add a safety margin
   const bnSafeGasLimit = isContractCall
-    ? bnEstimatedGas
-    : bnEstimatedGas.mul(100 + TX_GAS_LIMIT_SAFETY_RATIO).div(100)
+    ? bnEstimatedGas.mul(100 + TX_GAS_LIMIT_SAFETY_RATIO).div(100)
+    : bnEstimatedGas
   // RPC estimated gas may be too low (reliable ex: https://portal.zksync.io/bridge),
   // so if dapp suggests higher gas limit as the estimate, use that
   const highestLimit = bnSafeGasLimit.gt(bnSuggestedGasLimit) ? bnSafeGasLimit : bnSuggestedGasLimit

--- a/apps/extension/src/core/domains/ethereum/helpers.ts
+++ b/apps/extension/src/core/domains/ethereum/helpers.ts
@@ -217,24 +217,32 @@ export const prepareTransaction = (
   gasSettings: EthGasSettings,
   nonce: number
 ) => {
-  // keep only known fields except gas related ones
-  const { chainId, data, from, to, value, accessList, ccipReadEnabled, customData } = tx
-
-  const result: ethers.providers.TransactionRequest = {
+  // keep only known fields except gas related ones, there are sometimes invalid ones in the original payload (ex: "gas")
+  const {
     chainId,
     data,
     from,
     to,
-    value,
-    nonce,
+    value = BigNumber.from(0),
     accessList,
     ccipReadEnabled,
     customData,
-    // apply user gas settings
+  } = tx
+
+  const transaction: ethers.providers.TransactionRequest = {
+    chainId,
+    from,
+    to,
+    value,
+    nonce: BigNumber.from(nonce),
+    data,
     ...gasSettings,
   }
+  if (accessList) transaction.accessList = accessList
+  if (customData) transaction.customData = customData
+  if (ccipReadEnabled !== undefined) transaction.ccipReadEnabled = ccipReadEnabled
 
-  return result
+  return transaction
 }
 
 const testNoScriptTag = (text?: string) => !text?.toLowerCase().includes("<script")

--- a/apps/extension/src/core/domains/ethereum/helpers.ts
+++ b/apps/extension/src/core/domains/ethereum/helpers.ts
@@ -138,6 +138,8 @@ export const getGasLimit = (
   const bnSafeGasLimit = isContractCall
     ? bnEstimatedGas
     : bnEstimatedGas.mul(100 + TX_GAS_LIMIT_SAFETY_RATIO).div(100)
+  // RPC estimated gas may be too low (reliable ex: https://portal.zksync.io/bridge),
+  // so if dapp suggests higher gas limit as the estimate, use that
   const highestLimit = bnSafeGasLimit.gt(bnSuggestedGasLimit) ? bnSafeGasLimit : bnSuggestedGasLimit
 
   let gasLimit = BigNumber.from(highestLimit)
@@ -218,7 +220,7 @@ export const getTotalFeesFromGasSettings = (
 
 export const getMaxTransactionCost = (transaction: ethers.providers.TransactionRequest) => {
   if (transaction.gasLimit === undefined)
-    throw new Error("gasLimit is required for type 2 fee computation")
+    throw new Error("gasLimit is required for fee computation")
 
   const value = BigNumber.from(transaction.value ?? 0)
 
@@ -238,7 +240,6 @@ export const prepareTransaction = (
   gasSettings: EthGasSettings,
   nonce: number
 ) => {
-  // keep only known fields except gas related ones, there are sometimes invalid ones in the original payload (ex: "gas")
   const {
     chainId,
     data,

--- a/apps/extension/src/core/domains/ethereum/helpers.ts
+++ b/apps/extension/src/core/domains/ethereum/helpers.ts
@@ -123,7 +123,8 @@ const TX_GAS_LIMIT_SAFETY_RATIO = 2
 export const getGasLimit = (
   blockGasLimit: BigNumberish,
   estimatedGas: BigNumberish,
-  tx?: ethers.providers.TransactionRequest
+  tx: ethers.providers.TransactionRequest | undefined,
+  isContractCall?: boolean
 ) => {
   // some dapps use legacy gas field instead of gasLimit
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -133,7 +134,10 @@ export const getGasLimit = (
     ? BigNumber.from(suggestedGasLimit)
     : BigNumber.from(0)
   const bnEstimatedGas = BigNumber.from(estimatedGas)
-  const bnSafeGasLimit = bnEstimatedGas.mul(100 + TX_GAS_LIMIT_SAFETY_RATIO).div(100)
+  // for contract calls, cas cost can evolve overtime : add a safety margin
+  const bnSafeGasLimit = isContractCall
+    ? bnEstimatedGas
+    : bnEstimatedGas.mul(100 + TX_GAS_LIMIT_SAFETY_RATIO).div(100)
   const highestLimit = bnSafeGasLimit.gt(bnSuggestedGasLimit) ? bnSafeGasLimit : bnSuggestedGasLimit
 
   let gasLimit = BigNumber.from(highestLimit)

--- a/apps/extension/src/core/domains/ethereum/helpers.ts
+++ b/apps/extension/src/core/domains/ethereum/helpers.ts
@@ -118,6 +118,7 @@ export const rebuildGasSettings = (gasSettings: EthGasSettings) => {
 
 const TX_GAS_LIMIT_DEFAULT = BigNumber.from("250000")
 const TX_GAS_LIMIT_MIN = BigNumber.from("21000")
+const TX_GAS_LIMIT_SAFETY_RATIO = 2
 
 export const getGasLimit = (
   blockGasLimit: BigNumberish,
@@ -132,9 +133,8 @@ export const getGasLimit = (
     ? BigNumber.from(suggestedGasLimit)
     : BigNumber.from(0)
   const bnEstimatedGas = BigNumber.from(estimatedGas)
-  // RPC estimated gas may be too low (reliable ex: https://portal.zksync.io/bridge),
-  // so if dapp suggests higher gas limit as the estimate, use that
-  const highestLimit = bnEstimatedGas.gt(bnSuggestedGasLimit) ? bnEstimatedGas : bnSuggestedGasLimit
+  const bnSafeGasLimit = bnEstimatedGas.mul(100 + TX_GAS_LIMIT_SAFETY_RATIO).div(100)
+  const highestLimit = bnSafeGasLimit.gt(bnSuggestedGasLimit) ? bnSafeGasLimit : bnSuggestedGasLimit
 
   let gasLimit = BigNumber.from(highestLimit)
   if (gasLimit.gt(blockGasLimit)) {

--- a/apps/extension/src/core/domains/ethereum/helpers.ts
+++ b/apps/extension/src/core/domains/ethereum/helpers.ts
@@ -212,6 +212,23 @@ export const getTotalFeesFromGasSettings = (
   }
 }
 
+export const getMaxTransactionCost = (transaction: ethers.providers.TransactionRequest) => {
+  if (transaction.gasLimit === undefined)
+    throw new Error("gasLimit is required for type 2 fee computation")
+
+  const value = BigNumber.from(transaction.value ?? 0)
+
+  if (transaction.type === 2) {
+    if (transaction.maxFeePerGas === undefined)
+      throw new Error("maxFeePerGas is required for type 2 fee computation")
+    return BigNumber.from(transaction.maxFeePerGas).mul(transaction.gasLimit).add(value)
+  } else {
+    if (transaction.gasPrice === undefined)
+      throw new Error("gasPrice is required for legacy fee computation")
+    return BigNumber.from(transaction.gasPrice).mul(transaction.gasLimit).add(value)
+  }
+}
+
 export const prepareTransaction = (
   tx: ethers.providers.TransactionRequest,
   gasSettings: EthGasSettings,

--- a/apps/extension/src/ui/apps/popup/pages/Sign/EthSignTransactionRequest.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Sign/EthSignTransactionRequest.tsx
@@ -3,14 +3,13 @@ import { EthPriorityOptionName } from "@core/domains/signing/types"
 import { AppPill } from "@talisman/components/AppPill"
 import { WithTooltip } from "@talisman/components/Tooltip"
 import { InfoIcon } from "@talisman/theme/icons"
-import { useQuery } from "@tanstack/react-query"
 import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
 import { EthFeeSelect } from "@ui/domains/Ethereum/GasSettings/EthFeeSelect"
+import { useEthBalance } from "@ui/domains/Ethereum/useEthBalance"
 import { useEthereumProvider } from "@ui/domains/Ethereum/useEthereumProvider"
 import { EthSignBody } from "@ui/domains/Sign/Ethereum/EthSignBody"
 import { SignAlertMessage } from "@ui/domains/Sign/SignAlertMessage"
 import { useEthSignTransactionRequest } from "@ui/domains/Sign/SignRequestContext"
-import useToken from "@ui/hooks/useToken"
 import { Suspense, lazy, useCallback, useEffect, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
@@ -20,40 +19,23 @@ import { SignAccountAvatar } from "./SignAccountAvatar"
 
 const LedgerEthereum = lazy(() => import("@ui/domains/Sign/LedgerEthereum"))
 
-const useEvmBalance = (address?: string, evmNetworkId?: string) => {
-  const { t } = useTranslation("request")
+const useEvmBalance = (address: string, evmNetworkId: string | undefined) => {
   const provider = useEthereumProvider(evmNetworkId)
-  return useQuery({
-    queryKey: ["evm-balance", provider?.network?.chainId, address],
-    queryFn: async () => {
-      try {
-        if (!provider || !address) return null
-        const balance = await provider.getBalance(address)
-        return balance.toString()
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(err)
-        throw new Error(t("Failed to fetch balance"))
-      }
-    },
-  })
+  return useEthBalance(provider, address)
 }
 
 const FeeTooltip = ({
   estimatedFee,
-  account,
   maxFee,
   tokenId,
+  balance,
 }: {
-  account?: string
-  estimatedFee?: string | bigint
-  maxFee?: string | bigint
-  tokenId?: string
+  estimatedFee: string | bigint | undefined
+  maxFee: string | bigint | undefined
+  tokenId: string | undefined
+  balance: string | bigint | null | undefined
 }) => {
   const { t } = useTranslation("request")
-  // cannot use useBalance because our db may not include testnet balances
-  const token = useToken(tokenId)
-  const { data: balance, error } = useEvmBalance(account, token?.evmNetwork?.id)
 
   if (!estimatedFee && !maxFee) return null
 
@@ -76,16 +58,18 @@ const FeeTooltip = ({
             </div>
           </div>
         )}
-        {(balance || error) && (
+        {balance !== undefined && (
           <div className="flex w-full justify-between gap-8">
             <div>{t("Balance:")}</div>
-            {balance ? (
-              <div>
-                <TokensAndFiat tokenId={tokenId} planck={balance} noTooltip noCountUp isBalance />
-              </div>
-            ) : (
-              <div className="text-alert-warn">Failed to fetch balance</div>
-            )}
+            <div>
+              <TokensAndFiat
+                tokenId={tokenId}
+                planck={balance ?? 0n}
+                noTooltip
+                noCountUp
+                isBalance
+              />
+            </div>
           </div>
         )}
       </>
@@ -121,6 +105,7 @@ export const EthSignTransactionRequest = () => {
     isValid,
     networkUsage,
   } = useEthSignTransactionRequest()
+  const { balance } = useEvmBalance(account?.address, network?.id)
 
   const { processing, errorMessage } = useMemo(() => {
     return {
@@ -180,10 +165,10 @@ export const EthSignTransactionRequest = () => {
                       </TooltipTrigger>
                       <TooltipContent>
                         <FeeTooltip
-                          account={account?.address}
                           tokenId={network.nativeToken.id}
                           estimatedFee={txDetails.estimatedFee.toString()}
                           maxFee={txDetails.maxFee.toString()}
+                          balance={balance?.toString()}
                         />
                       </TooltipContent>
                     </Tooltip>

--- a/apps/extension/src/ui/domains/Ethereum/useEthBalance.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthBalance.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query"
+import { ethers } from "ethers"
+
+export const useEthBalance = (
+  provider: ethers.providers.JsonRpcProvider | undefined,
+  address: string | undefined
+) => {
+  const { data: balance, ...rest } = useQuery({
+    queryKey: ["balance", address],
+    queryFn: () => {
+      if (!provider || !address) return null
+      return provider.getBalance(address)
+    },
+    enabled: !!provider && !!address,
+  })
+
+  return { balance, ...rest }
+}

--- a/apps/extension/src/ui/domains/Ethereum/useEthBalance.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthBalance.ts
@@ -6,12 +6,16 @@ export const useEthBalance = (
   address: string | undefined
 ) => {
   const { data: balance, ...rest } = useQuery({
-    queryKey: ["balance", address],
+    queryKey: ["useEthBalance", provider?.network?.chainId, address],
     queryFn: () => {
       if (!provider || !address) return null
       return provider.getBalance(address)
     },
-    enabled: !!provider && !!address,
+    refetchInterval: 12_000,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    enabled: !!provider?.network && !!address,
   })
 
   return { balance, ...rest }

--- a/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
@@ -257,7 +257,6 @@ const useGasSettings = ({
   tx?: ethers.providers.TransactionRequest
   isReplacement?: boolean
 }) => {
-  // TODO init with values from tx (supplied by dapp)
   const [customSettings, setCustomSettings] = useState<EthGasSettings>()
 
   const gasSettingsByPriority: GasSettingsByPriority | undefined = useMemo(() => {

--- a/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
@@ -35,11 +35,11 @@ const UNRELIABLE_GASPRICE_NETWORK_IDS = [137, 80001]
 
 const useNonce = (address?: string, evmNetworkId?: EvmNetworkId, forcedValue?: number) => {
   const { data, ...rest } = useQuery({
-    queryKey: ["nonce", address, evmNetworkId],
+    queryKey: ["nonce", address, evmNetworkId, forcedValue],
     queryFn: () => {
+      if (forcedValue !== undefined) return forcedValue
       return address && evmNetworkId ? api.ethGetTransactionsCount(address, evmNetworkId) : null
     },
-    enabled: forcedValue === undefined, // don't bother fetching if value is forced
   })
 
   return { nonce: forcedValue ?? data ?? undefined, ...rest }

--- a/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
@@ -19,7 +19,6 @@ import {
   GasSettingsByPriority,
 } from "@core/domains/signing/types"
 import { ETH_ERROR_EIP1474_METHOD_NOT_FOUND } from "@core/injectEth/EthProviderRpcError"
-import { log } from "@core/log"
 import { getEthTransactionInfo } from "@core/util/getEthTransactionInfo"
 import { FeeHistoryAnalysis, getFeeHistoryAnalysis } from "@core/util/getFeeHistoryAnalysis"
 import { useQuery } from "@tanstack/react-query"
@@ -50,7 +49,7 @@ const useNonce = (
   return { nonce: forcedValue ?? data ?? undefined, ...rest }
 }
 
-// TODO : could be skipped (store in db ?) for networks that we know already support it, but need to keep checking for legacy network in case they upgrade
+// TODO : could be skipped for networks that we know already support it, but need to keep checking for legacy network in case they upgrade
 const useHasEip1559Support = (provider: ethers.providers.JsonRpcProvider | undefined) => {
   const { data, ...rest } = useQuery({
     queryKey: ["hasEip1559Support", provider?.network?.chainId],
@@ -118,8 +117,6 @@ const useBlockFeeData = (
         // estimate gas may change over time for contract calls, so we need to refresh it every time we prepare the tx to prevent an invalid transaction
         provider.estimateGas(txForEstimate),
       ])
-
-      log.debug("estimatedGas", estimatedGas.toString())
 
       if (
         feeHistoryAnalysis &&

--- a/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
@@ -262,7 +262,7 @@ const useGasSettings = ({
   const gasSettingsByPriority: GasSettingsByPriority | undefined = useMemo(() => {
     if (hasEip1559Support === undefined || !estimatedGas || !gasPrice || !blockGasLimit || !tx)
       return undefined
-    const gasLimit = getGasLimit(blockGasLimit, estimatedGas, tx)
+    const gasLimit = getGasLimit(blockGasLimit, estimatedGas, tx, isContractCall)
     const suggestedSettings = getEthGasSettingsFromTransaction(
       tx,
       hasEip1559Support,

--- a/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
@@ -34,7 +34,11 @@ import { useIsValidEthTransaction } from "./useIsValidEthTransaction"
 // gasPrice isn't reliable on polygon & mumbai, see https://github.com/ethers-io/ethers.js/issues/2828#issuecomment-1283014250
 const UNRELIABLE_GASPRICE_NETWORK_IDS = [137, 80001]
 
-const useNonce = (address?: string, evmNetworkId?: EvmNetworkId, forcedValue?: number) => {
+const useNonce = (
+  address: string | undefined,
+  evmNetworkId: EvmNetworkId | undefined,
+  forcedValue?: number
+) => {
   const { data, ...rest } = useQuery({
     queryKey: ["nonce", address, evmNetworkId, forcedValue],
     queryFn: () => {
@@ -47,7 +51,7 @@ const useNonce = (address?: string, evmNetworkId?: EvmNetworkId, forcedValue?: n
 }
 
 // TODO : could be skipped (store in db ?) for networks that we know already support it, but need to keep checking for legacy network in case they upgrade
-const useHasEip1559Support = (provider?: ethers.providers.JsonRpcProvider) => {
+const useHasEip1559Support = (provider: ethers.providers.JsonRpcProvider | undefined) => {
   const { data, ...rest } = useQuery({
     queryKey: ["hasEip1559Support", provider?.network?.chainId],
     queryFn: async () => {

--- a/apps/extension/src/ui/domains/Ethereum/useIsValidEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useIsValidEthTransaction.ts
@@ -1,13 +1,14 @@
 import { EthPriorityOptionName } from "@core/domains/signing/types"
+import { log } from "@core/log"
 import { useQuery } from "@tanstack/react-query"
 import { useAccountByAddress } from "@ui/hooks/useAccountByAddress"
 import { ethers } from "ethers"
 import { useTranslation } from "react-i18next"
 
 export const useIsValidEthTransaction = (
-  provider?: ethers.providers.JsonRpcProvider,
-  transaction?: ethers.providers.TransactionRequest,
-  priority?: EthPriorityOptionName
+  provider: ethers.providers.JsonRpcProvider | undefined,
+  transaction: ethers.providers.TransactionRequest | undefined,
+  priority: EthPriorityOptionName | undefined
 ) => {
   const { t } = useTranslation("request")
   const account = useAccountByAddress(transaction?.from)
@@ -30,6 +31,7 @@ export const useIsValidEthTransaction = (
 
       // dry runs the transaction, if it fails we can't know for sure what the issue really is
       // there should be helpful message in the error though.
+      log.debug("validating tx using estimateGas", transaction)
       const estimatedGas = await provider.estimateGas(transaction)
       return estimatedGas?.gt(0)
     },
@@ -37,6 +39,7 @@ export const useIsValidEthTransaction = (
     refetchOnWindowFocus: false,
     retry: 0,
     keepPreviousData: true,
+    enabled: !!provider && !!transaction && !!account,
   })
 
   return { isValid: !!data, error, isLoading }

--- a/apps/extension/src/ui/domains/Ethereum/useIsValidEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useIsValidEthTransaction.ts
@@ -1,9 +1,12 @@
+import { getMaxTransactionCost } from "@core/domains/ethereum/helpers"
 import { EthPriorityOptionName } from "@core/domains/signing/types"
 import { log } from "@core/log"
 import { useQuery } from "@tanstack/react-query"
 import { useAccountByAddress } from "@ui/hooks/useAccountByAddress"
 import { ethers } from "ethers"
 import { useTranslation } from "react-i18next"
+
+import { useEthBalance } from "./useEthBalance"
 
 export const useIsValidEthTransaction = (
   provider: ethers.providers.JsonRpcProvider | undefined,
@@ -12,6 +15,7 @@ export const useIsValidEthTransaction = (
 ) => {
   const { t } = useTranslation("request")
   const account = useAccountByAddress(transaction?.from)
+  const { balance } = useEthBalance(provider, transaction?.from)
 
   const { data, error, isLoading } = useQuery({
     queryKey: [
@@ -22,12 +26,17 @@ export const useIsValidEthTransaction = (
       priority,
     ],
     queryFn: async () => {
-      if (!provider || !transaction || !account) {
-        return null
-      }
+      if (!provider || !transaction || !account || balance === undefined) return null
 
       if (account.origin === "WATCHED")
         throw new Error(t("Cannot sign transactions with a watched account"))
+
+      // balance checks
+      const value = ethers.BigNumber.from(transaction.value ?? 0)
+      const maxTransactionCost = getMaxTransactionCost(transaction)
+      if (!balance || value.gt(balance)) throw new Error(t("Insufficient balance"))
+      if (!balance || maxTransactionCost.gt(balance))
+        throw new Error(t("Insufficient balance to pay for fee"))
 
       // dry runs the transaction, if it fails we can't know for sure what the issue really is
       // there should be helpful message in the error though.
@@ -39,7 +48,7 @@ export const useIsValidEthTransaction = (
     refetchOnWindowFocus: false,
     retry: 0,
     keepPreviousData: true,
-    enabled: !!provider && !!transaction && !!account,
+    enabled: !!provider && !!transaction && !!account && balance !== undefined,
   })
 
   return { isValid: !!data, error, isLoading }

--- a/apps/extension/src/ui/domains/Ethereum/useIsValidEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useIsValidEthTransaction.ts
@@ -1,6 +1,5 @@
 import { getMaxTransactionCost } from "@core/domains/ethereum/helpers"
 import { EthPriorityOptionName } from "@core/domains/signing/types"
-import { log } from "@core/log"
 import { useQuery } from "@tanstack/react-query"
 import { useAccountByAddress } from "@ui/hooks/useAccountByAddress"
 import { ethers } from "ethers"
@@ -40,7 +39,6 @@ export const useIsValidEthTransaction = (
 
       // dry runs the transaction, if it fails we can't know for sure what the issue really is
       // there should be helpful message in the error though.
-      log.debug("validating tx using estimateGas", transaction)
       const estimatedGas = await provider.estimateGas(transaction)
       return estimatedGas?.gt(0)
     },

--- a/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsEth.tsx
+++ b/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsEth.tsx
@@ -204,6 +204,14 @@ const ViewDetailsContent: FC<ViewDetailsContentProps> = ({ onClose }) => {
                   </>
                 )}
                 <ViewDetailsGridRow
+                  left={t("Estimated gas")}
+                  right={
+                    txDetails?.estimatedGas
+                      ? BigNumber.from(txDetails?.estimatedGas)?.toNumber()
+                      : t("N/A")
+                  }
+                />
+                <ViewDetailsGridRow
                   left={t("Gas limit")}
                   right={
                     transaction?.gasLimit

--- a/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsEth.tsx
+++ b/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsEth.tsx
@@ -204,14 +204,6 @@ const ViewDetailsContent: FC<ViewDetailsContentProps> = ({ onClose }) => {
                   </>
                 )}
                 <ViewDetailsGridRow
-                  left={t("Estimated gas")}
-                  right={
-                    txDetails?.estimatedGas
-                      ? BigNumber.from(txDetails?.estimatedGas)?.toNumber()
-                      : t("N/A")
-                  }
-                />
-                <ViewDetailsGridRow
                   left={t("Gas limit")}
                   right={
                     transaction?.gasLimit


### PR DESCRIPTION
- Fixes #753 
- Closes #994 

Fixes : 
- Adds a 2% safety margin on gas limit
- EVM transactions will be considered invalid if balance is insufficient to pay for gas
- In EVM transaction request popup, gas tooltip will now display balance instantly

Until now we were using the estimated gas as gas limit.
The gas cost of a contract call can change overtime if it's logic is based on any oracle or state that can change, so we need to add a safety margin to that estimate when setting the gas limit.

=> Pirates may now voyage without tweaking gas settings

![pirate life](https://media.giphy.com/media/10X22vzgNamaiI/giphy.gif)