### PR TITLE
fix: bump min chrome version to 98

### DIFF
--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -39,5 +39,5 @@
       "strict_min_version": "95.0"
     }
   },
-  "minimum_chrome_version": "92"
+  "minimum_chrome_version": "98"
 }


### PR DESCRIPTION
- Closes #1005 

Minimum versions with structuredClone support : 
- Chrome 98
- Firefox 94