### PR TITLE
fix: incorrect cached/stale balances for evm accounts

### DIFF
--- a/.changeset/angry-bottles-look.md
+++ b/.changeset/angry-bottles-look.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances-substrate-native": patch
+---
+
+fix: incorrect cached/stale balances for evm accounts

--- a/packages/balances-substrate-native/src/SubstrateNativeModule.ts
+++ b/packages/balances-substrate-native/src/SubstrateNativeModule.ts
@@ -496,18 +496,33 @@ async function buildQueries(
           "account",
           decodeAnyAddress(address)
         )
-        const stateKey = hasMetadataV14
-          ? storageHelper.stateKey
-          : (() => {
-              const addressBytes = decodeAnyAddress(address)
-              const addressHash = blake2Concat(addressBytes).replace(/^0x/, "")
-              const moduleHash = "26aa394eea5630e07c48ae0c9558cef7" // util_crypto.xxhashAsHex("System", 128);
-              const storageHash = "b99d880ec681799c0cf30e8886371da9" // util_crypto.xxhashAsHex("Account", 128);
-              const moduleStorageHash = `${moduleHash}${storageHash}` // System.Account is the state_storage key prefix for nativeToken balances
-              const stateKey = `0x${moduleStorageHash}${addressHash}`
-              return stateKey
-            })()
-        if (!stateKey) return
+        const getFallbackStateKey = () => {
+          const addressBytes = decodeAnyAddress(address)
+          const addressHash = blake2Concat(addressBytes).replace(/^0x/, "")
+          const moduleHash = "26aa394eea5630e07c48ae0c9558cef7" // util_crypto.xxhashAsHex("System", 128);
+          const storageHash = "b99d880ec681799c0cf30e8886371da9" // util_crypto.xxhashAsHex("Account", 128);
+          const moduleStorageHash = `${moduleHash}${storageHash}` // System.Account is the state_storage key prefix for nativeToken balances
+          return `0x${moduleStorageHash}${addressHash}`
+        }
+
+        /**
+         * NOTE: For many MetadataV14 chains, it is not valid to encode an ethereum address into this System.Account state call.
+         * However, because we have always made that state call in the past, existing users will have the result (a balance of `0`)
+         * cached in their BalancesDB.
+         *
+         * So, until we refactor the storage of this module in a way which nukes the existing cached balances, we'll need to continue
+         * making these invalid state calls to keep those balances from showing as `cached` or `stale`.
+         *
+         * Current logic:
+         *
+         *     stateKey: string = hasMetadataV14 && storageHelper.stateKey ? storageHelper.stateKey : getFallbackStateKey()
+         *
+         * Future (ideal) logic:
+         *
+         *     stateKey: string | undefined = hasMetadataV14 ? storageHelper.stateKey : getFallbackStateKey()
+         */
+        const stateKey =
+          hasMetadataV14 && storageHelper.stateKey ? storageHelper.stateKey : getFallbackStateKey()
 
         const decodeResult = (change: string | null) => {
           // BEGIN: Handle chains which use metadata < v14


### PR DESCRIPTION
[Fixes the sneaky bug introduced by this commit](https://github.com/TalismanSociety/talisman/commit/d2ccdafba8d97023e58f2234dfef3d153de0b2e1#diff-7253ed9dc13e7a9171ac4fbef647aa74c4886356e9bc087151534000f61b90c5R491-R511).

Because we were no longer making unnecessary state calls (System.Account `address` for evm accounts on non-evm chains) the store was left with a bunch of `Balance` rows which would go stale/remain forever cached.

This PR patches the problem by continuing to make those calls for now.

The better fix would be to delete the rows from the DB, but I don't want to set up any fancy migrations sort of code for this area yet.

There are other limitations on the current balances db structure which will need to be addressed soon anyway. So, I don't think it's worth trying to polish up what's there.

Specifically - the current structure doesn't allow us to have different statuses (e.g. `cached`, `live`) for a token whose balance comes from multiple pallets - e.g. nomination pools:
- DOT (System.Account)
- DOT (nominationPools)

When we fix that we will implicitly ditch the current cache anyway :)