### PR TITLE
fix: remove old tokenRates for tokens which have no coingeckoId anymore

### DIFF
--- a/.changeset/gold-camels-brush.md
+++ b/.changeset/gold-camels-brush.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances-react": patch
+---
+
+fix: remove old tokenRates for tokens which have no coingeckoId anymore


### PR DESCRIPTION
When we remove coingeckoIds from chaindata, the wallet just keeps the last-fetched rate for the token instead of removing it from the tokenRatesDb.

This PR fixes that.