### PR TITLE
fix: extrinsic payload parsing

### DIFF
--- a/apps/extension/src/core/domains/signing/handler.ts
+++ b/apps/extension/src/core/domains/signing/handler.ts
@@ -19,6 +19,7 @@ import { TypeRegistry } from "@polkadot/types"
 import keyring from "@polkadot/ui-keyring"
 import { assert } from "@polkadot/util"
 import { encodeAnyAddress } from "@talismn/util"
+import { getExtrinsicPayload } from "@ui/util/getExtrinsicPayload"
 
 import { getHostName } from "../app/helpers"
 
@@ -43,14 +44,14 @@ export default class SigningHandler extends ExtensionHandler {
       let registry = new TypeRegistry()
 
       if (isJsonPayload(payload)) {
-        const { signedExtensions, specVersion, blockHash } = payload
-        const genesisHash = validateHexString(payload.genesisHash)
+        const extPayload = getExtrinsicPayload(payload)
+        const genesisHash = extPayload.genesisHash.toHex()
 
         const { registry: fullRegistry } = await getTypeRegistry(
           genesisHash,
-          specVersion,
-          blockHash,
-          signedExtensions
+          extPayload.specVersion.toNumber(),
+          extPayload.blockHash.toHex(),
+          payload.signedExtensions
         )
 
         registry = fullRegistry

--- a/apps/extension/src/ui/apps/popup/pages/Sign/PolkadotSignTransactionRequest.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Sign/PolkadotSignTransactionRequest.tsx
@@ -1,6 +1,5 @@
 import { AccountJsonHardwareSubstrate, AccountJsonQr } from "@core/domains/accounts/types"
 import { isJsonPayload } from "@core/util/isJsonPayload"
-import { validateHexString } from "@core/util/validateHexString"
 import { AppPill } from "@talisman/components/AppPill"
 import { InfoIcon, LoaderIcon } from "@talisman/theme/icons"
 import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
@@ -10,6 +9,7 @@ import { QrSubstrate } from "@ui/domains/Sign/Qr/QrSubstrate"
 import { SignAlertMessage } from "@ui/domains/Sign/SignAlertMessage"
 import { usePolkadotSigningRequest } from "@ui/domains/Sign/SignRequestContext"
 import { SubSignBody } from "@ui/domains/Sign/Substrate/SubSignBody"
+import { getExtrinsicPayload } from "@ui/util/getExtrinsicPayload"
 import { FC, Suspense, lazy, useEffect, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
@@ -75,12 +75,13 @@ export const PolkadotSignTransactionRequest: FC = () => {
   } = usePolkadotSigningRequest()
 
   const { genesisHash, specVersion } = useMemo(() => {
-    return payload && isJsonPayload(payload)
-      ? {
-          genesisHash: validateHexString(payload.genesisHash),
-          specVersion: parseInt(payload.specVersion, 16),
-        }
-      : {}
+    if (!payload || !isJsonPayload(payload)) return {}
+
+    const extPayload = getExtrinsicPayload(payload)
+    return {
+      genesisHash: extPayload.genesisHash.toHex(),
+      specVersion: extPayload.specVersion.toNumber(),
+    }
   }, [payload])
 
   const { processing, errorMessage } = useMemo(() => {

--- a/apps/extension/src/ui/domains/Sign/Qr/MetadataQrCode.tsx
+++ b/apps/extension/src/ui/domains/Sign/Qr/MetadataQrCode.tsx
@@ -11,7 +11,7 @@ import { QrCodeSource, qrCodeLogoForSource } from "./QrCodeSourceSelector"
 
 type Props = {
   genesisHash: SignerPayloadGenesisHash
-  specVersion: string
+  specVersion: number
   qrCodeSource: QrCodeSource
 }
 
@@ -22,7 +22,7 @@ export const MetadataQrCode = ({ genesisHash, specVersion, qrCodeSource }: Props
   const { data, isLoading, error } = useQuery({
     queryKey: ["chainMetadataQr", genesisHash, specVersion],
     queryFn: async () => {
-      const hexData = await api.generateChainMetadataQr(genesisHash, Number(specVersion))
+      const hexData = await api.generateChainMetadataQr(genesisHash, specVersion)
       return hexToU8a(hexData)
     },
     enabled: qrCodeSource === "talisman",

--- a/apps/extension/src/ui/domains/Sign/Qr/QrSubstrate.tsx
+++ b/apps/extension/src/ui/domains/Sign/Qr/QrSubstrate.tsx
@@ -10,7 +10,8 @@ import { classNames } from "@talismn/util"
 import { ChainLogo } from "@ui/domains/Asset/ChainLogo"
 import { ScanQr } from "@ui/domains/Sign/Qr/ScanQr"
 import useChainByGenesisHash from "@ui/hooks/useChainByGenesisHash"
-import { ReactElement, useState } from "react"
+import { getExtrinsicPayload } from "@ui/util/getExtrinsicPayload"
+import { ReactElement, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { Button, Drawer, Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
 
@@ -80,6 +81,10 @@ export const QrSubstrate = ({
   const chain = useChainByGenesisHash(genesisHash)
   const qrCodeSourceSelectorState = useQrCodeSourceSelectorState(genesisHash)
   const { qrCodeSource } = qrCodeSourceSelectorState
+
+  const extPayload = useMemo(() => {
+    return isJsonPayload(payload) ? getExtrinsicPayload(payload) : null
+  }, [payload])
 
   if (scanState.page === "INIT")
     return (
@@ -162,10 +167,10 @@ export const QrSubstrate = ({
               <div className="text-body-secondary absolute left-1/2 top-1/2 inline-flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-8">
                 <LoaderIcon className="animate-spin-slow text-3xl" />
               </div>
-              {qrCodeSource && isJsonPayload(payload) && (
+              {qrCodeSource && extPayload && (
                 <MetadataQrCode
-                  genesisHash={payload.genesisHash}
-                  specVersion={payload.specVersion}
+                  genesisHash={extPayload.genesisHash.toHex()}
+                  specVersion={extPayload.specVersion.toNumber()}
                   qrCodeSource={qrCodeSource}
                 />
               )}

--- a/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsSub.tsx
+++ b/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsSub.tsx
@@ -1,11 +1,11 @@
 import { BalanceFormatter } from "@core/domains/balances/types"
 import { SignerPayloadJSON, SignerPayloadRaw, TransactionMethod } from "@core/domains/signing/types"
 import { isJsonPayload } from "@core/util/isJsonPayload"
-import { TypeRegistry } from "@polkadot/types"
 import { useOpenClose } from "@talisman/hooks/useOpenClose"
 import { useAnalytics } from "@ui/hooks/useAnalytics"
 import useToken from "@ui/hooks/useToken"
 import { useTokenRates } from "@ui/hooks/useTokenRates"
+import { getExtrinsicPayload } from "@ui/util/getExtrinsicPayload"
 import { FC, useEffect, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Button, Drawer } from "talisman-ui"
@@ -53,12 +53,7 @@ const ViewDetailsContent: FC<{
   )
 
   const decodedPayload = useMemo(() => {
-    try {
-      const typeRegistry = new TypeRegistry()
-      return typeRegistry.createType("ExtrinsicPayload", payload)
-    } catch (err) {
-      return null
-    }
+    return isJsonPayload(payload) ? getExtrinsicPayload(payload) : null
   }, [payload])
 
   const { methodName, args, decodedMethod } = useMemo(() => {

--- a/apps/extension/src/ui/hooks/useExtrinsic.ts
+++ b/apps/extension/src/ui/hooks/useExtrinsic.ts
@@ -10,6 +10,7 @@ import { hexToNumber, isHex } from "@polkadot/util"
 import { HexString } from "@polkadot/util/types"
 import { useQuery } from "@tanstack/react-query"
 import { api } from "@ui/api"
+import { getExtrinsicPayload } from "@ui/util/getExtrinsicPayload"
 
 // do not reuse getTypeRegistry because we're on front-end, we need to leverage backend's metadata cache
 const getFrontEndTypeRegistry = async (
@@ -86,13 +87,13 @@ const getFrontEndTypeRegistry = async (
 
 const decodeExtrinsic = async (payload: SignerPayloadJSON) => {
   try {
-    const { genesisHash, signedExtensions, specVersion: hexSpecVersion } = payload
+    const extPayload = getExtrinsicPayload(payload)
 
     const { registry } = await getFrontEndTypeRegistry(
-      genesisHash,
-      hexToNumber(hexSpecVersion),
+      extPayload.genesisHash.toHex(),
+      extPayload.specVersion.toNumber(),
       undefined, // dapp may be using an RPC that is a block ahead our provder's RPC, do not specify payload's blockHash or it could throw
-      signedExtensions
+      payload.signedExtensions
     )
 
     return registry.createType("Extrinsic", payload)

--- a/apps/extension/src/ui/util/getExtrinsicPayload.ts
+++ b/apps/extension/src/ui/util/getExtrinsicPayload.ts
@@ -1,0 +1,9 @@
+import { TypeRegistry } from "@polkadot/types"
+import { SignerPayloadJSON } from "@polkadot/types/types"
+
+// reuse this as it's not chain specific
+const registry = new TypeRegistry()
+
+export const getExtrinsicPayload = (payload: SignerPayloadJSON) => {
+  return registry.createType("ExtrinsicPayload", payload)
+}


### PR DESCRIPTION
Found out that extrinsic payloads sent from dapps may not always use the same format.
Some dapps (at least the ones built with CAPI) craft payloads where the specVersion can be a number instead of hex string.
This displayed a warning in Talisman's signing popup, and probably prevented QR codes from being generated.

This PR fixes associated issues by decoding the payload using TypeRegistry before reading the specVersion.