### PR TITLE
fix: inject error on unauthorised sites

### DIFF
--- a/apps/extension/src/core/domains/sitesAuthorised/store.ts
+++ b/apps/extension/src/core/domains/sitesAuthorised/store.ts
@@ -1,6 +1,5 @@
 import { AuthorizedSite, AuthorizedSites, ProviderType } from "@core/domains/sitesAuthorised/types"
 import { SubscribableByIdStorageProvider } from "@core/libs/Store"
-import { isTalismanHostname } from "@core/page"
 import { urlToDomain } from "@core/util/urlToDomain"
 import { assert } from "@polkadot/util"
 import { convertAddress } from "@talisman/util/convertAddress"
@@ -34,13 +33,11 @@ export class SitesAuthorizedStore extends SubscribableByIdStorageProvider<
     })
   }
 
-  async getSiteFromUrl(url: string): Promise<AuthorizedSite> {
+  getSiteFromUrl(url: string): Promise<AuthorizedSite> {
     const { val, err } = urlToDomain(url)
     if (err) throw new Error(val)
 
-    const site = await this.get(val)
-
-    return { ...site, connectWatchedAccounts: isTalismanHostname(site.url) }
+    return this.get(val)
   }
 
   public async ensureUrlAuthorized(

--- a/apps/extension/src/core/domains/sitesAuthorised/types.ts
+++ b/apps/extension/src/core/domains/sitesAuthorised/types.ts
@@ -58,7 +58,6 @@ export type AuthorizedSite = {
   url: string
   ethChainId?: number
   connectAllSubstrate?: boolean
-  connectWatchedAccounts?: boolean
 }
 
 export type ProviderType = "polkadot" | "ethereum"

--- a/apps/extension/src/core/handlers/Extension.ts
+++ b/apps/extension/src/core/handlers/Extension.ts
@@ -22,6 +22,7 @@ import { talismanAnalytics } from "@core/libs/Analytics"
 import { ExtensionHandler } from "@core/libs/Handler"
 import { generateQrAddNetworkSpecs, generateQrUpdateNetworkMetadata } from "@core/libs/QrGenerator"
 import { log } from "@core/log"
+import { isTalismanHostname } from "@core/page"
 import { MessageTypes, RequestType, ResponseType } from "@core/types"
 import { Port, RequestIdOnly } from "@core/types/base"
 import { awaitKeyringLoaded } from "@core/util/awaitKeyringLoaded"
@@ -86,7 +87,7 @@ export default class Extension extends ExtensionHandler {
             const newAddresses = Object.values(addresses)
               .filter(
                 ({ json: { meta } }) =>
-                  autoAddSite.connectWatchedAccounts || meta.origin !== AccountType.Watched
+                  isTalismanHostname(autoAddSite.url) || meta.origin !== AccountType.Watched
               )
               .filter(({ json: { address } }) => !autoAddSite.addresses?.includes(address))
               .map(({ json: { address } }) => address)


### PR DESCRIPTION
Fixes an error making extension unable to inject on sites that are not yet authorised. 
`connectWatchedAccounts` property was being set on an object that doesn't exist, resulting in an unexpected error

Solution : 
- removed the `connectWatchedAccounts` property from AuthorisedSite object as it doesn't need to be in the store
- instead call `isTalismanHostname(site.url)` when needed at runtime

