### PR TITLE
feat: forget/disconnect all sites

### DIFF
--- a/.changeset/chilled-readers-itch.md
+++ b/.changeset/chilled-readers-itch.md
@@ -1,0 +1,5 @@
+---
+"talisman-ui": patch
+---
+
+feat: nicer toggle colors

--- a/apps/extension/src/core/domains/sitesAuthorised/handler.ts
+++ b/apps/extension/src/core/domains/sitesAuthorised/handler.ts
@@ -1,6 +1,7 @@
 import {
   AuthRequestApprove,
   AuthorizedSite,
+  RequestAuthorizedSiteBatchOp,
   RequestAuthorizedSiteForget,
   RequestAuthorizedSiteUpdate,
 } from "@core/domains/sitesAuthorised/types"
@@ -18,6 +19,16 @@ import { ignoreRequest } from "./requests"
 export default class SitesAuthorisationHandler extends ExtensionHandler {
   private async authorizedForget({ id, type }: RequestAuthorizedSiteForget) {
     await this.stores.sites.forgetSite(id, type)
+    return true
+  }
+
+  private async disconnectAll({ type }: RequestAuthorizedSiteBatchOp): Promise<boolean> {
+    await this.stores.sites.disconnectAllSites(type)
+    return true
+  }
+
+  private async forgetAll({ type }: RequestAuthorizedSiteBatchOp): Promise<boolean> {
+    await this.stores.sites.forgetAllSites(type)
     return true
   }
 
@@ -88,6 +99,12 @@ export default class SitesAuthorisationHandler extends ExtensionHandler {
 
       case "pri(sites.update)":
         return this.authorizedUpdate(request as RequestAuthorizedSiteUpdate)
+
+      case "pri(sites.disconnect.all)":
+        return this.disconnectAll(request as RequestAuthorizedSiteBatchOp)
+
+      case "pri(sites.forget.all)":
+        return this.forgetAll(request as RequestAuthorizedSiteBatchOp)
 
       // --------------------------------------------------------------------
       // authorised site requests handlers ----------------------------------

--- a/apps/extension/src/core/domains/sitesAuthorised/store.ts
+++ b/apps/extension/src/core/domains/sitesAuthorised/store.ts
@@ -1,5 +1,6 @@
 import { AuthorizedSite, AuthorizedSites, ProviderType } from "@core/domains/sitesAuthorised/types"
 import { SubscribableByIdStorageProvider } from "@core/libs/Store"
+import { isTalismanHostname } from "@core/page"
 import { urlToDomain } from "@core/util/urlToDomain"
 import { assert } from "@polkadot/util"
 import { convertAddress } from "@talisman/util/convertAddress"
@@ -88,6 +89,42 @@ export class SitesAuthorizedStore extends SubscribableByIdStorageProvider<
       sites[id] = {
         ...sites[id],
         ...props,
+      }
+      return sites
+    })
+  }
+
+  async forgetAllSites(type: ProviderType) {
+    await this.mutate((sites) => {
+      for (const host of Object.keys(sites)) {
+        if (type === "ethereum") {
+          if (!sites[host].addresses) delete sites[host]
+          else {
+            delete sites[host].ethAddresses
+            delete sites[host].ethPermissions
+            delete sites[host].ethChainId
+          }
+        }
+        // don't forget Talisman web app
+        if (type === "polkadot" && !isTalismanHostname(host)) {
+          if (!sites[host].ethAddresses) delete sites[host]
+          else {
+            delete sites[host].addresses
+            delete sites[host].connectAllSubstrate
+          }
+        }
+      }
+      return sites
+    })
+  }
+
+  async disconnectAllSites(type: ProviderType) {
+    await this.mutate((sites) => {
+      for (const host of Object.keys(sites)) {
+        // disconnect all accounts unless it's Talisman web app
+        if (type === "polkadot" && sites[host].addresses && !isTalismanHostname(host))
+          sites[host].addresses = []
+        if (type === "ethereum" && sites[host].ethAddresses) sites[host].ethAddresses = []
       }
       return sites
     })

--- a/apps/extension/src/core/domains/sitesAuthorised/types.ts
+++ b/apps/extension/src/core/domains/sitesAuthorised/types.ts
@@ -71,6 +71,8 @@ export declare type RequestAuthorizedSiteUpdate = {
 
 export declare type RequestAuthorizedSiteForget = { id: string; type: ProviderType }
 
+export declare type RequestAuthorizedSiteBatchOp = { type: ProviderType }
+
 // authorized sites message signatures
 export interface AuthorisedSiteMessages {
   // authorization requests message signatures
@@ -85,6 +87,8 @@ export interface AuthorisedSiteMessages {
   "pri(sites.byid.subscribe)": [RequestIdOnly, boolean, AuthorizedSite]
   "pri(sites.forget)": [RequestAuthorizedSiteForget, boolean]
   "pri(sites.update)": [RequestAuthorizedSiteUpdate, boolean]
+  "pri(sites.disconnect.all)": [RequestAuthorizedSiteBatchOp, boolean]
+  "pri(sites.forget.all)": [RequestAuthorizedSiteBatchOp, boolean]
 
   // public messages
   "pub(authorize.tab)": [RequestAuthorizeTab, boolean]

--- a/apps/extension/src/ui/api/api.ts
+++ b/apps/extension/src/ui/api/api.ts
@@ -163,6 +163,9 @@ export const api: MessageTypes = {
   authorizedSiteForget: (id, type) => messageService.sendMessage("pri(sites.forget)", { id, type }),
   authorizedSiteUpdate: (id, authorisedSite) =>
     messageService.sendMessage("pri(sites.update)", { id, authorisedSite }),
+  authorizedSitesDisconnectAll: (type) =>
+    messageService.sendMessage("pri(sites.disconnect.all)", { type }),
+  authorizedSitesForgetAll: (type) => messageService.sendMessage("pri(sites.forget.all)", { type }),
 
   // authorization requests messages ------------------------------------
   authrequestApprove: (id, addresses) =>

--- a/apps/extension/src/ui/api/types.ts
+++ b/apps/extension/src/ui/api/types.ts
@@ -167,6 +167,8 @@ export default interface MessageTypes {
   authorizedSiteSubscribe: (id: string, cb: (sites: AuthorizedSite) => void) => UnsubscribeFn
   authorizedSiteForget: (id: string, type: ProviderType) => Promise<boolean>
   authorizedSiteUpdate: (id: string, authorisedSite: AuthorisedSiteUpdate) => Promise<boolean>
+  authorizedSitesDisconnectAll: (type: ProviderType) => Promise<boolean>
+  authorizedSitesForgetAll: (type: ProviderType) => Promise<boolean>
 
   // authorization requests message types ------------------------------------
   authrequestApprove: (id: AuthRequestId, addresses: AuthRequestAddresses) => Promise<boolean>

--- a/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSite.tsx
+++ b/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSite.tsx
@@ -83,7 +83,7 @@ export const AuthorizedSite: FC<{
             totalCount: availableAddresses?.length ?? 0,
           })}
         </div>
-        <div>
+        <div className="text-lg">
           <AccordionIcon isOpen={isOpen} />
         </div>
       </button>

--- a/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSiteAccount.tsx
+++ b/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSiteAccount.tsx
@@ -29,7 +29,7 @@ export const AuthorisedSiteAccount: FC<{
           address={account.address}
           genesisHash={account.genesisHash}
         />
-        <div className="text-body-secondary text-md overflow-x-hidden text-ellipsis whitespace-nowrap">
+        <div className="text-body-secondary truncate text-base">
           {account.name ?? <Address address={account.address} />}
         </div>
         <AccountTypeIcon origin={account.origin} className="text-primary-500 text-md" />

--- a/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSiteAccount.tsx
+++ b/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSiteAccount.tsx
@@ -34,9 +34,7 @@ export const AuthorisedSiteAccount: FC<{
         </div>
         <AccountTypeIcon origin={account.origin} className="text-primary-500 text-md" />
       </div>
-      <div>
-        <Toggle checked={isConnected} onChange={handleChange} />
-      </div>
+      <Toggle checked={isConnected} onChange={handleChange} />
     </div>
   )
 }

--- a/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSiteBatchActions.tsx
+++ b/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSiteBatchActions.tsx
@@ -1,0 +1,105 @@
+import { ProviderType } from "@core/domains/sitesAuthorised/types"
+import { notify } from "@talisman/components/Notifications"
+import { api } from "@ui/api"
+import { FC, ReactNode, useCallback } from "react"
+import { Trans, useTranslation } from "react-i18next"
+import { Button, Modal, ModalDialog, useOpenClose } from "talisman-ui"
+
+const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
+
+export const BatchActionButton: FC<{
+  confirmTitle: ReactNode
+  confirmDescription: ReactNode
+  confirmBtnText: ReactNode
+  children: ReactNode
+  className?: string
+  handler: () => Promise<boolean>
+}> = ({ confirmTitle, confirmDescription, confirmBtnText, children, className, handler }) => {
+  const { t } = useTranslation()
+  const { isOpen, open, close } = useOpenClose()
+
+  const handlerConfirm = useCallback(async () => {
+    if (await handler()) close()
+  }, [close, handler])
+
+  return (
+    <>
+      <button type="button" onClick={open} className={className}>
+        {children}
+      </button>
+      <Modal isOpen={isOpen} onDismiss={close}>
+        <ModalDialog onClose={close} title={confirmTitle} className="border-grey-800 border">
+          <p className="text-body-secondary">{confirmDescription}</p>
+          <div className="mt-8 grid grid-cols-2 gap-8">
+            <Button onClick={close}>{t("Cancel")}</Button>
+            <Button primary onClick={handlerConfirm}>
+              {confirmBtnText}
+            </Button>
+          </div>
+        </ModalDialog>
+      </Modal>
+    </>
+  )
+}
+
+export const AuthorisedSitesBatchActions: FC<{ providerType: ProviderType }> = ({
+  providerType,
+}) => {
+  const { t } = useTranslation("admin")
+
+  const handleForgetAll = useCallback(async () => {
+    try {
+      return await api.authorizedSitesForgetAll(providerType)
+    } catch (err) {
+      notify({ type: "error", title: t("Error"), subtitle: t("Failed to forget all sites") })
+      return false
+    }
+  }, [providerType, t])
+
+  const handleDisconnectAll = useCallback(async () => {
+    try {
+      return await api.authorizedSitesDisconnectAll(providerType)
+    } catch (err) {
+      notify({ type: "error", title: t("Error"), subtitle: t("Failed to disconnect all sites") })
+      return false
+    }
+  }, [providerType, t])
+
+  return (
+    <div className="text-grey-500 flex gap-[0.5rem] text-xs">
+      <BatchActionButton
+        confirmTitle={t("Forget All Sites")}
+        confirmDescription={
+          <Trans
+            t={t}
+            components={{ Highlight: <span className="text-body"></span> }}
+            defaults="Are you sure you want to forget all <Highlight>{{providerType}}</Highlight> sites?"
+            values={{ providerType: capitalize(providerType) }}
+          />
+        }
+        confirmBtnText={t("Continue")}
+        handler={handleForgetAll}
+        className="hover:text-body"
+      >
+        {t("Forget All Sites")}
+      </BatchActionButton>
+      <div className="bg-grey-700 w-0.5 py-1"></div>
+      <BatchActionButton
+        confirmTitle={t("Disconnect All Sites")}
+        confirmDescription={
+          <Trans
+            t={t}
+            components={{ Highlight: <span className="text-body"></span> }}
+            defaults="Are you sure you want to disconnect from all <Highlight>{{providerType}}</Highlight> sites?"
+            values={{ providerType: capitalize(providerType) }}
+          />
+        }
+        confirmBtnText={t("Continue")}
+        handler={handleDisconnectAll}
+        className="hover:text-body"
+      >
+        {t("Disconnect All Sites")}
+      </BatchActionButton>
+    </div>
+  )
+}

--- a/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSites.tsx
+++ b/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSites.tsx
@@ -1,113 +1,14 @@
 import { TALISMAN_WEB_APP_URL } from "@core/constants"
 import { ProviderType } from "@core/domains/sitesAuthorised/types"
 import { HeaderBlock } from "@talisman/components/HeaderBlock"
-import { notify } from "@talisman/components/Notifications"
 import { Spacer } from "@talisman/components/Spacer"
-import { api } from "@ui/api"
 import { ProviderTypeSwitch } from "@ui/domains/Site/ProviderTypeSwitch"
 import { useAuthorisedSites } from "@ui/hooks/useAuthorisedSites"
-import { FC, ReactNode, useCallback, useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
-import { Button, Modal, ModalDialog, useOpenClose } from "talisman-ui"
 
 import { AuthorizedSite } from "./AuthorisedSite"
-
-const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
-
-export const BatchActionButton: FC<{
-  confirmTitle: ReactNode
-  confirmDescription: ReactNode
-  confirmBtnText: ReactNode
-  children: ReactNode
-  className?: string
-  handler: () => Promise<boolean>
-}> = ({ confirmTitle, confirmDescription, confirmBtnText, children, className, handler }) => {
-  const { t } = useTranslation()
-  const { isOpen, open, close } = useOpenClose()
-
-  const handlerConfirm = useCallback(async () => {
-    if (await handler()) close()
-  }, [close, handler])
-
-  return (
-    <>
-      <button type="button" onClick={open} className={className}>
-        {children}
-      </button>
-      <Modal isOpen={isOpen} onDismiss={close}>
-        <ModalDialog onClose={close} title={confirmTitle} className="border-grey-800 border">
-          <p className="text-body-secondary">{confirmDescription}</p>
-          <div className="mt-8 grid grid-cols-2 gap-8">
-            <Button onClick={close}>{t("Cancel")}</Button>
-            <Button primary onClick={handlerConfirm}>
-              {confirmBtnText}
-            </Button>
-          </div>
-        </ModalDialog>
-      </Modal>
-    </>
-  )
-}
-
-const BatchActions: FC<{ providerType: ProviderType }> = ({ providerType }) => {
-  const { t } = useTranslation("admin")
-
-  const handleForgetAll = useCallback(async () => {
-    try {
-      return await api.authorizedSitesForgetAll(providerType)
-    } catch (err) {
-      notify({ type: "error", title: t("Error"), subtitle: t("Failed to forget all sites") })
-      return false
-    }
-  }, [providerType, t])
-
-  const handleDisconnectAll = useCallback(async () => {
-    try {
-      return await api.authorizedSitesDisconnectAll(providerType)
-    } catch (err) {
-      notify({ type: "error", title: t("Error"), subtitle: t("Failed to disconnect all sites") })
-      return false
-    }
-  }, [providerType, t])
-
-  return (
-    <div className="text-grey-500 flex gap-[0.5rem] text-xs">
-      <BatchActionButton
-        confirmTitle={t("Forget All Sites")}
-        confirmDescription={
-          <Trans
-            t={t}
-            components={{ Highlight: <span className="text-body"></span> }}
-            defaults="Are you sure you want to forget all <Highlight>{{providerType}}</Highlight> sites?"
-            values={{ providerType: capitalize(providerType) }}
-          />
-        }
-        confirmBtnText={t("Continue")}
-        handler={handleForgetAll}
-        className="hover:text-body"
-      >
-        {t("Forget All Sites")}
-      </BatchActionButton>
-      <div className="bg-grey-700 w-0.5 py-1"></div>
-      <BatchActionButton
-        confirmTitle={t("Disconnect All Sites")}
-        confirmDescription={
-          <Trans
-            t={t}
-            components={{ Highlight: <span className="text-body"></span> }}
-            defaults="Are you sure you want to disconnect from all <Highlight>{{providerType}}</Highlight> sites?"
-            values={{ providerType: capitalize(providerType) }}
-          />
-        }
-        confirmBtnText={t("Continue")}
-        handler={handleDisconnectAll}
-        className="hover:text-body"
-      >
-        {t("Disconnect All Sites")}
-      </BatchActionButton>
-    </div>
-  )
-}
+import { AuthorisedSitesBatchActions } from "./AuthorisedSiteBatchActions"
 
 export const AuthorisedSites = () => {
   const { t } = useTranslation("admin")
@@ -166,7 +67,7 @@ export const AuthorisedSites = () => {
             />
           ) : null}
         </div>
-        {showBatchActions && <BatchActions providerType={providerType} />}
+        {showBatchActions && <AuthorisedSitesBatchActions providerType={providerType} />}
       </div>
       <Spacer small />
       <div className="flex flex-col gap-4">

--- a/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSites.tsx
+++ b/apps/extension/src/ui/domains/Settings/AuthorisedSites/AuthorisedSites.tsx
@@ -1,13 +1,113 @@
 import { TALISMAN_WEB_APP_URL } from "@core/constants"
 import { ProviderType } from "@core/domains/sitesAuthorised/types"
 import { HeaderBlock } from "@talisman/components/HeaderBlock"
+import { notify } from "@talisman/components/Notifications"
 import { Spacer } from "@talisman/components/Spacer"
+import { api } from "@ui/api"
 import { ProviderTypeSwitch } from "@ui/domains/Site/ProviderTypeSwitch"
 import { useAuthorisedSites } from "@ui/hooks/useAuthorisedSites"
-import { useEffect, useMemo, useState } from "react"
+import { FC, ReactNode, useCallback, useEffect, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
+import { Button, Modal, ModalDialog, useOpenClose } from "talisman-ui"
 
 import { AuthorizedSite } from "./AuthorisedSite"
+
+const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
+
+export const BatchActionButton: FC<{
+  confirmTitle: ReactNode
+  confirmDescription: ReactNode
+  confirmBtnText: ReactNode
+  children: ReactNode
+  className?: string
+  handler: () => Promise<boolean>
+}> = ({ confirmTitle, confirmDescription, confirmBtnText, children, className, handler }) => {
+  const { t } = useTranslation()
+  const { isOpen, open, close } = useOpenClose()
+
+  const handlerConfirm = useCallback(async () => {
+    if (await handler()) close()
+  }, [close, handler])
+
+  return (
+    <>
+      <button type="button" onClick={open} className={className}>
+        {children}
+      </button>
+      <Modal isOpen={isOpen} onDismiss={close}>
+        <ModalDialog onClose={close} title={confirmTitle} className="border-grey-800 border">
+          <p className="text-body-secondary">{confirmDescription}</p>
+          <div className="mt-8 grid grid-cols-2 gap-8">
+            <Button onClick={close}>{t("Cancel")}</Button>
+            <Button primary onClick={handlerConfirm}>
+              {confirmBtnText}
+            </Button>
+          </div>
+        </ModalDialog>
+      </Modal>
+    </>
+  )
+}
+
+const BatchActions: FC<{ providerType: ProviderType }> = ({ providerType }) => {
+  const { t } = useTranslation("admin")
+
+  const handleForgetAll = useCallback(async () => {
+    try {
+      return await api.authorizedSitesForgetAll(providerType)
+    } catch (err) {
+      notify({ type: "error", title: t("Error"), subtitle: t("Failed to forget all sites") })
+      return false
+    }
+  }, [providerType, t])
+
+  const handleDisconnectAll = useCallback(async () => {
+    try {
+      return await api.authorizedSitesDisconnectAll(providerType)
+    } catch (err) {
+      notify({ type: "error", title: t("Error"), subtitle: t("Failed to disconnect all sites") })
+      return false
+    }
+  }, [providerType, t])
+
+  return (
+    <div className="text-grey-500 flex gap-[0.5rem] text-xs">
+      <BatchActionButton
+        confirmTitle={t("Forget All Sites")}
+        confirmDescription={
+          <Trans
+            t={t}
+            components={{ Highlight: <span className="text-body"></span> }}
+            defaults="Are you sure you want to forget all <Highlight>{{providerType}}</Highlight> sites?"
+            values={{ providerType: capitalize(providerType) }}
+          />
+        }
+        confirmBtnText={t("Continue")}
+        handler={handleForgetAll}
+        className="hover:text-body"
+      >
+        {t("Forget All Sites")}
+      </BatchActionButton>
+      <div className="bg-grey-700 w-0.5 py-1"></div>
+      <BatchActionButton
+        confirmTitle={t("Disconnect All Sites")}
+        confirmDescription={
+          <Trans
+            t={t}
+            components={{ Highlight: <span className="text-body"></span> }}
+            defaults="Are you sure you want to disconnect from all <Highlight>{{providerType}}</Highlight> sites?"
+            values={{ providerType: capitalize(providerType) }}
+          />
+        }
+        confirmBtnText={t("Continue")}
+        handler={handleDisconnectAll}
+        className="hover:text-body"
+      >
+        {t("Disconnect All Sites")}
+      </BatchActionButton>
+    </div>
+  )
+}
 
 export const AuthorisedSites = () => {
   const { t } = useTranslation("admin")
@@ -29,18 +129,25 @@ export const AuthorisedSites = () => {
     })
   }, [providerType, sites])
 
-  const hasEthereumTrustedSites = useMemo(() => {
-    if (!sites) return false
-    return Object.keys(sites).some((id: string) => {
-      const site = sites[id]
-      return !!site.ethAddresses
-    })
-  }, [sites])
+  const { hasPolkadotSites, hasEthereumSites } = useMemo(
+    () => ({
+      hasPolkadotSites: Object.values(sites).some((site) => !!site.addresses),
+      hasEthereumSites: Object.values(sites).some((site) => !!site.ethAddresses),
+    }),
+    [sites]
+  )
+
+  const showBatchActions = useMemo(
+    () =>
+      (providerType === "polkadot" && hasPolkadotSites) ||
+      (providerType === "ethereum" && hasEthereumSites),
+    [hasEthereumSites, hasPolkadotSites, providerType]
+  )
 
   useEffect(() => {
     //when forgetting last ethereum site, force switch to polkadot
-    if (providerType === "ethereum" && !hasEthereumTrustedSites) setProviderType("polkadot")
-  }, [hasEthereumTrustedSites, providerType])
+    if (providerType === "ethereum" && !hasEthereumSites) setProviderType("polkadot")
+  }, [hasEthereumSites, providerType])
 
   return (
     <>
@@ -49,31 +156,42 @@ export const AuthorisedSites = () => {
         text={t("Manage the sites that have access to your accounts")}
       />
       <Spacer large />
-      {hasEthereumTrustedSites ? (
-        <ProviderTypeSwitch
-          className="text-xs [&>div]:h-full"
-          defaultProvider="polkadot"
-          onChange={setProviderType}
-        />
-      ) : null}
+      <div className="flex items-center justify-between">
+        <div>
+          {hasEthereumSites ? (
+            <ProviderTypeSwitch
+              className="text-xs [&>div]:h-full"
+              defaultProvider="polkadot"
+              onChange={setProviderType}
+            />
+          ) : null}
+        </div>
+        {showBatchActions && <BatchActions providerType={providerType} />}
+      </div>
       <Spacer small />
       <div className="flex flex-col gap-4">
         {siteIds.map((id) => (
           <AuthorizedSite key={`${providerType}-${id}`} id={id} provider={providerType} />
         ))}
-        {!sites ||
-          (Object.keys(sites).length === 0 && (
-            <div className="bg-grey-850 w-full rounded p-8">
-              <Trans t={t}>
-                You haven't connected to any sites yet. Why not start with the{" "}
-                <a href={TALISMAN_WEB_APP_URL} target="_blank" className="text-primary">
-                  Talisman Web App
-                </a>
-                ?
-              </Trans>
-            </div>
-          ))}
-        {sites && !hasEthereumTrustedSites && providerType === "ethereum" && (
+        {providerType === "polkadot" && !hasPolkadotSites && (
+          <div className="bg-grey-850 text-body-secondary w-full rounded p-8">
+            <Trans
+              t={t}
+              components={{
+                Link: (
+                  // eslint-disable-next-line jsx-a11y/anchor-has-content
+                  <a
+                    href={TALISMAN_WEB_APP_URL}
+                    target="_blank"
+                    className="text-grey-200 hover:text-body"
+                  ></a>
+                ),
+              }}
+              defaults="You haven't connected to any Polkadot sites yet. Why not start with <Link>Talisman Portal</Link>?"
+            ></Trans>
+          </div>
+        )}
+        {sites && !hasEthereumSites && providerType === "ethereum" && (
           // This should never be displayed unless we decide to display the provider switcher without check
           <div className="bg-grey-850 w-full rounded p-8">
             {t("You haven't connected to any Ethereum sites yet.")}

--- a/packages/talisman-ui/src/components/Toggle.tsx
+++ b/packages/talisman-ui/src/components/Toggle.tsx
@@ -24,10 +24,10 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         <input id={id} ref={ref} type="checkbox" className="peer sr-only" {...props} />
         <div
           className={classNames(
-            "bg-grey-600 peer h-14 w-24 shrink-0 rounded-full",
+            "bg-grey-600 peer h-12 w-[4.4rem] shrink-0 rounded-full",
             "peer-focus-visible:ring-body peer-focus:outline-none peer-focus-visible:ring-2",
             "peer-checked:after:bg-primary peer-checked:after:translate-x-full",
-            "after:bg-grey-800 relative after:absolute after:left-2 after:top-2 after:h-10 after:w-10 after:rounded-full after:transition-all after:content-['']"
+            "after:bg-grey-800 relative after:absolute after:left-1 after:top-1 after:h-10 after:w-10 after:rounded-full after:transition-all after:content-['']"
           )}
         ></div>
         {children && <span className="ml-3">{children}</span>}

--- a/packages/talisman-ui/src/components/Toggle.tsx
+++ b/packages/talisman-ui/src/components/Toggle.tsx
@@ -24,10 +24,10 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         <input id={id} ref={ref} type="checkbox" className="peer sr-only" {...props} />
         <div
           className={classNames(
-            "bg-grey-700 peer h-14 w-24 shrink-0 rounded-full",
+            "bg-grey-600 peer h-14 w-24 shrink-0 rounded-full",
             "peer-focus-visible:ring-body peer-focus:outline-none peer-focus-visible:ring-2",
             "peer-checked:after:bg-primary peer-checked:after:translate-x-full",
-            "relative after:absolute after:left-2 after:top-2 after:h-10 after:w-10 after:rounded-full after:bg-white after:transition-all after:content-['']"
+            "after:bg-grey-800 relative after:absolute after:left-2 after:top-2 after:h-10 after:w-10 after:rounded-full after:transition-all after:content-['']"
           )}
         ></div>
         {children && <span className="ml-3">{children}</span>}


### PR DESCRIPTION
- Closes #544 
- Closes #1044 

Misc: adjusted Toggle component as per Figma

Note: Figma indicates that each trusted site row should provide a link to the target site, which causes an accessibility problem as rows are buttons used to collapse/expand accounts. 
Will handle this in another PR after discussing it with Diogo