### PR TITLE
Ensure polkadot vault verifier cert mnemonic is stored as confirmed during migration

### DIFF
--- a/apps/extension/src/core/domains/mnemonics/migrations/index.ts
+++ b/apps/extension/src/core/domains/mnemonics/migrations/index.ts
@@ -106,6 +106,7 @@ export const migrateSeedStoreToMultiple: Migration = {
             name: "Polkadot Vault Verifier Certificate",
             source: SOURCES.Legacy,
             cipher: vcCipher,
+            confirmed: true, // verifier certificate is always confirmed, because it was imported manually
           },
         })
       }


### PR DESCRIPTION
Fixes an error in 1.19.0 RC1 where during migrations for the mnemonic store, an imported polkadot vault verifier certificate mnemonic would have `confirmed: false` when migrated to the new mnemonics store.