### PR TITLE
Really disable DCent in FF

### DIFF
--- a/apps/extension/src/core/background.ts
+++ b/apps/extension/src/core/background.ts
@@ -44,7 +44,7 @@ Browser.runtime.onInstalled.addListener(async ({ reason, previousVersion }) => {
     await migrationRunner.isComplete
   } else if (reason === "update") {
     // Main migrations will occur on login to ensure that password is present for any migrations that require it
-    passwordStore.isLoggedIn.subscribe(async (isLoggedIn) => {
+    const sub = passwordStore.isLoggedIn.subscribe(async (isLoggedIn) => {
       if (isLoggedIn) {
         const password = passwordStore.getPassword()
         if (!password) return
@@ -53,7 +53,10 @@ Browser.runtime.onInstalled.addListener(async ({ reason, previousVersion }) => {
         const migrationRunner = new MigrationRunner(migrations, false, {
           password,
         })
+
         await migrationRunner.isComplete
+        // only do this once
+        sub.unsubscribe()
       }
     })
     // run any legacy migrations

--- a/apps/extension/src/ui/domains/Account/AccountAdd/Container.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/Container.tsx
@@ -181,6 +181,7 @@ const ConnectAccountMethodButtons = () => {
             ? t("Connect your D'CENT Biometric Wallet")
             : t("Not supported on this browser")
         }
+        disabled={IS_FIREFOX}
         networks={["polkadot", "ethereum"]}
         to={`/accounts/add/dcent`}
       />


### PR DESCRIPTION
Also a random unrelated fix - the migrations runner was running on every login after upgrade events. The PR unsubscribes from listening to login events after the migrations are run once.