### PR TITLE
fix: send funds address format

### DIFF
--- a/apps/extension/src/ui/domains/SendFunds/SendFundsAccountPicker.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsAccountPicker.tsx
@@ -56,6 +56,7 @@ export const SendFundsAccountPicker = () => {
       <ScrollContainer className=" bg-black-secondary border-grey-700 scrollable h-full w-full grow overflow-x-hidden border-t">
         <SendFundsAccountsList
           accounts={accounts}
+          genesisHash={chain?.genesisHash}
           selected={from}
           onSelect={handleSelect}
           showBalances

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsAccountsList.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsAccountsList.tsx
@@ -26,11 +26,13 @@ export type SendFundsAccount = {
 
 type AccountRowProps = {
   account: SendFundsAccount
+  genesisHash?: string | null
   selected: boolean
   showBalances?: boolean
   token?: Token
   onClick?: () => void
   disabled?: boolean
+  noFormat?: boolean
 }
 
 const AccountTokenBalance = ({ token, balance }: { token?: Token; balance?: Balance }) => {
@@ -63,13 +65,23 @@ const AccountTokenBalance = ({ token, balance }: { token?: Token; balance?: Bala
 
 const AccountRow: FC<AccountRowProps> = ({
   account,
+  genesisHash,
+  noFormat,
   selected,
   onClick,
   showBalances,
   token,
   disabled,
 }) => {
-  const formattedAddress = useFormattedAddress(account?.address, account?.genesisHash)
+  const formattedAddress = useFormattedAddress(
+    account?.address,
+    genesisHash ?? account?.genesisHash
+  )
+
+  const displayAddress = useMemo(
+    () => (noFormat ? account?.address : formattedAddress),
+    [noFormat, account?.address, formattedAddress]
+  )
 
   return (
     <button
@@ -93,12 +105,12 @@ const AccountRow: FC<AccountRowProps> = ({
           <div className="flex items-center gap-2">
             <div className="truncate">
               {account.name ?? (
-                <Address address={formattedAddress} startCharCount={6} endCharCount={6} noTooltip />
+                <Address address={displayAddress} startCharCount={6} endCharCount={6} noTooltip />
               )}
             </div>
             <AccountTypeIcon origin={account.origin} className="text-primary" />
           </div>
-          <Address className="text-body-secondary text-xs" address={formattedAddress} />
+          <Address className="text-body-secondary text-xs" address={displayAddress} />
         </div>
         {selected && <CheckCircleIcon className="ml-3 inline shrink-0" />}
       </div>
@@ -109,6 +121,8 @@ const AccountRow: FC<AccountRowProps> = ({
 
 type SendFundsAccountsListProps = {
   accounts: SendFundsAccount[]
+  genesisHash?: string | null
+  noFormat?: boolean
   selected?: string | null
   onSelect?: (address: string) => void
   header?: ReactNode
@@ -121,6 +135,8 @@ type SendFundsAccountsListProps = {
 export const SendFundsAccountsList: FC<SendFundsAccountsListProps> = ({
   selected,
   accounts,
+  noFormat,
+  genesisHash,
   onSelect,
   header,
   allowZeroBalance,
@@ -173,6 +189,8 @@ export const SendFundsAccountsList: FC<SendFundsAccountsListProps> = ({
           selected={account.address === selected}
           key={account.address}
           account={account}
+          genesisHash={genesisHash}
+          noFormat={noFormat}
           onClick={handleAccountClick(account.address)}
           showBalances={showBalances}
           token={token}

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsRecipientPicker.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsRecipientPicker.tsx
@@ -194,6 +194,7 @@ export const SendFundsRecipientPicker = () => {
           <SendFundsAccountsList
             allowZeroBalance
             accounts={newAddresses}
+            noFormat // preserve user input chain format
             selected={to}
             onSelect={handleSelect}
           />
@@ -201,6 +202,7 @@ export const SendFundsRecipientPicker = () => {
         <SendFundsAccountsList
           allowZeroBalance
           accounts={contacts}
+          genesisHash={chain?.genesisHash}
           selected={to}
           onSelect={handleSelect}
           header={
@@ -213,6 +215,7 @@ export const SendFundsRecipientPicker = () => {
         <SendFundsAccountsList
           allowZeroBalance
           accounts={myAccounts}
+          genesisHash={chain?.genesisHash}
           selected={to}
           onSelect={handleSelect}
           header={
@@ -228,6 +231,7 @@ export const SendFundsRecipientPicker = () => {
         <SendFundsAccountsList
           allowZeroBalance
           accounts={watchedAccounts}
+          genesisHash={chain?.genesisHash}
           selected={to}
           onSelect={handleSelect}
           header={

--- a/apps/extension/src/ui/domains/SendFunds/useGenesisHashFromTokenId.ts
+++ b/apps/extension/src/ui/domains/SendFunds/useGenesisHashFromTokenId.ts
@@ -1,0 +1,8 @@
+import useChain from "@ui/hooks/useChain"
+import useToken from "@ui/hooks/useToken"
+
+export const useGenesisHashFromTokenId = (tokenId?: string | null) => {
+  const token = useToken(tokenId)
+  const chain = useChain(token?.chain?.id)
+  return chain?.genesisHash
+}


### PR DESCRIPTION
fixes address format in send funds wizard : 
- use selected token's chain's prefix for formatting addresses in account pickers & pills
- for the recipient do not display token's chain's format if address has been manually input, except in the confirm form address tooltip (allows visual confirmation that the address is the intended one)
- in the confirm form address tooltip, do not show original format for talisman accounts, only display the token's chain's address format