### PR TITLE
fix: prevent useOnChainId unnecessary refreshes

### DIFF
--- a/apps/extension/src/ui/hooks/useOnChainId.ts
+++ b/apps/extension/src/ui/hooks/useOnChainId.ts
@@ -12,6 +12,10 @@ export const useOnChainId = (address?: string) => {
     },
     enabled: !!address,
     cacheTime: Infinity,
+    refetchInterval: false,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
     initialData: () => address && onChainIdsCache.get(address)?.onChainId,
     onSuccess: (onChainId) => {
       if (!address) return


### PR DESCRIPTION
Prevents useOnChainId(address) from refetching data each time it's called

test case : navigate back & forth between popup home page and one account's page