### PR TITLE
Open send funds from portfolio asset page with token search prefilled with symbol

### DIFF
--- a/apps/extension/src/@talisman/components/SearchInput.tsx
+++ b/apps/extension/src/@talisman/components/SearchInput.tsx
@@ -24,6 +24,7 @@ type SearchInputProps = {
   containerClassName?: string
   autoFocus?: boolean
   placeholder?: string
+  initialValue?: string
   after?: ReactNode
   onChange?: (search: string) => void
   onValidate?: () => void
@@ -35,12 +36,13 @@ export const SearchInput: FC<SearchInputProps> = ({
   small,
   autoFocus,
   placeholder,
+  initialValue,
   after,
   onChange,
   onValidate,
 }) => {
   const ref = useRef<HTMLInputElement>(null)
-  const [search, setSearch] = useDebouncedState("", 200)
+  const [search, setSearch] = useDebouncedState(initialValue ?? "", 200)
 
   const handleSearchChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     (e) => {
@@ -82,6 +84,7 @@ export const SearchInput: FC<SearchInputProps> = ({
       containerProps={containerProps}
       before={<SearchIcon className="text-body-disabled shrink-0" />}
       after={after}
+      defaultValue={initialValue}
       placeholder={placeholder}
       onChange={handleSearchChange}
       onKeyUp={handleKeyUp}

--- a/apps/extension/src/core/domains/app/handler.ts
+++ b/apps/extension/src/core/domains/app/handler.ts
@@ -177,10 +177,17 @@ export default class AppHandler extends ExtensionHandler {
     return true
   }
 
-  private async openSendFunds({ from, tokenId, to }: SendFundsOpenRequest): Promise<boolean> {
+  private async openSendFunds({
+    from,
+    tokenId,
+    tokenSymbol,
+    to,
+  }: SendFundsOpenRequest): Promise<boolean> {
     const params = new URLSearchParams()
     if (from) params.append("from", from)
     if (tokenId) params.append("tokenId", tokenId)
+    // tokenId takes precedence over tokenSymbol
+    if (!tokenId && tokenSymbol) params.append("tokenSymbol", tokenSymbol)
     if (to) params.append("to", to)
     await windowManager.popupOpen(`#/send?${params.toString()}`)
 

--- a/apps/extension/src/core/domains/app/types.ts
+++ b/apps/extension/src/core/domains/app/types.ts
@@ -20,7 +20,12 @@ export type ModalOpenRequestBuy = {
   modalType: "buy"
 }
 export type ModalOpenRequest = ModalOpenRequestBuy
-export type SendFundsOpenRequest = { from?: Address; tokenId?: TokenId; to?: Address }
+export type SendFundsOpenRequest = {
+  from?: Address
+  tokenId?: TokenId
+  tokenSymbol?: string
+  to?: Address
+}
 
 export interface AnalyticsCaptureRequest {
   eventName: string

--- a/apps/extension/src/ui/apps/dashboard/routes/Portfolio/PortfolioAsset.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Portfolio/PortfolioAsset.tsx
@@ -26,7 +26,11 @@ const PageContent = ({ balances, symbol }: { balances: Balances; symbol: string 
   const { account } = useSelectedAccount()
 
   // don't set the token id here because it could be one of many
-  const { canSendFunds, cannotSendFundsReason, openSendFundsPopup } = useSendFundsPopup(account)
+  const { canSendFunds, cannotSendFundsReason, openSendFundsPopup } = useSendFundsPopup(
+    account,
+    undefined,
+    symbol
+  )
 
   const handleCopyAddressClick = useCallback(() => {
     openCopyAddressModal({ mode: "copy", address: account?.address })

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/AddressBookPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/AddressBookPage.tsx
@@ -79,6 +79,7 @@ const AddressBookContactItem = ({ contact, handleDelete, handleEdit }: ContactIt
   const { canSendFunds, cannotSendFundsReason, openSendFundsPopup } = useSendFundsPopup(
     account,
     undefined,
+    undefined,
     contact.address
   )
 

--- a/apps/extension/src/ui/apps/popup/pages/SendFunds/context.ts
+++ b/apps/extension/src/ui/apps/popup/pages/SendFunds/context.ts
@@ -23,11 +23,12 @@ const useSendFundsWizardProvider = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
 
-  const { from, to, tokenId, amount, allowReap, sendMax } = useMemo(
+  const { from, to, tokenId, amount, allowReap, sendMax, tokenSymbol } = useMemo(
     () => ({
       from: searchParams.get("from") ?? undefined,
       to: searchParams.get("to") ?? undefined,
       tokenId: searchParams.get("tokenId") ?? undefined,
+      tokenSymbol: searchParams.get("tokenSymbol") ?? undefined,
       amount: searchParams.get("amount") ?? undefined,
       allowReap: searchParams.get("allowReap") !== null,
       sendMax: searchParams.get("sendMax") !== null,
@@ -123,6 +124,7 @@ const useSendFundsWizardProvider = () => {
     from,
     to,
     tokenId,
+    tokenSymbol,
     amount,
     allowReap,
     sendMax,

--- a/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
+++ b/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
@@ -375,6 +375,7 @@ const TokensList: FC<TokensListProps> = ({
 type TokenPickerProps = {
   address?: string
   selected?: TokenId
+  initialSearch?: string
   showEmptyBalances?: boolean
   allowUntransferable?: boolean
   ownedOnly?: boolean
@@ -386,6 +387,7 @@ type TokenPickerProps = {
 export const TokenPicker: FC<TokenPickerProps> = ({
   address,
   selected,
+  initialSearch = "",
   showEmptyBalances,
   allowUntransferable,
   ownedOnly,
@@ -394,7 +396,7 @@ export const TokenPicker: FC<TokenPickerProps> = ({
   onSelect,
 }) => {
   const { t } = useTranslation()
-  const [search, setSearch] = useState("")
+  const [search, setSearch] = useState(initialSearch)
 
   return (
     <div
@@ -404,8 +406,9 @@ export const TokenPicker: FC<TokenPickerProps> = ({
         <SearchInput
           onChange={setSearch}
           placeholder={t("Search by token or network name")}
+          initialValue={initialSearch}
           // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus
+          autoFocus={!initialSearch}
         />
       </div>
       <ScrollContainer className="bg-black-secondary border-grey-700 scrollable h-full w-full grow overflow-x-hidden border-t">

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsTokenPicker.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsTokenPicker.tsx
@@ -5,7 +5,7 @@ import { useCallback } from "react"
 import { TokenPicker } from "../Asset/TokenPicker"
 
 export const SendFundsTokenPicker = () => {
-  const { from, tokenId, set } = useSendFundsWizard()
+  const { from, tokenId, tokenSymbol, set } = useSendFundsWizard()
 
   const handleTokenSelect = useCallback(
     (tokenId: TokenId) => {
@@ -14,5 +14,13 @@ export const SendFundsTokenPicker = () => {
     [set]
   )
 
-  return <TokenPicker ownedOnly address={from} selected={tokenId} onSelect={handleTokenSelect} />
+  return (
+    <TokenPicker
+      ownedOnly
+      address={from}
+      initialSearch={tokenSymbol}
+      selected={tokenId}
+      onSelect={handleTokenSelect}
+    />
+  )
 }

--- a/apps/extension/src/ui/hooks/useSendFundsPopup.ts
+++ b/apps/extension/src/ui/hooks/useSendFundsPopup.ts
@@ -17,6 +17,7 @@ const isCompatibleAddress = (from: Address, to: Address) => {
 export const useSendFundsPopup = (
   account: AccountJsonAny | undefined,
   tokenId?: TokenId,
+  tokenSymbol?: string,
   to?: Address
 ) => {
   const { t } = useTranslation()
@@ -64,8 +65,8 @@ export const useSendFundsPopup = (
 
   const openSendFundsPopup = useCallback(() => {
     if (!canSendFunds) return
-    api.sendFundsOpen({ from: account?.address, tokenId, to })
-  }, [account?.address, canSendFunds, to, tokenId])
+    api.sendFundsOpen({ from: account?.address, tokenId, tokenSymbol, to })
+  }, [account?.address, canSendFunds, to, tokenId, tokenSymbol])
 
   return { canSendFunds, cannotSendFundsReason, openSendFundsPopup }
 }


### PR DESCRIPTION
Uses the token symbol as the initial search input for the token picker when 'send funds' is selected from the button at the top of the portfolio asset detail page.