### PR TITLE
feat: networks and tokens opt-in enhancements

### DIFF
--- a/apps/extension/src/core/domains/balances/handler.ts
+++ b/apps/extension/src/core/domains/balances/handler.ts
@@ -1,6 +1,8 @@
 import { DEBUG } from "@core/constants"
 import { getNomPoolStake } from "@core/domains/balances/helpers"
 import {
+  AddressesAndEvmNetwork,
+  AddressesAndTokens,
   Balances,
   RequestBalance,
   RequestBalancesByParamsSubscribe,
@@ -10,14 +12,21 @@ import { createSubscription, unsubscribe } from "@core/handlers/subscriptions"
 import { ExtensionHandler } from "@core/libs/Handler"
 import { balanceModules } from "@core/rpcs/balance-modules"
 import { chaindataProvider } from "@core/rpcs/chaindata"
-import { Port } from "@core/types/base"
-import { AddressesByToken } from "@talismn/balances"
-import { Token } from "@talismn/chaindata-provider"
+import { AddressesByChain, Port } from "@core/types/base"
+import { AddressesByToken, MiniMetadata, UnsubscribeFn, db as balancesDb } from "@talismn/balances"
+import { ChainId, ChainList, EvmNetworkList, Token, TokenList } from "@talismn/chaindata-provider"
 import { MessageTypes, RequestTypes, ResponseType } from "core/types"
+import { liveQuery } from "dexie"
+import { isEqual } from "lodash"
+import { BehaviorSubject, combineLatest } from "rxjs"
 
-import { enabledChainsStore, isChainEnabled } from "../chains/store.enabledChains"
-import { enabledEvmNetworksStore, isEvmNetworkEnabled } from "../ethereum/store.enabledEvmNetworks"
-import { enabledTokensStore, isTokenEnabled } from "../tokens/store.enabledTokens"
+import { EnabledChains, enabledChainsStore, isChainEnabled } from "../chains/store.enabledChains"
+import {
+  EnabledEvmNetworks,
+  enabledEvmNetworksStore,
+  isEvmNetworkEnabled,
+} from "../ethereum/store.enabledEvmNetworks"
+import { EnabledTokens, enabledTokensStore, isTokenEnabled } from "../tokens/store.enabledTokens"
 
 export class BalancesHandler extends ExtensionHandler {
   public async handle<TMessageType extends MessageTypes>(
@@ -42,119 +51,198 @@ export class BalancesHandler extends ExtensionHandler {
       // TODO: Replace this call with something internal to the balances store
       // i.e. refactor the balances store to allow us to subscribe to arbitrary balances here,
       // instead of being limited to the accounts which are in the wallet's keystore
-      case "pri(balances.byparams.subscribe)": {
-        // create subscription callback
-        const callback = createSubscription<"pri(balances.byparams.subscribe)">(id, port)
-
-        const { addressesByChain, addressesAndEvmNetworks, addressesAndTokens } =
-          request as RequestBalancesByParamsSubscribe
-
-        //
-        // Collect the required data from chaindata.
-        //
-
-        const [chains, evmNetworks, tokens, enabledTokens, enabledChains, enabledEvmNetworks] =
-          await Promise.all([
-            chaindataProvider.chains(),
-            chaindataProvider.evmNetworks(),
-            chaindataProvider.tokens(),
-            enabledTokensStore.get(),
-            enabledChainsStore.get(),
-            enabledEvmNetworksStore.get(),
-          ])
-
-        //
-        // Convert the inputs of `addressesByChain` and `addressesAndEvmNetworks` into what we need
-        // for each balance module: `addressesByToken`.
-        //
-
-        const addressesByToken: AddressesByToken<Token> = [
-          ...Object.entries(addressesByChain)
-            // convert chainIds into chains
-            .map(([chainId, addresses]) => [chains[chainId], addresses] as const)
-            .filter(([chain]) => isChainEnabled(chain, enabledChains)),
-
-          ...addressesAndEvmNetworks.evmNetworks
-            // convert evmNetworkIds into evmNetworks
-            .map(({ id }) => [evmNetworks[id], addressesAndEvmNetworks.addresses] as const)
-            .filter(([evmNetwork]) => isEvmNetworkEnabled(evmNetwork, enabledEvmNetworks)),
-        ]
-          // filter out requested chains/evmNetworks which don't exist
-          .filter(([chainOrNetwork]) => chainOrNetwork !== undefined)
-          // filter out requested chains/evmNetworks which have no rpcs
-          .filter(([chainOrNetwork]) => (chainOrNetwork.rpcs?.length ?? 0) > 0)
-
-          // convert chains and evmNetworks into a list of tokenIds
-          .flatMap(([chainOrNetwork, addresses]) =>
-            Object.values(tokens)
-              .filter(
-                (t) => t.chain?.id === chainOrNetwork.id || t.evmNetwork?.id === chainOrNetwork.id
-              )
-              .filter((t) => isTokenEnabled(t, enabledTokens))
-              .map((t) => [t.id, addresses] as const)
-          )
-
-          // collect all of the addresses for each tokenId into a map of { [tokenId]: addresses }
-          .reduce((addressesByToken, [tokenId, addresses]) => {
-            if (!addressesByToken[tokenId]) addressesByToken[tokenId] = []
-            addressesByToken[tokenId].push(...addresses)
-            return addressesByToken
-          }, {} as AddressesByToken<Token>)
-
-        for (const tokenId of addressesAndTokens.tokenIds) {
-          if (!addressesByToken[tokenId]) addressesByToken[tokenId] = []
-          addressesByToken[tokenId].push(
-            ...addressesAndTokens.addresses.filter((a) => !addressesByToken[tokenId].includes(a))
-          )
-        }
-
-        //
-        // Separate out the tokens in `addressesByToken` into groups based on `token.type`
-        // Input:  {                 [token.id]: addresses,                    [token2.id]: addresses   }
-        // Output: { [token.type]: { [token.id]: addresses }, [token2.type]: { [token2.id]: addresses } }
-        //
-        // This lets us only send each token to the balance module responsible for querying its balance.
-        //
-
-        const addressesByTokenByModule: Record<string, AddressesByToken<Token>> = [
-          ...Object.entries(addressesByToken)
-            // convert tokenIds into tokens
-            .map(([tokenId, addresses]) => [tokens[tokenId], addresses] as const),
-        ]
-          // filter out tokens which don't exist
-          .filter(([token]) => !!token)
-
-          // group each `{ [token.id]: addresses }` by token.type
-          .reduce((byModule, [token, addresses]) => {
-            if (!byModule[token.type]) byModule[token.type] = {}
-            byModule[token.type][token.id] = addresses
-            return byModule
-          }, {} as Record<string, AddressesByToken<Token>>)
-
-        // subscribe to balances by params
-        const closeSubscriptionCallbacks = balanceModules.map((balanceModule) =>
-          balanceModule.subscribeBalances(
-            addressesByTokenByModule[balanceModule.type] ?? {},
-            (error, result) => {
-              // eslint-disable-next-line no-console
-              if (error) DEBUG && console.error(error)
-              else callback({ type: "upsert", balances: (result ?? new Balances([])).toJSON() })
-            }
-          )
-        )
-
-        // unsub on port disconnect
-        port.onDisconnect.addListener((): void => {
-          unsubscribe(id)
-          closeSubscriptionCallbacks.forEach((cb) => cb.then((close) => close()))
-        })
-
-        // subscription created
-        return true
-      }
+      case "pri(balances.byparams.subscribe)":
+        return subscribeBalancesByParams(id, port, request as RequestBalancesByParamsSubscribe)
 
       default:
         throw new Error(`Unable to handle message of type ${type}`)
     }
+  }
+}
+
+type BalanceSubscriptionParams = {
+  addressesByTokenByModule: Record<string, AddressesByToken<Token>>
+  miniMetadataIds: string[]
+}
+
+const subscribeBalancesByParams = async (
+  id: string,
+  port: Port,
+  request: RequestBalancesByParamsSubscribe
+): Promise<boolean> => {
+  const { addressesByChain, addressesAndEvmNetworks, addressesAndTokens } =
+    request as RequestBalancesByParamsSubscribe
+
+  // create subscription callback
+  const callback = createSubscription<"pri(balances.byparams.subscribe)">(id, port)
+
+  const obsSubscriptionParams = new BehaviorSubject<BalanceSubscriptionParams>({
+    addressesByTokenByModule: {},
+    miniMetadataIds: [],
+  })
+
+  let closeSubscriptionCallbacks: Promise<UnsubscribeFn>[] = []
+
+  // watch for changes to all stores, mainly important for onboarding as they start empty
+  combineLatest([
+    // chains
+    liveQuery(async () => await chaindataProvider.chains()),
+    // evmNetworks
+    liveQuery(async () => await chaindataProvider.evmNetworks()),
+    // tokens
+    liveQuery(async () => await chaindataProvider.tokens()),
+    // miniMetadatas - not used here but we must retrigger the subscription when this changes
+    liveQuery(async () => await balancesDb.miniMetadatas.toArray()),
+    // enabled state of evm networks
+    enabledEvmNetworksStore.observable,
+    // enabled state of substrate chains
+    enabledChainsStore.observable,
+    // enable state of tokens
+    enabledTokensStore.observable,
+  ]).subscribe({
+    next: async ([
+      chains,
+      evmNetworks,
+      tokens,
+      miniMetadatas,
+      enabledEvmNetworks,
+      enabledChains,
+      enabledTokens,
+    ]) => {
+      const newSubscriptionParams = getSubscriptionParams(
+        addressesByChain,
+        addressesAndEvmNetworks,
+        addressesAndTokens,
+        chains,
+        evmNetworks,
+        tokens,
+        enabledChains,
+        enabledEvmNetworks,
+        enabledTokens,
+        miniMetadatas
+      )
+
+      // restart subscription only if params change
+      if (!isEqual(obsSubscriptionParams.value, newSubscriptionParams))
+        obsSubscriptionParams.next(newSubscriptionParams)
+    },
+  })
+
+  // restart subscriptions each type params update
+  obsSubscriptionParams.subscribe(async ({ addressesByTokenByModule }) => {
+    // close previous subscriptions
+    await Promise.all(closeSubscriptionCallbacks)
+
+    // subscribe to balances by params
+    closeSubscriptionCallbacks = balanceModules.map((balanceModule) =>
+      balanceModule.subscribeBalances(
+        addressesByTokenByModule[balanceModule.type] ?? {},
+        (error, result) => {
+          // eslint-disable-next-line no-console
+          if (error) DEBUG && console.error(error)
+          else callback({ type: "upsert", balances: (result ?? new Balances([])).toJSON() })
+        }
+      )
+    )
+  })
+
+  // unsub on port disconnect
+  port.onDisconnect.addListener((): void => {
+    unsubscribe(id)
+    closeSubscriptionCallbacks.forEach((cb) => cb.then((close) => close()))
+  })
+
+  // subscription created
+  return true
+}
+
+const getSubscriptionParams = (
+  addressesByChain: AddressesByChain,
+  addressesAndEvmNetworks: AddressesAndEvmNetwork,
+  addressesAndTokens: AddressesAndTokens,
+  chains: ChainList,
+  evmNetworks: EvmNetworkList,
+  tokens: TokenList,
+  enabledChains: EnabledChains,
+  enabledEvmNetworks: EnabledEvmNetworks,
+  enabledTokens: EnabledTokens,
+  miniMetadatas: MiniMetadata[]
+): BalanceSubscriptionParams => {
+  //
+  // Convert the inputs of `addressesByChain` and `addressesAndEvmNetworks` into what we need
+  // for each balance module: `addressesByToken`.
+  //
+  const addressesByToken: AddressesByToken<Token> = [
+    ...Object.entries(addressesByChain)
+      // convert chainIds into chains
+      .map(([chainId, addresses]) => [chains[chainId], addresses] as const)
+      .filter(([chain]) => isChainEnabled(chain, enabledChains)),
+
+    ...addressesAndEvmNetworks.evmNetworks
+      // convert evmNetworkIds into evmNetworks
+      .map(({ id }) => [evmNetworks[id], addressesAndEvmNetworks.addresses] as const)
+      .filter(([evmNetwork]) => isEvmNetworkEnabled(evmNetwork, enabledEvmNetworks)),
+  ]
+    // filter out requested chains/evmNetworks which don't exist
+    .filter(([chainOrNetwork]) => chainOrNetwork !== undefined)
+    // filter out requested chains/evmNetworks which have no rpcs
+    .filter(([chainOrNetwork]) => (chainOrNetwork.rpcs?.length ?? 0) > 0)
+
+    // convert chains and evmNetworks into a list of tokenIds
+    .flatMap(([chainOrNetwork, addresses]) =>
+      Object.values(tokens)
+        .filter((t) => t.chain?.id === chainOrNetwork.id || t.evmNetwork?.id === chainOrNetwork.id)
+        .filter((t) => isTokenEnabled(t, enabledTokens))
+        .map((t) => [t.id, addresses] as const)
+    )
+
+    // collect all of the addresses for each tokenId into a map of { [tokenId]: addresses }
+    .reduce((addressesByToken, [tokenId, addresses]) => {
+      if (!addressesByToken[tokenId]) addressesByToken[tokenId] = []
+      addressesByToken[tokenId].push(...addresses)
+      return addressesByToken
+    }, {} as AddressesByToken<Token>)
+
+  for (const tokenId of addressesAndTokens.tokenIds) {
+    if (!addressesByToken[tokenId]) addressesByToken[tokenId] = []
+    addressesByToken[tokenId].push(
+      ...addressesAndTokens.addresses.filter((a) => !addressesByToken[tokenId].includes(a))
+    )
+  }
+
+  //
+  // Separate out the tokens in `addressesByToken` into groups based on `token.type`
+  // Input:  {                 [token.id]: addresses,                    [token2.id]: addresses   }
+  // Output: { [token.type]: { [token.id]: addresses }, [token2.type]: { [token2.id]: addresses } }
+  //
+  // This lets us only send each token to the balance module responsible for querying its balance.
+  //
+  const addressesByTokenByModule: Record<string, AddressesByToken<Token>> = [
+    ...Object.entries(addressesByToken)
+      // convert tokenIds into tokens
+      .map(([tokenId, addresses]) => [tokens[tokenId], addresses] as const),
+  ]
+    // filter out tokens which don't exist
+    .filter(([token]) => !!token)
+
+    // group each `{ [token.id]: addresses }` by token.type
+    .reduce((byModule, [token, addresses]) => {
+      if (!byModule[token.type]) byModule[token.type] = {}
+      byModule[token.type][token.id] = addresses
+      return byModule
+    }, {} as Record<string, AddressesByToken<Token>>)
+
+  const chainIds = Object.keys(addressesByChain).concat(
+    ...addressesAndTokens.tokenIds.map((tid) => tokens[tid].chain?.id as ChainId).filter(Boolean)
+  )
+
+  // this restarts subscription if metadata changes for any of the chains we subscribe to
+  const miniMetadataIds = miniMetadatas
+    .filter((mm) => chainIds.includes(mm.chainId))
+    .map((m) => m.id)
+
+  return {
+    addressesByTokenByModule,
+    miniMetadataIds,
   }
 }

--- a/apps/extension/src/core/domains/balances/handler.ts
+++ b/apps/extension/src/core/domains/balances/handler.ts
@@ -8,6 +8,21 @@ import {
   RequestBalancesByParamsSubscribe,
   RequestNomPoolStake,
 } from "@core/domains/balances/types"
+import {
+  EnabledChains,
+  enabledChainsStore,
+  isChainEnabled,
+} from "@core/domains/chains/store.enabledChains"
+import {
+  EnabledEvmNetworks,
+  enabledEvmNetworksStore,
+  isEvmNetworkEnabled,
+} from "@core/domains/ethereum/store.enabledEvmNetworks"
+import {
+  EnabledTokens,
+  enabledTokensStore,
+  isTokenEnabled,
+} from "@core/domains/tokens/store.enabledTokens"
 import { createSubscription, unsubscribe } from "@core/handlers/subscriptions"
 import { ExtensionHandler } from "@core/libs/Handler"
 import { balanceModules } from "@core/rpcs/balance-modules"
@@ -19,14 +34,6 @@ import { MessageTypes, RequestTypes, ResponseType } from "core/types"
 import { liveQuery } from "dexie"
 import { isEqual } from "lodash"
 import { BehaviorSubject, combineLatest } from "rxjs"
-
-import { EnabledChains, enabledChainsStore, isChainEnabled } from "../chains/store.enabledChains"
-import {
-  EnabledEvmNetworks,
-  enabledEvmNetworksStore,
-  isEvmNetworkEnabled,
-} from "../ethereum/store.enabledEvmNetworks"
-import { EnabledTokens, enabledTokensStore, isTokenEnabled } from "../tokens/store.enabledTokens"
 
 export class BalancesHandler extends ExtensionHandler {
   public async handle<TMessageType extends MessageTypes>(

--- a/apps/extension/src/core/domains/balances/handler.ts
+++ b/apps/extension/src/core/domains/balances/handler.ts
@@ -107,7 +107,7 @@ export class BalancesHandler extends ExtensionHandler {
             .map(([tokenId, addresses]) => [tokens[tokenId], addresses] as const),
         ]
           // filter out tokens which don't exist
-          .filter(([token]) => token !== undefined && token.isDefault !== false) // TODO filter based on if token is enabled
+          .filter(([token]) => !!token)
 
           // group each `{ [token.id]: addresses }` by token.type
           .reduce((byModule, [token, addresses]) => {

--- a/apps/extension/src/core/domains/balances/store.ts
+++ b/apps/extension/src/core/domains/balances/store.ts
@@ -461,10 +461,7 @@ export class BalanceStore {
 
     if (missingBalances.length) {
       const updates = Object.entries(new Balances(missingBalances).toJSON()).map(
-        ([id, balance]) => ({
-          id,
-          ...balance,
-        })
+        ([id, balance]) => ({ id, ...balance })
       )
       await balancesDb.balances.bulkPut(updates)
     }

--- a/apps/extension/src/core/domains/balances/store.ts
+++ b/apps/extension/src/core/domains/balances/store.ts
@@ -464,7 +464,6 @@ export class BalanceStore {
         ([id, balance]) => ({
           id,
           ...balance,
-          status: BalanceStatusLive(subscriptionId),
         })
       )
       await balancesDb.balances.bulkPut(updates)

--- a/apps/extension/src/core/domains/balances/store.ts
+++ b/apps/extension/src/core/domains/balances/store.ts
@@ -449,12 +449,13 @@ export class BalanceStore {
     // create placeholder rows for all missing balances, so FE knows they are initializing
     const missingBalances: BalanceJson[] = []
     const existingBalances = await balancesDb.balances.toArray()
+    const existingBalancesKeys = new Set(existingBalances.map((b) => `${b.tokenId}:${b.address}`))
 
     for (const balanceModule of balanceModules) {
       const addressesByToken = addressesByTokenByModule[balanceModule.type] ?? {}
       for (const [tokenId, addresses] of Object.entries(addressesByToken))
         for (const address of addresses) {
-          if (!existingBalances.find((b) => b.address === address && b.tokenId === tokenId))
+          if (!existingBalancesKeys.has(`${tokenId}:${address}`))
             missingBalances.push(balanceModule.getPlaceholderBalance(tokenId, address))
         }
     }

--- a/apps/extension/src/core/domains/tokenRates/store.ts
+++ b/apps/extension/src/core/domains/tokenRates/store.ts
@@ -1,4 +1,5 @@
 import { db } from "@core/db"
+import { enabledTokensStore, filterEnabledTokens } from "@core/domains/tokens/store.enabledTokens"
 import { unsubscribe } from "@core/handlers/subscriptions"
 import { log } from "@core/log"
 import { chaindataProvider } from "@core/rpcs/chaindata"
@@ -8,8 +9,6 @@ import { fetchTokenRates } from "@talismn/token-rates"
 import { Subscription, liveQuery } from "dexie"
 import debounce from "lodash/debounce"
 import { BehaviorSubject, combineLatest } from "rxjs"
-
-import { enabledTokensStore, filterEnabledTokens } from "../tokens/store.enabledTokens"
 
 const MIN_REFRESH_INTERVAL = 60_000 // 60_000ms = 60s = 1 minute
 const REFRESH_INTERVAL = 300_000 // 5 minutes

--- a/apps/extension/src/core/domains/tokenRates/store.ts
+++ b/apps/extension/src/core/domains/tokenRates/store.ts
@@ -89,7 +89,9 @@ export class TokenRatesStore {
     }
   }
 
-  // warning : make sure the tokens list only includes enabled tokens
+  /**
+   * WARNING: Make sure the tokens list `tokens` only includes enabled tokens.
+   */
   private async updateTokenRates(tokens: TokenList): Promise<void> {
     const now = Date.now()
     const strTokenIds = Object.keys(tokens ?? {}).join(",")

--- a/apps/extension/src/core/domains/tokens/store.enabledTokens.ts
+++ b/apps/extension/src/core/domains/tokens/store.enabledTokens.ts
@@ -1,5 +1,5 @@
 import { StorageProvider } from "@core/libs/Store"
-import { Token, TokenId } from "@talismn/chaindata-provider"
+import { Token, TokenId, TokenList } from "@talismn/chaindata-provider"
 
 import { CustomErc20Token, CustomEvmNativeToken, CustomNativeToken } from "./types"
 
@@ -38,4 +38,10 @@ export const isTokenEnabled = (
   enabledTokens: EnabledTokens
 ) => {
   return enabledTokens[token.id] ?? (isCustomToken(token) || token.isDefault)
+}
+
+export const filterEnabledTokens = (tokens: TokenList, enabledTokens: EnabledTokens) => {
+  return Object.fromEntries(
+    Object.entries(tokens).filter(([, token]) => isTokenEnabled(token as Token, enabledTokens))
+  ) as TokenList
 }

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/ChainsList.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/ChainsList.tsx
@@ -1,6 +1,7 @@
 import { enabledChainsStore, isChainEnabled } from "@core/domains/chains/store.enabledChains"
 import { Chain, isCustomChain } from "@talismn/chaindata-provider"
 import { ChevronRightIcon } from "@talismn/icons"
+import { classNames } from "@talismn/util"
 import { sendAnalyticsEvent } from "@ui/api/analytics"
 import { ChainLogo } from "@ui/domains/Asset/ChainLogo"
 import useChains from "@ui/hooks/useChains"
@@ -69,16 +70,21 @@ export const ChainsList = ({ search }: { search?: string }) => {
   const enableAll = useCallback(
     (enable = false) =>
       () => {
-        enabledChainsStore.set(Object.fromEntries(chains.map((n) => [n.id, enable])))
+        enabledChainsStore.set(Object.fromEntries(filteredChains.map((n) => [n.id, enable])))
       },
-    [chains]
+    [filteredChains]
   )
 
   if (!sortedChains) return null
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex w-full items-center justify-end gap-4">
+      <div
+        className={classNames(
+          "flex w-full items-center justify-end gap-4",
+          !filteredChains.length && "invisible"
+        )}
+      >
         <button
           type="button"
           onClick={enableAll(true)}

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/ChainsList.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/ChainsList.tsx
@@ -8,6 +8,7 @@ import { useEnabledChainsState } from "@ui/hooks/useEnabledChainsState"
 import { useSetting } from "@ui/hooks/useSettings"
 import sortBy from "lodash/sortBy"
 import { ChangeEventHandler, useCallback, useMemo, useRef } from "react"
+import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useIntersection } from "react-use"
 import { ListButton, Toggle } from "talisman-ui"
@@ -16,6 +17,7 @@ import { ANALYTICS_PAGE } from "./analytics"
 import { CustomPill, TestnetPill } from "./Pills"
 
 export const ChainsList = ({ search }: { search?: string }) => {
+  const { t } = useTranslation("admin")
   const [useTestnets] = useSetting("useTestnets")
   const { chains: allChains } = useChains("all")
   const chains = useMemo(
@@ -64,10 +66,35 @@ export const ChainsList = ({ search }: { search?: string }) => {
     []
   )
 
+  const enableAll = useCallback(
+    (enable = false) =>
+      () => {
+        enabledChainsStore.set(Object.fromEntries(chains.map((n) => [n.id, enable])))
+      },
+    [chains]
+  )
+
   if (!sortedChains) return null
 
   return (
     <div className="flex flex-col gap-4">
+      <div className="flex w-full items-center justify-end gap-4">
+        <button
+          type="button"
+          onClick={enableAll(true)}
+          className="text-body-disabled hover:text-body-secondary text-xs"
+        >
+          {t("Enable all")}
+        </button>
+        <div className="bg-body-disabled h-6 w-0.5"></div>
+        <button
+          type="button"
+          onClick={enableAll(false)}
+          className="text-body-disabled hover:text-body-secondary text-xs"
+        >
+          {t("Disable all")}
+        </button>
+      </div>
       {sortedChains.map((chain) => (
         <ChainsListItem
           key={chain.id}

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/EvmNetworksList.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/EvmNetworksList.tsx
@@ -5,6 +5,7 @@ import {
 import { EvmNetwork } from "@core/domains/ethereum/types"
 import { isCustomEvmNetwork } from "@talismn/chaindata-provider"
 import { ChevronRightIcon } from "@talismn/icons"
+import { classNames } from "@talismn/util"
 import { sendAnalyticsEvent } from "@ui/api/analytics"
 import { ChainLogo } from "@ui/domains/Asset/ChainLogo"
 import { useEnabledEvmNetworksState } from "@ui/hooks/useEnabledEvmNetworksState"
@@ -12,6 +13,7 @@ import { useEvmNetworks } from "@ui/hooks/useEvmNetworks"
 import { useSetting } from "@ui/hooks/useSettings"
 import sortBy from "lodash/sortBy"
 import { ChangeEventHandler, useCallback, useMemo, useRef } from "react"
+import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useIntersection } from "react-use"
 import { ListButton, Toggle } from "talisman-ui"
@@ -20,6 +22,8 @@ import { ANALYTICS_PAGE } from "./analytics"
 import { CustomPill, TestnetPill } from "./Pills"
 
 export const EvmNetworksList = ({ search }: { search?: string }) => {
+  const { t } = useTranslation("admin")
+
   const [useTestnets] = useSetting("useTestnets")
   const { evmNetworks: allEvmNetworks } = useEvmNetworks("all")
   const evmNetworks = useMemo(
@@ -77,10 +81,42 @@ export const EvmNetworksList = ({ search }: { search?: string }) => {
     []
   )
 
+  const enableAll = useCallback(
+    (enable = false) =>
+      () => {
+        enabledEvmNetworksStore.set(
+          Object.fromEntries(filteredEvmNetworks.map((n) => [n.id, enable]))
+        )
+      },
+    [filteredEvmNetworks]
+  )
+
   if (!sortedNetworks) return null
 
   return (
     <div className="flex flex-col gap-4">
+      <div
+        className={classNames(
+          "flex w-full items-center justify-end gap-4",
+          !filteredEvmNetworks.length && "invisible"
+        )}
+      >
+        <button
+          type="button"
+          onClick={enableAll(true)}
+          className="text-body-disabled hover:text-body-secondary text-xs"
+        >
+          {t("Enable all")}
+        </button>
+        <div className="bg-body-disabled h-6 w-0.5"></div>
+        <button
+          type="button"
+          onClick={enableAll(false)}
+          className="text-body-disabled hover:text-body-secondary text-xs"
+        >
+          {t("Disable all")}
+        </button>
+      </div>
       {sortedNetworks.map((network) => (
         <EvmNetworksListItem
           key={network.id}

--- a/apps/extension/src/ui/apps/dashboard/routes/Portfolio/PortfolioAssets.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Portfolio/PortfolioAssets.tsx
@@ -16,18 +16,17 @@ import { NoAccountsFullscreen } from "./NoAccounts"
 
 const FullscreenPortfolioAssets = ({ balances }: { balances: Balances }) => {
   const { t } = useTranslation()
-  const balancesToDisplay = useDisplayBalances(balances)
 
   const currency = useSelectedCurrency()
 
   const { portfolio, available, locked } = useMemo(() => {
-    const { total, frozen, reserved, transferable } = balancesToDisplay.sum.fiat(currency)
+    const { total, frozen, reserved, transferable } = balances.sum.fiat(currency)
     return {
       portfolio: total,
       available: transferable,
       locked: frozen + reserved,
     }
-  }, [balancesToDisplay.sum, currency])
+  }, [balances.sum, currency])
 
   return (
     <>
@@ -45,7 +44,7 @@ const FullscreenPortfolioAssets = ({ balances }: { balances: Balances }) => {
         <NetworkPicker />
       </div>
       <div className="mt-6">
-        <DashboardAssetsTable balances={balancesToDisplay} />
+        <DashboardAssetsTable balances={balances} />
       </div>
     </>
   )
@@ -74,7 +73,7 @@ const EnableNetworkMessage: FC<{ type?: "substrate" | "evm" }> = ({ type }) => {
 
 const PageContent = () => {
   const { networkBalances, evmNetworks, chains, accountType } = usePortfolio()
-  const balancesToDisplay = useDisplayBalances(networkBalances)
+  const balances = useDisplayBalances(networkBalances)
   const hasAccounts = useHasAccounts()
 
   if (hasAccounts === undefined) return null
@@ -95,7 +94,7 @@ const PageContent = () => {
   )
     return <EnableNetworkMessage type="evm" />
 
-  return <FullscreenPortfolioAssets balances={balancesToDisplay} />
+  return <FullscreenPortfolioAssets balances={balances} />
 }
 
 export const PortfolioAssets = () => {

--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAssets.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAssets.tsx
@@ -1,6 +1,7 @@
 import { Balance, Balances } from "@core/domains/balances/types"
 import { ChevronLeftIcon, CopyIcon, MoreHorizontalIcon, SendIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
+import { api } from "@ui/api"
 import { AccountContextMenu } from "@ui/apps/dashboard/routes/Portfolio/AccountContextMenu"
 import { AccountTypeIcon } from "@ui/domains/Account/AccountTypeIcon"
 import { Address } from "@ui/domains/Account/Address"
@@ -17,10 +18,11 @@ import { useFormattedAddress } from "@ui/hooks/useFormattedAddress"
 import { useSearchParamsSelectedAccount } from "@ui/hooks/useSearchParamsSelectedAccount"
 import { useSearchParamsSelectedFolder } from "@ui/hooks/useSearchParamsSelectedFolder"
 import { useSendFundsPopup } from "@ui/hooks/useSendFundsPopup"
-import { useCallback, useEffect, useMemo } from "react"
+import { FC, useCallback, useEffect, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import {
+  Button,
   ContextMenuTrigger,
   IconButton,
   Tooltip,
@@ -28,13 +30,47 @@ import {
   TooltipTrigger,
 } from "talisman-ui"
 
-const PageContent = ({
-  allBalances,
-  networkBalances,
-}: {
-  allBalances: Balances
-  networkBalances: Balances
-}) => {
+const EnableNetworkMessage: FC<{ type?: "substrate" | "evm" }> = ({ type }) => {
+  const { t } = useTranslation()
+  const handleClick = useCallback(() => {
+    if (type === "substrate") api.dashboardOpen("/networks/polkadot")
+    else if (type === "evm") api.dashboardOpen("/networks/ethereum")
+    else api.dashboardOpen("/networks")
+    window.close()
+  }, [type])
+
+  return (
+    <div className="text-body-secondary mt-56 flex flex-col items-center justify-center gap-8 text-center">
+      <div>{t("Enable some networks to display your assets")}</div>
+      <div>
+        <Button onClick={handleClick} primary small type="button">
+          {t("Manage Networks")}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+const MainContent: FC<{ balances: Balances }> = ({ balances }) => {
+  const { evmNetworks, chains } = usePortfolio()
+  const { account } = useSearchParamsSelectedAccount()
+
+  if (!account?.type && !evmNetworks.length && !chains.length) return <EnableNetworkMessage />
+  if (account?.type === "sr25519" && !chains.length)
+    return <EnableNetworkMessage type="substrate" />
+  if (
+    account?.type === "ethereum" &&
+    !evmNetworks.length &&
+    !chains.filter((c) => c.account === "secp256k1").length
+  )
+    return <EnableNetworkMessage type="evm" />
+
+  return <PopupAssetsTable balances={balances} />
+}
+
+const PageContent = () => {
+  const allBalances = useBalances()
+  const { networkBalances } = usePortfolio()
   const { account } = useSearchParamsSelectedAccount()
   const { folder } = useSearchParamsSelectedFolder()
 
@@ -166,20 +202,18 @@ const PageContent = ({
         </div>
       </div>
       <div className="py-12">
-        <PopupAssetsTable balances={balancesToDisplay} />
+        <MainContent balances={balancesToDisplay} />
       </div>
     </>
   )
 }
 
 export const PortfolioAssets = () => {
-  const allBalances = useBalances()
-  const { networkBalances } = usePortfolio()
   const { popupOpenEvent } = useAnalytics()
 
   useEffect(() => {
     popupOpenEvent("portfolio assets")
   }, [popupOpenEvent])
 
-  return <PageContent allBalances={allBalances} networkBalances={networkBalances} />
+  return <PageContent />
 }

--- a/apps/extension/src/ui/atoms/balances.ts
+++ b/apps/extension/src/ui/atoms/balances.ts
@@ -24,7 +24,6 @@ const NO_OP = () => {}
 
 const rawBalancesState = atom<BalanceJson[]>({
   key: "rawBalancesState",
-  default: [],
   effects: [
     // sync from db
     ({ setSelf }) => {

--- a/apps/extension/src/ui/atoms/balances.ts
+++ b/apps/extension/src/ui/atoms/balances.ts
@@ -36,7 +36,7 @@ const rawBalancesState = atom<BalanceJson[]>({
 
       return () => sub.unsubscribe()
     },
-    // instruct backend to keep db syncrhonized while this atom is in use
+    // instruct backend to keep db synchronized while this atom is in use
     () => api.balances(NO_OP),
   ],
   /**

--- a/apps/extension/src/ui/atoms/chaindata.ts
+++ b/apps/extension/src/ui/atoms/chaindata.ts
@@ -118,7 +118,7 @@ export const allChainsState = atom<(Chain | CustomChain)[]>({
       const sub = obs.subscribe(setSelf)
       return () => sub.unsubscribe()
     },
-    // instruct backend to keep db syncrhonized while this atom is in use
+    // instruct backend to keep db synchronized while this atom is in use
     () => api.chains(NO_OP),
   ],
 })
@@ -187,7 +187,7 @@ export const allTokensMapState = atom<TokenList>({
 
       return () => sub.unsubscribe()
     },
-    // instruct backend to keep db syncrhonized while this atom is in use
+    // instruct backend to keep db synchronized while this atom is in use
     () => api.tokens(NO_OP),
   ],
 })

--- a/apps/extension/src/ui/atoms/chaindata.ts
+++ b/apps/extension/src/ui/atoms/chaindata.ts
@@ -30,7 +30,6 @@ const filterNoTestnet = ({ isTestnet }: { isTestnet?: boolean }) => isTestnet ==
 
 export const evmNetworksEnabledState = atom<EnabledEvmNetworks>({
   key: "evmNetworksEnabledState",
-  default: {},
   effects: [
     ({ setSelf }) => {
       const sub = enabledEvmNetworksStore.observable.subscribe(setSelf)
@@ -43,7 +42,6 @@ export const evmNetworksEnabledState = atom<EnabledEvmNetworks>({
 
 export const allEvmNetworksState = atom<(EvmNetwork | CustomEvmNetwork)[]>({
   key: "allEvmNetworksState",
-  default: [],
   effects: [
     // sync from db
     ({ setSelf }) => {
@@ -83,16 +81,6 @@ export const evmNetworksWithTestnetsMapState = selector<EvmNetworkList>({
   },
 })
 
-// export const evmNetworkQuery = selectorFamily({
-//   key: "evmNetworkQuery",
-//   get:
-//     (evmNetworkId: EvmNetworkId) =>
-//     ({ get }) => {
-//       const networks = get(evmNetworksWithTestnetsMapState)
-//       return networks[evmNetworkId]
-//     },
-// })
-
 export const evmNetworksWithoutTestnetsState = selector({
   key: "evmNetworksWithoutTestnetsState",
   get: ({ get }) => {
@@ -111,7 +99,6 @@ export const evmNetworksWithoutTestnetsMapState = selector<EvmNetworkList>({
 
 export const chainsEnabledState = atom<EnabledChains>({
   key: "chainsEnabledState",
-  default: {},
   effects: [
     ({ setSelf }) => {
       const sub = enabledChainsStore.observable.subscribe(setSelf)
@@ -124,7 +111,6 @@ export const chainsEnabledState = atom<EnabledChains>({
 
 export const allChainsState = atom<(Chain | CustomChain)[]>({
   key: "allChainsState",
-  default: [],
   effects: [
     // sync from db
     ({ setSelf }) => {
@@ -163,16 +149,6 @@ export const chainsWithTestnetsMapState = selector<ChainList>({
   },
 })
 
-// export const chainQuery = selectorFamily({
-//   key: "chainQuery",
-//   get:
-//     (chainId: ChainId) =>
-//     ({ get }) => {
-//       const networks = get(chainsWithTestnetsMapState)
-//       return networks[chainId]
-//     },
-// })
-
 export const chainsWithoutTestnetsState = selector({
   key: "chainsWithoutTestnetsState",
   get: ({ get }) => {
@@ -191,7 +167,6 @@ export const chainsWithoutTestnetsMapState = selector<ChainList>({
 
 export const tokensEnabledState = atom<EnabledTokens>({
   key: "tokensEnabledState",
-  default: {},
   effects: [
     ({ setSelf }) => {
       const sub = enabledTokensStore.observable.subscribe(setSelf)
@@ -204,7 +179,6 @@ export const tokensEnabledState = atom<EnabledTokens>({
 
 export const allTokensMapState = atom<TokenList>({
   key: "allTokensMapState",
-  default: {},
   effects: [
     // sync from db
     ({ setSelf }) => {

--- a/apps/extension/src/ui/atoms/chaindata.ts
+++ b/apps/extension/src/ui/atoms/chaindata.ts
@@ -235,10 +235,10 @@ export const allTokensState = selector<Token[]>({
 export const tokensWithTestnetsState = selector<Token[]>({
   key: "tokensWithTestnetsState",
   get: ({ get }) => {
-    const tokensMap = get(allTokensState)
+    const tokens = get(allTokensState)
     const chainsMap = get(chainsWithTestnetsMapState)
     const evmNetworksMap = get(evmNetworksWithTestnetsMapState)
-    return Object.values(tokensMap).filter(
+    return tokens.filter(
       (token) =>
         (token.chain && chainsMap[token.chain.id]) ||
         (token.evmNetwork && evmNetworksMap[token.evmNetwork.id])

--- a/apps/extension/src/ui/atoms/tokenRates.ts
+++ b/apps/extension/src/ui/atoms/tokenRates.ts
@@ -17,7 +17,7 @@ export const tokenRatesState = atom<DbTokenRates[]>({
       const sub = obs.subscribe(setSelf)
       return () => sub.unsubscribe()
     },
-    // instruct backend to keep db syncrhonized while this atom is in use
+    // instruct backend to keep db synchronized while this atom is in use
     () => api.tokenRates(NO_OP),
   ],
 })

--- a/apps/extension/src/ui/domains/Account/DerivedAccountPickerBase.tsx
+++ b/apps/extension/src/ui/domains/Account/DerivedAccountPickerBase.tsx
@@ -25,14 +25,19 @@ const PagerButton: FC<{ disabled?: boolean; children: ReactNode; onClick?: () =>
   </button>
 )
 
-const AccountButtonShimmer = () => (
+const AccountButtonShimmer: FC<{ withBalances: boolean }> = ({ withBalances }) => (
   <div className={"bg-grey-850 flex h-32 w-full items-center gap-8 rounded px-8"}>
     <div className="bg-grey-750 inline-block h-16 w-16 animate-pulse rounded-full"></div>
     <div className="flex grow flex-col gap-2">
       <div className="rounded-xs bg-grey-750 h-[1.6rem] w-[13rem] animate-pulse"></div>
       <div className="rounded-xs bg-grey-750 h-[1.4rem] w-[6.8rem] animate-pulse"></div>
     </div>
-    <div className="rounded-xs bg-grey-750 h-[1.8rem] w-[6.8rem] animate-pulse"></div>
+    <div
+      className={classNames(
+        "rounded-xs bg-grey-750 h-[1.8rem] w-[6.8rem] animate-pulse",
+        !withBalances && "invisible"
+      )}
+    ></div>
     <div className="rounded-xs bg-grey-750 h-[2rem] w-[2rem] animate-pulse"></div>
   </div>
 )
@@ -46,6 +51,7 @@ const AccountButton: FC<AccountButtonProps> = ({
   selected,
   onClick,
   isBalanceLoading,
+  withBalances,
 }) => {
   const { balanceDetails, totalUsd } = useBalanceDetails(balances)
 
@@ -66,18 +72,20 @@ const AccountButton: FC<AccountButtonProps> = ({
         </div>
       </div>
       <div className="flex items-center justify-end gap-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className={classNames(isBalanceLoading && "animate-pulse")}>
-              <Fiat className="leading-none" amount={totalUsd} />
-            </span>
-          </TooltipTrigger>
-          {balanceDetails && (
-            <TooltipContent>
-              <div className="whitespace-pre-wrap text-right">{balanceDetails}</div>
-            </TooltipContent>
-          )}
-        </Tooltip>
+        {withBalances && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className={classNames(isBalanceLoading && "animate-pulse")}>
+                <Fiat className="leading-none" amount={totalUsd} />
+              </span>
+            </TooltipTrigger>
+            {balanceDetails && (
+              <TooltipContent>
+                <div className="whitespace-pre-wrap text-right">{balanceDetails}</div>
+              </TooltipContent>
+            )}
+          </Tooltip>
+        )}
       </div>
       <div className="flex w-12 shrink-0 flex-col items-center justify-center">
         {connected ? (
@@ -96,16 +104,19 @@ export type DerivedAccountBase = AccountJson & {
   address: string
   balances: Balances
   isBalanceLoading: boolean
+
   connected?: boolean
   selected?: boolean
 }
 
 type AccountButtonProps = DerivedAccountBase & {
+  withBalances: boolean
   onClick: () => void
 }
 
 type DerivedAccountPickerBaseProps = {
   accounts: (DerivedAccountBase | null)[]
+  withBalances: boolean
   canPageBack?: boolean
   disablePaging?: boolean
   onPagerFirstClick?: () => void
@@ -122,6 +133,7 @@ export const DerivedAccountPickerBase: FC<DerivedAccountPickerBaseProps> = ({
   onPagerPrevClick,
   onPagerNextClick,
   onAccountClick,
+  withBalances = true,
 }) => {
   const handleToggleAccount = useCallback(
     (acc: DerivedAccountBase) => () => {
@@ -137,11 +149,12 @@ export const DerivedAccountPickerBase: FC<DerivedAccountPickerBaseProps> = ({
           account ? (
             <AccountButton
               key={account.address}
+              withBalances={withBalances}
               {...account}
               onClick={handleToggleAccount(account)}
             />
           ) : (
-            <AccountButtonShimmer key={i} />
+            <AccountButtonShimmer key={i} withBalances={withBalances} />
           )
         )}
       </div>

--- a/apps/extension/src/ui/domains/Account/DerivedFromMnemonicAccountPicker.tsx
+++ b/apps/extension/src/ui/domains/Account/DerivedFromMnemonicAccountPicker.tsx
@@ -1,13 +1,17 @@
 import { formatSuri } from "@core/domains/accounts/helpers"
 import { AccountAddressType, RequestAccountCreateFromSuri } from "@core/domains/accounts/types"
 import { AddressesAndEvmNetwork } from "@core/domains/balances/types"
+import { isChainEnabled } from "@core/domains/chains/store.enabledChains"
 import { getEthDerivationPath } from "@core/domains/ethereum/helpers"
+import { isEvmNetworkEnabled } from "@core/domains/ethereum/store.enabledEvmNetworks"
 import { AddressesByChain } from "@core/types/base"
 import { convertAddress } from "@talisman/util/convertAddress"
 import { api } from "@ui/api"
 import useAccounts from "@ui/hooks/useAccounts"
 import useBalancesByParams from "@ui/hooks/useBalancesByParams"
 import useChains from "@ui/hooks/useChains"
+import { useEnabledChainsState } from "@ui/hooks/useEnabledChainsState"
+import { useEnabledEvmNetworksState } from "@ui/hooks/useEnabledEvmNetworksState"
 import { useEvmNetworks } from "@ui/hooks/useEvmNetworks"
 import { FC, useCallback, useEffect, useMemo, useState } from "react"
 
@@ -70,8 +74,11 @@ const useDerivedAccounts = (
     }
   }, [itemsPerPage, mnemonic, name, pageIndex, type])
 
-  const { chains } = useChains("all")
+  const { chains } = useChains("enabledWithoutTestnets")
   const { evmNetworks } = useEvmNetworks("enabledWithoutTestnets")
+
+  const enabledChains = useEnabledChainsState()
+  const enabledEvmNetworks = useEnabledEvmNetworksState()
 
   const { expectedBalancesCount, addressesByChain, addressesAndEvmNetworks } = useMemo(() => {
     const expectedBalancesCount =
@@ -87,21 +94,23 @@ const useDerivedAccounts = (
 
     const evmNetworkIds = type === "ethereum" ? BALANCE_CHECK_EVM_NETWORK_IDS : []
     const chainIds = type === "ethereum" ? [] : BALANCE_CHECK_SUBSTRATE_CHAIN_IDS
-    const testChains = (chains || []).filter((chain) => chainIds.includes(chain.id))
 
     const addressesByChain: AddressesByChain =
       type === "ethereum"
         ? {}
-        : testChains.reduce(
-            (prev, curr) => ({
-              ...prev,
-              [curr.id]: derivedAccounts
-                .filter((acc) => !!acc)
-                .map((acc) => acc as DerivedFromMnemonicAccount)
-                .map((account) => convertAddress(account.address, curr.prefix)),
-            }),
-            {}
-          )
+        : (chains || [])
+            .filter((chain) => chainIds.includes(chain.id))
+            .filter((chain) => isChainEnabled(chain, enabledChains))
+            .reduce(
+              (prev, curr) => ({
+                ...prev,
+                [curr.id]: derivedAccounts
+                  .filter((acc) => !!acc)
+                  .map((acc) => acc as DerivedFromMnemonicAccount)
+                  .map((account) => convertAddress(account.address, curr.prefix)),
+              }),
+              {}
+            )
 
     const addressesAndEvmNetworks: AddressesAndEvmNetwork =
       type === "ethereum"
@@ -112,6 +121,7 @@ const useDerivedAccounts = (
               .filter(Boolean) as string[],
             evmNetworks: (evmNetworks || [])
               .filter((chain) => evmNetworkIds.includes(chain.id))
+              .filter((chain) => isEvmNetworkEnabled(chain, enabledEvmNetworks))
               .map(({ id, nativeToken }) => ({
                 id,
                 nativeToken: { id: nativeToken?.id as string },
@@ -124,7 +134,14 @@ const useDerivedAccounts = (
       addressesByChain,
       addressesAndEvmNetworks,
     }
-  }, [chains, derivedAccounts, evmNetworks, type])
+  }, [chains, derivedAccounts, enabledChains, enabledEvmNetworks, evmNetworks, type])
+
+  const withBalances = useMemo(
+    () =>
+      (addressesByChain && Object.values(addressesByChain).some((addresses) => addresses.length)) ||
+      !!addressesAndEvmNetworks?.evmNetworks.length,
+    [addressesAndEvmNetworks?.evmNetworks.length, addressesByChain]
+  )
 
   const balances = useBalancesByParams({
     addressesByChain,
@@ -176,6 +193,7 @@ const useDerivedAccounts = (
 
   return {
     accounts,
+    withBalances,
     error,
   }
 }
@@ -198,7 +216,7 @@ export const DerivedFromMnemonicAccountPicker: FC<DerivedAccountPickerProps> = (
   const itemsPerPage = 5
   const [pageIndex, setPageIndex] = useState(0)
   const [selectedAccounts, setSelectedAccounts] = useState<RequestAccountCreateFromSuri[]>([])
-  const { accounts, error } = useDerivedAccounts(
+  const { accounts, withBalances, error } = useDerivedAccounts(
     name,
     mnemonic,
     type,
@@ -232,6 +250,7 @@ export const DerivedFromMnemonicAccountPicker: FC<DerivedAccountPickerProps> = (
     <>
       <DerivedAccountPickerBase
         accounts={accounts}
+        withBalances={withBalances}
         canPageBack={pageIndex > 0}
         onAccountClick={handleToggleAccount}
         onPagerFirstClick={handlePageFirst}

--- a/apps/extension/src/ui/domains/Account/LedgerSubstrateAccountPicker.tsx
+++ b/apps/extension/src/ui/domains/Account/LedgerSubstrateAccountPicker.tsx
@@ -1,3 +1,4 @@
+import { isChainEnabled } from "@core/domains/chains/store.enabledChains"
 import { log } from "@core/log"
 import { AddressesByChain } from "@core/types/base"
 import { convertAddress } from "@talisman/util/convertAddress"
@@ -7,6 +8,7 @@ import { useLedgerSubstrateApp } from "@ui/hooks/ledger/useLedgerSubstrateApp"
 import useAccounts from "@ui/hooks/useAccounts"
 import useBalancesByParams from "@ui/hooks/useBalancesByParams"
 import useChain from "@ui/hooks/useChain"
+import { useEnabledChainsState } from "@ui/hooks/useEnabledChainsState"
 import { FC, useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -22,6 +24,11 @@ const useLedgerChainAccounts = (
   const { t } = useTranslation()
   const chain = useChain(chainId)
   const app = useLedgerSubstrateApp(chain?.genesisHash)
+  const enabledChains = useEnabledChainsState()
+  const withBalances = useMemo(
+    () => !!chain && isChainEnabled(chain, enabledChains),
+    [chain, enabledChains]
+  )
 
   const [ledgerAccounts, setLedgerAccounts] = useState<(LedgerSubstrateAccount | undefined)[]>([
     ...Array(itemsPerPage),
@@ -71,17 +78,17 @@ const useLedgerChainAccounts = (
     // start fetching balances only when all accounts are known to prevent recreating subscription 5 times
     if (ledgerAccounts.filter(Boolean).length < ledgerAccounts.length) return undefined
 
-    const result: AddressesByChain = chain
-      ? {
-          [chain.id]: ledgerAccounts
-            .filter((acc) => !!acc)
-            .map((acc) => acc as LedgerSubstrateAccount)
-            .map((account) => convertAddress(account.address, chain.prefix)),
-        }
-      : {}
+    if (!chain || !isChainEnabled(chain, enabledChains)) return {}
+
+    const result: AddressesByChain = {
+      [chain.id]: ledgerAccounts
+        .filter((acc) => !!acc)
+        .map((acc) => acc as LedgerSubstrateAccount)
+        .map((account) => convertAddress(account.address, chain.prefix)),
+    }
 
     return result
-  }, [chain, ledgerAccounts])
+  }, [chain, enabledChains, ledgerAccounts])
 
   const balances = useBalancesByParams({ addressesByChain })
 
@@ -129,6 +136,7 @@ const useLedgerChainAccounts = (
     isBusy,
     error,
     connectionStatus,
+    withBalances,
   }
 }
 
@@ -147,7 +155,7 @@ export const LedgerSubstrateAccountPicker: FC<LedgerSubstrateAccountPickerProps>
   const itemsPerPage = 5
   const [pageIndex, setPageIndex] = useState(0)
   const [selectedAccounts, setSelectedAccounts] = useState<LedgerAccountDefSubstrate[]>([])
-  const { accounts, error, isBusy } = useLedgerChainAccounts(
+  const { accounts, withBalances, error, isBusy } = useLedgerChainAccounts(
     chainId,
     selectedAccounts,
     pageIndex,
@@ -176,6 +184,7 @@ export const LedgerSubstrateAccountPicker: FC<LedgerSubstrateAccountPickerProps>
     <>
       <DerivedAccountPickerBase
         accounts={accounts}
+        withBalances={withBalances}
         disablePaging={isBusy}
         canPageBack={pageIndex > 0}
         onAccountClick={handleToggleAccount}

--- a/apps/extension/src/ui/domains/Asset/Buy/BuyTokensForm.tsx
+++ b/apps/extension/src/ui/domains/Asset/Buy/BuyTokensForm.tsx
@@ -58,7 +58,7 @@ const useSupportedTokenIds = (chains?: Chain[], tokens?: Token[], address?: stri
   useEffect(() => {
     // pull up to date list from github
     // note that there is a 5min cache on github files
-    fetch(`${githubChaindataBaseUrl}/tokens-buyable.json`)
+    fetch(`${githubChaindataBaseUrl}/data/tokens-buyable.json`)
       .then(async (response) => {
         const tokenIds: string[] = await response.json()
         setSupportedTokenIds(tokenIds)

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
@@ -5,7 +5,7 @@ import { classNames } from "@talismn/util"
 import Fiat from "@ui/domains/Asset/Fiat"
 import { useAnalytics } from "@ui/hooks/useAnalytics"
 import { useBalancesStatus } from "@ui/hooks/useBalancesStatus"
-import { useCallback } from "react"
+import { useCallback, useEffect } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 
@@ -162,6 +162,16 @@ export const DashboardAssetsTable = ({ balances }: AssetsTableProps) => {
   // group by token (symbol)
   const { account } = useSelectedAccount()
   const { symbolBalances } = usePortfolioSymbolBalances(balances)
+
+  useEffect(() => {
+    console.log({
+      balances: balances.toJSON(),
+      symbolBalances: symbolBalances.map(([, b]) => b.toJSON()),
+    })
+  }, [balances, symbolBalances])
+
+  // assume balance subscription is initializing if there are no balances
+  if (!balances.count) return null
 
   if (!symbolBalances.length)
     return (

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
@@ -5,7 +5,7 @@ import { classNames } from "@talismn/util"
 import Fiat from "@ui/domains/Asset/Fiat"
 import { useAnalytics } from "@ui/hooks/useAnalytics"
 import { useBalancesStatus } from "@ui/hooks/useBalancesStatus"
-import { useCallback, useEffect } from "react"
+import { useCallback } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 
@@ -162,13 +162,6 @@ export const DashboardAssetsTable = ({ balances }: AssetsTableProps) => {
   // group by token (symbol)
   const { account } = useSelectedAccount()
   const { symbolBalances } = usePortfolioSymbolBalances(balances)
-
-  useEffect(() => {
-    console.log({
-      balances: balances.toJSON(),
-      symbolBalances: symbolBalances.map(([, b]) => b.toJSON()),
-    })
-  }, [balances, symbolBalances])
 
   // assume balance subscription is initializing if there are no balances
   if (!balances.count) return null

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
@@ -5,46 +5,18 @@ import { classNames } from "@talismn/util"
 import Fiat from "@ui/domains/Asset/Fiat"
 import { useAnalytics } from "@ui/hooks/useAnalytics"
 import { useBalancesStatus } from "@ui/hooks/useBalancesStatus"
-import { FC, useCallback } from "react"
+import { useCallback } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 
 import { TokenLogo } from "../../Asset/TokenLogo"
 import { AssetBalanceCellValue } from "../AssetBalanceCellValue"
 import { useNomPoolStakingBanner } from "../NomPoolStakingContext"
+import { useSelectedAccount } from "../SelectedAccountContext"
 import { useTokenBalancesSummary } from "../useTokenBalancesSummary"
 import { NetworksLogoStack } from "./NetworksLogoStack"
 import { usePortfolioNetworkIds } from "./usePortfolioNetworkIds"
 import { usePortfolioSymbolBalances } from "./usePortfolioSymbolBalances"
-
-const AssetRowSkeleton: FC<{ className?: string }> = ({ className }) => {
-  return (
-    <div
-      className={classNames(
-        "text-body-secondary bg-grey-850 mb-4 grid w-full grid-cols-[40%_30%_30%] rounded text-left text-base",
-        className
-      )}
-    >
-      <div>
-        <div className="flex h-[6.6rem]">
-          <div className="p-8 text-xl">
-            <div className="bg-grey-700 h-16 w-16 animate-pulse rounded-full"></div>
-          </div>
-          <div className="flex grow flex-col justify-center gap-2">
-            <div className="bg-grey-700 rounded-xs h-8 w-20 animate-pulse"></div>
-          </div>
-        </div>
-      </div>
-      <div></div>
-      <div>
-        <div className="flex h-full flex-col items-end justify-center gap-2 px-8">
-          <div className="bg-grey-700 rounded-xs h-8 w-[10rem] animate-pulse"></div>
-          <div className="bg-grey-700 rounded-xs h-8 w-[6rem] animate-pulse"></div>
-        </div>
-      </div>
-    </div>
-  )
-}
 
 type AssetRowProps = {
   balances: Balances
@@ -185,47 +157,29 @@ type AssetsTableProps = {
   balances: Balances
 }
 
-const getSkeletonOpacity = (index: number) => {
-  // tailwind parses files to find classes that it should include in it's bundle
-  // so we can't dynamically compute the className
-  switch (index) {
-    case 0:
-      return "opacity-100"
-    case 1:
-      return "opacity-80"
-    case 2:
-      return "opacity-60"
-    case 3:
-      return "opacity-40"
-    case 4:
-      return "opacity-30"
-    case 5:
-      return "opacity-20"
-    case 6:
-      return "opacity-10"
-    default:
-      return "opacity-0"
-  }
-}
-
 export const DashboardAssetsTable = ({ balances }: AssetsTableProps) => {
   const { t } = useTranslation()
   // group by token (symbol)
-  const { symbolBalances, skeletons } = usePortfolioSymbolBalances(balances)
+  const { account } = useSelectedAccount()
+  const { symbolBalances } = usePortfolioSymbolBalances(balances)
+
+  if (!symbolBalances.length)
+    return (
+      <div className="text-body-secondary bg-grey-850 mt-12 rounded-sm p-8">
+        {account ? t("No assets were found on this account.") : t("No assets were found.")}
+      </div>
+    )
 
   return (
     <div className="text-body-secondary min-w-[45rem] text-left text-base">
       <div className="mb-5 grid grid-cols-[40%_30%_30%] text-sm font-normal">
-        <div>Asset</div>
+        <div>{t("Asset")}</div>
         <div className="text-right">{t("Locked")}</div>
         <div className="text-right">{t("Available")}</div>
       </div>
 
       {symbolBalances.map(([symbol, b]) => (
         <AssetRow key={symbol} balances={b} />
-      ))}
-      {[...Array(skeletons).keys()].map((i) => (
-        <AssetRowSkeleton key={i} className={getSkeletonOpacity(i)} />
       ))}
     </div>
   )

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetsTable.tsx
@@ -137,16 +137,23 @@ const AssetRow = ({ balances }: AssetRowProps) => {
           />
         </div>
         <div className="text-right">
-          <AssetBalanceCellValue
-            render
-            tokens={summary.availableTokens}
-            fiat={summary.availableFiat}
-            symbol={token.symbol}
-            balancesStatus={status}
-            className={classNames(
-              status.status === "fetching" && "animate-pulse transition-opacity"
-            )}
-          />
+          {status.status === "initializing" ? (
+            <div className="flex h-[6.6rem]  w-full flex-col items-end justify-center gap-2 px-8">
+              <div className="bg-grey-700 rounded-xs h-8 w-[10rem] animate-pulse"></div>
+              <div className="bg-grey-700 rounded-xs h-8 w-[6rem] animate-pulse"></div>
+            </div>
+          ) : (
+            <AssetBalanceCellValue
+              render
+              tokens={summary.availableTokens}
+              fiat={summary.availableFiat}
+              symbol={token.symbol}
+              balancesStatus={status}
+              className={classNames(
+                status.status === "fetching" && "animate-pulse transition-opacity"
+              )}
+            />
+          )}
         </div>
       </button>
     </>

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
@@ -119,26 +119,35 @@ const AssetRow = ({ balances, locked }: AssetRowProps) => {
           </div>
           <div
             className={classNames(
-              "flex flex-col gap-2 text-right",
+              "flex flex-col items-end gap-2 text-right",
               status.status === "fetching" && "animate-pulse transition-opacity"
             )}
           >
-            <div
-              className={classNames(
-                "whitespace-nowrap text-sm font-bold",
-                locked ? "text-body-secondary" : "text-white"
-              )}
-            >
-              <Tokens amount={tokens} symbol={token?.symbol} isBalance />
-              {locked ? <LockIcon className="lock ml-2 inline align-baseline text-xs" /> : null}
-              <StaleBalancesIcon
-                className="alert ml-2 inline align-baseline text-sm"
-                staleChains={status.status === "stale" ? status.staleChains : []}
-              />
-            </div>
-            <div className="text-body-secondary leading-base text-xs">
-              {fiat === null ? "-" : <Fiat amount={fiat} isBalance />}
-            </div>
+            {status.status === "initializing" ? (
+              <>
+                <div className="bg-grey-700 rounded-xs h-7 w-[10rem] animate-pulse"></div>
+                <div className="bg-grey-700 rounded-xs h-7 w-[6rem] animate-pulse"></div>
+              </>
+            ) : (
+              <>
+                <div
+                  className={classNames(
+                    "whitespace-nowrap text-sm font-bold",
+                    locked ? "text-body-secondary" : "text-white"
+                  )}
+                >
+                  <Tokens amount={tokens} symbol={token?.symbol} isBalance />
+                  {locked ? <LockIcon className="lock ml-2 inline align-baseline text-xs" /> : null}
+                  <StaleBalancesIcon
+                    className="alert ml-2 inline align-baseline text-sm"
+                    staleChains={status.status === "stale" ? status.staleChains : []}
+                  />
+                </div>
+                <div className="text-body-secondary leading-base text-xs">
+                  {fiat === null ? "-" : <Fiat amount={fiat} isBalance />}
+                </div>
+              </>
+            )}
           </div>
         </div>
       </button>
@@ -228,6 +237,9 @@ export const PopupAssetsTable = ({ balances }: GroupedAssetsTableProps) => {
     const { total, transferable, locked, reserved } = balances.sum.fiat(currency)
     return { total, totalAvailable: transferable, totalLocked: locked + reserved }
   }, [balances.sum, currency])
+
+  // assume balance subscription is initializing if there are no balances
+  if (!balances.count) return null
 
   if (!available.length && !locked.length)
     return (

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/usePortfolioSymbolBalances.ts
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/usePortfolioSymbolBalances.ts
@@ -1,15 +1,8 @@
-import {
-  DEFAULT_PORTFOLIO_TOKENS_ETHEREUM,
-  DEFAULT_PORTFOLIO_TOKENS_SUBSTRATE,
-} from "@core/constants"
 import { Balance, Balances } from "@core/domains/balances/types"
 import { FiatSumBalancesFormatter } from "@talismn/balances"
 import { TokenRateCurrency } from "@talismn/token-rates"
 import { useSelectedCurrency } from "@ui/hooks/useCurrency"
 import { useMemo } from "react"
-
-import { usePortfolio } from "../context"
-import { useSelectedAccount } from "../SelectedAccountContext"
 
 type SymbolBalances = [string, Balances]
 const sortSymbolBalancesBy =
@@ -147,38 +140,5 @@ export const usePortfolioSymbolBalances = (balances: Balances) => {
     [currency, symbolBalances]
   )
 
-  const { account, accounts } = useSelectedAccount()
-  const { networkFilter } = usePortfolio()
-
-  const hasEthereumAccount = useMemo(() => accounts.some((a) => a.type === "ethereum"), [accounts])
-
-  // if specific account we have 2 rows minimum, if all accounts we have 4
-  const skeletons = useMemo(() => {
-    // in this case we don't know the number of min rows, balances should be already loaded anyway
-    if (networkFilter) return symbolBalances.length ? 0 : 1
-
-    // If no accounts then it means "all accounts", expect all default tokens (substrate + eth)
-    // if account has a genesis hash then we expect only 1 chain
-    // otherwise we expect default tokens for account type
-    const expectedRows = (() => {
-      if (!account)
-        return (
-          DEFAULT_PORTFOLIO_TOKENS_SUBSTRATE.length +
-          (hasEthereumAccount ? DEFAULT_PORTFOLIO_TOKENS_ETHEREUM.length : 0)
-        )
-      if (account.genesisHash) return 1
-
-      // DEFAULT_TOKENS are only shown for accounts with no balance
-      const accountHasSomeBalance =
-        balances.find({ address: account?.address }).sum.planck.total > 0n
-      if (accountHasSomeBalance) return 0
-
-      if (account.type === "ethereum") return DEFAULT_PORTFOLIO_TOKENS_ETHEREUM.length
-      return DEFAULT_PORTFOLIO_TOKENS_SUBSTRATE.length
-    })()
-
-    return symbolBalances.length < expectedRows ? expectedRows - symbolBalances.length : 0
-  }, [account, hasEthereumAccount, networkFilter, balances, symbolBalances.length])
-
-  return { symbolBalances, availableSymbolBalances, lockedSymbolBalances, skeletons }
+  return { symbolBalances, availableSymbolBalances, lockedSymbolBalances }
 }

--- a/apps/extension/src/ui/domains/Portfolio/context.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/context.tsx
@@ -1,6 +1,7 @@
 import { AccountAddressType } from "@core/domains/accounts/types"
 import { Balances } from "@core/domains/balances/types"
 import { Token } from "@core/domains/tokens/types"
+import { KeypairType } from "@polkadot/util-crypto/types"
 import { provideContext } from "@talisman/util/provideContext"
 import { ChainId, EvmNetworkId } from "@talismn/chaindata-provider"
 import { useSelectedAccount } from "@ui/domains/Portfolio/SelectedAccountContext"
@@ -136,7 +137,7 @@ const usePortfolioProvider = () => {
     [account, balances, myBalances]
   )
 
-  const accountType = useMemo(() => {
+  const accountType = useMemo<KeypairType | undefined>(() => {
     if (account?.type === "ethereum") return "ethereum"
     if (account?.type) return "sr25519" // all substrate
     return undefined
@@ -169,6 +170,7 @@ const usePortfolioProvider = () => {
     hydrate,
     allBalances,
     isLoading,
+    accountType,
   }
 }
 

--- a/apps/extension/src/ui/domains/Portfolio/useDisplayBalances.ts
+++ b/apps/extension/src/ui/domains/Portfolio/useDisplayBalances.ts
@@ -5,6 +5,7 @@ import {
 import { AccountJsonAny } from "@core/domains/accounts/types"
 import { Balance, Balances } from "@core/domains/balances/types"
 import { useSelectedAccount } from "@ui/domains/Portfolio/SelectedAccountContext"
+import { useSearchParamsSelectedAccount } from "@ui/hooks/useSearchParamsSelectedAccount"
 import { useMemo } from "react"
 
 // TODO: default tokens should be controlled from chaindata
@@ -37,7 +38,11 @@ const shouldDisplayBalance = (account: AccountJsonAny | undefined, balances: Bal
 }
 
 export const useDisplayBalances = (balances: Balances) => {
-  const { account } = useSelectedAccount()
+  const { account: dashboardAccount } = useSelectedAccount()
+  const { account: popupAccount } = useSearchParamsSelectedAccount()
 
-  return useMemo(() => balances.find(shouldDisplayBalance(account, balances)), [account, balances])
+  return useMemo(
+    () => balances.find(shouldDisplayBalance(dashboardAccount || popupAccount, balances)),
+    [balances, dashboardAccount, popupAccount]
+  )
 }

--- a/apps/extension/src/ui/hooks/__tests__/useBalances.spec.ts
+++ b/apps/extension/src/ui/hooks/__tests__/useBalances.spec.ts
@@ -1,14 +1,14 @@
 import { Balances } from "@talismn/balances"
-import { renderHook } from "@testing-library/react"
-import { RecoilRoot } from "recoil"
+import { renderHook, waitFor } from "@testing-library/react"
 
+import { TestWrapper } from "../../../../tests/TestWrapper"
 import { useBalances } from "../useBalances"
 
 describe("useBalances tests", () => {
   test("Can get useBalances data", async () => {
     const { result } = renderHook(() => useBalances(), {
-      wrapper: RecoilRoot,
+      wrapper: TestWrapper,
     })
-    expect(result.current).toBeInstanceOf(Balances)
+    await waitFor(() => expect(result.current).toBeInstanceOf(Balances))
   })
 })

--- a/apps/extension/src/ui/hooks/useBalancesByParams.tsx
+++ b/apps/extension/src/ui/hooks/useBalancesByParams.tsx
@@ -45,12 +45,12 @@ export const useBalancesByParams = ({
         async (update) => {
           switch (update.type) {
             case "reset": {
-              const newBalances = new Balances(update.balances, hydrate)
+              const newBalances = new Balances(update.balances)
               return subject.next(newBalances)
             }
 
             case "upsert": {
-              const newBalances = new Balances(update.balances, hydrate)
+              const newBalances = new Balances(update.balances)
               return subject.next(subject.value.add(newBalances))
             }
 
@@ -65,7 +65,7 @@ export const useBalancesByParams = ({
           }
         }
       ),
-    [addressesByChain, addressesAndEvmNetworks, addressesAndTokens, hydrate]
+    [addressesByChain, addressesAndEvmNetworks, addressesAndTokens]
   )
 
   // subscrition must be reinitialized (using the key) if parameters change
@@ -83,6 +83,6 @@ export const useBalancesByParams = ({
   const [debouncedBalances, setDebouncedBalances] = useState<Balances>(() => balances)
   useDebounce(() => setDebouncedBalances(balances), 100, [balances])
 
-  return debouncedBalances
+  return useMemo(() => new Balances(debouncedBalances, hydrate), [debouncedBalances, hydrate])
 }
 export default useBalancesByParams

--- a/apps/extension/src/ui/hooks/useBalancesStatus.ts
+++ b/apps/extension/src/ui/hooks/useBalancesStatus.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react"
 export type BalancesStatus =
   | { status: "live" }
   | { status: "fetching" }
+  | { status: "initializing" }
   | { status: "stale"; staleChains: string[] }
 
 /**
@@ -22,6 +23,8 @@ export const useBalancesStatus = (balances: Balances) =>
     // fetching
     const hasCachedBalances = balances.each.some((b) => b.status === "cache")
     if (hasCachedBalances) return { status: "fetching" }
+
+    if (balances.each.every((b) => b.status === "initializing")) return { status: "initializing" }
 
     // live
     return { status: "live" }

--- a/apps/extension/src/ui/hooks/useSearchParamsSelectedAccount.tsx
+++ b/apps/extension/src/ui/hooks/useSearchParamsSelectedAccount.tsx
@@ -6,7 +6,7 @@ export const useSearchParamsSelectedAccount = () => {
   const [searchParams] = useSearchParams()
 
   const address = searchParams.get("account")
-  const account = useAccountByAddress(address) ?? undefined
+  const account = useAccountByAddress(address !== "all" ? address : undefined) ?? undefined
 
   return { account }
 }

--- a/apps/extension/tests/TestWrapper.tsx
+++ b/apps/extension/tests/TestWrapper.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import { RecoilRoot } from "recoil"
+
+export const TestWrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <RecoilRoot>
+      <React.Suspense fallback={<div>loading children</div>}>{children}</React.Suspense>
+    </RecoilRoot>
+  )
+}

--- a/packages/balances/src/BalanceModule.ts
+++ b/packages/balances/src/BalanceModule.ts
@@ -3,7 +3,14 @@ import { ChainConnector } from "@talismn/chain-connector"
 import { ChainConnectorEvm } from "@talismn/chain-connector-evm"
 import { ChainId, ChaindataProvider, IToken } from "@talismn/chaindata-provider"
 
-import { AddressesByToken, Balances, SubscriptionCallback, UnsubscribeFn } from "./types"
+import {
+  Address,
+  AddressesByToken,
+  BalanceJson,
+  Balances,
+  SubscriptionCallback,
+  UnsubscribeFn,
+} from "./types"
 
 export type ExtendableTokenType = IToken
 export type ExtendableChainMeta = Record<string, unknown> | undefined
@@ -83,6 +90,10 @@ export const DefaultBalanceModule = <
     return () => {}
   },
 
+  getPlaceholderBalance() {
+    throw new Error("Balance placeholder is not implemented in this module.")
+  },
+
   async fetchBalances() {
     throw new Error("Balance fetching is not implemented in this module.")
   },
@@ -152,6 +163,9 @@ interface BalanceModuleCommon<
     addressesByToken: AddressesByToken<TTokenType>,
     callback: SubscriptionCallback<Balances>
   ): Promise<UnsubscribeFn>
+
+  /** Used to provision balances in db while they are fetching for the first time */
+  getPlaceholderBalance(tokenId: TTokenType["id"], address: Address): BalanceJson
 
   /** Fetch balances for this module with optional filtering */
   fetchBalances(addressesByToken: AddressesByToken<TTokenType>): Promise<Balances>

--- a/packages/balances/src/modules/EvmErc20Module.ts
+++ b/packages/balances/src/modules/EvmErc20Module.ts
@@ -155,6 +155,19 @@ export const EvmErc20Module: NewBalanceModule<
       return tokens
     },
 
+    getPlaceholderBalance(tokenId, address): EvmErc20Balance {
+      const evmNetworkId = tokenId.split("-")[0] as EvmNetworkId
+      return {
+        source: "evm-erc20",
+        status: "initializing",
+        address: address,
+        multiChainId: { evmChainId: evmNetworkId },
+        evmNetworkId,
+        tokenId,
+        free: "0",
+      }
+    },
+
     async subscribeBalances(addressesByToken, callback) {
       let subscriptionActive = true
       const subscriptionInterval = 6_000 // 6_000ms == 6 seconds

--- a/packages/balances/src/modules/EvmErc20Module.ts
+++ b/packages/balances/src/modules/EvmErc20Module.ts
@@ -158,6 +158,7 @@ export const EvmErc20Module: NewBalanceModule<
     async subscribeBalances(addressesByToken, callback) {
       let subscriptionActive = true
       const subscriptionInterval = 6_000 // 6_000ms == 6 seconds
+      const initDelay = 1_500 // 1_500ms == 1.5 seconds
       const cache = new Map<EvmNetworkId, BalanceJsonList>()
 
       // TODO remove this log
@@ -222,7 +223,8 @@ export const EvmErc20Module: NewBalanceModule<
           setTimeout(poll, subscriptionInterval)
         }
       }
-      setTimeout(poll, subscriptionInterval)
+
+      setTimeout(poll, initDelay)
 
       return () => {
         subscriptionActive = false

--- a/packages/balances/src/modules/EvmNativeModule.ts
+++ b/packages/balances/src/modules/EvmNativeModule.ts
@@ -127,6 +127,7 @@ export const EvmNativeModule: NewBalanceModule<
       log.debug("subscribeBalances", "evm-native", addressesByToken)
       let subscriptionActive = true
       const subscriptionInterval = 6_000 // 6_000ms == 6 seconds
+      const initDelay = 500 // 500ms == 0.5 seconds
       const cache = new Map<EvmNetworkId, BalanceJsonList>()
 
       // for chains with a zero balance we only call fetchBalances once every 5 subscriptionIntervals
@@ -183,7 +184,8 @@ export const EvmNativeModule: NewBalanceModule<
           setTimeout(poll, subscriptionInterval)
         }
       }
-      setTimeout(poll, subscriptionInterval)
+
+      setTimeout(poll, initDelay)
 
       return () => {
         subscriptionActive = false

--- a/packages/balances/src/modules/EvmNativeModule.ts
+++ b/packages/balances/src/modules/EvmNativeModule.ts
@@ -122,6 +122,19 @@ export const EvmNativeModule: NewBalanceModule<
       return { [nativeToken.id]: nativeToken }
     },
 
+    getPlaceholderBalance(tokenId, address): EvmNativeBalance {
+      const evmNetworkId = tokenId.split("-")[0] as EvmNetworkId
+      return {
+        source: "evm-native",
+        status: "initializing",
+        address: address,
+        multiChainId: { evmChainId: evmNetworkId },
+        evmNetworkId,
+        tokenId,
+        free: "0",
+      }
+    },
+
     async subscribeBalances(addressesByToken, callback) {
       // TODO remove
       log.debug("subscribeBalances", "evm-native", addressesByToken)

--- a/packages/balances/src/modules/SubstrateAssetsModule.ts
+++ b/packages/balances/src/modules/SubstrateAssetsModule.ts
@@ -243,8 +243,8 @@ export const SubAssetsModule: NewBalanceModule<
     },
 
     getPlaceholderBalance(tokenId, address): SubAssetsBalance {
-      const match = /([\d\w]+)-substrate-assets/.exec(tokenId)
-      const chainId = match?.[0]
+      const match = /([\d\w-]+)-substrate-assets/.exec(tokenId)
+      const chainId = match?.[1]
       if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
 
       return {

--- a/packages/balances/src/modules/SubstrateAssetsModule.ts
+++ b/packages/balances/src/modules/SubstrateAssetsModule.ts
@@ -242,6 +242,23 @@ export const SubAssetsModule: NewBalanceModule<
       return tokens
     },
 
+    getPlaceholderBalance(tokenId, address): SubAssetsBalance {
+      const match = /([\d\w]+)-substrate-assets/.exec(tokenId)
+      const chainId = match?.[0]
+      if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
+
+      return {
+        source: "substrate-assets",
+        status: "initializing",
+        address,
+        multiChainId: { subChainId: chainId },
+        chainId,
+        tokenId,
+        free: "0",
+        locks: "0",
+      }
+    },
+
     // TODO: Don't create empty subscriptions
     async subscribeBalances(addressesByToken, callback) {
       const queries = await buildQueries(

--- a/packages/balances/src/modules/SubstrateEquilibriumModule.ts
+++ b/packages/balances/src/modules/SubstrateEquilibriumModule.ts
@@ -211,6 +211,22 @@ export const SubEquilibriumModule: NewBalanceModule<
       return tokens
     },
 
+    getPlaceholderBalance(tokenId, address): SubEquilibriumBalance {
+      const match = /([\d\w]+)-substrate-equilibrium/.exec(tokenId)
+      const chainId = match?.[0]
+      if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
+
+      return {
+        source: "substrate-equilibrium",
+        status: "initializing",
+        address,
+        multiChainId: { subChainId: chainId },
+        chainId,
+        tokenId,
+        free: "0",
+      }
+    },
+
     // TODO: Don't create empty subscriptions
     async subscribeBalances(addressesByToken, callback) {
       const queries = await buildQueries(

--- a/packages/balances/src/modules/SubstrateEquilibriumModule.ts
+++ b/packages/balances/src/modules/SubstrateEquilibriumModule.ts
@@ -212,8 +212,9 @@ export const SubEquilibriumModule: NewBalanceModule<
     },
 
     getPlaceholderBalance(tokenId, address): SubEquilibriumBalance {
-      const match = /([\d\w]+)-substrate-equilibrium/.exec(tokenId)
-      const chainId = match?.[0]
+      const match = /([\d\w-]+)-substrate-equilibrium/.exec(tokenId)
+      const chainId = match?.[1]
+      console.log("token to chain : ", tokenId, chainId)
       if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
 
       return {

--- a/packages/balances/src/modules/SubstrateEquilibriumModule.ts
+++ b/packages/balances/src/modules/SubstrateEquilibriumModule.ts
@@ -214,7 +214,6 @@ export const SubEquilibriumModule: NewBalanceModule<
     getPlaceholderBalance(tokenId, address): SubEquilibriumBalance {
       const match = /([\d\w-]+)-substrate-equilibrium/.exec(tokenId)
       const chainId = match?.[1]
-      console.log("token to chain : ", tokenId, chainId)
       if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
 
       return {

--- a/packages/balances/src/modules/SubstrateNativeModule.ts
+++ b/packages/balances/src/modules/SubstrateNativeModule.ts
@@ -299,8 +299,9 @@ export const SubNativeModule: NewBalanceModule<
     },
 
     getPlaceholderBalance(tokenId, address): SubNativeBalance {
-      const match = /([\d\w]+)-substrate-native/.exec(tokenId)
-      const chainId = match?.[0]
+      const match = /([\d\w-]+)-substrate-native/.exec(tokenId)
+      const chainId = match?.[1]
+      console.log("token to chain : ", tokenId, chainId)
       if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
 
       return {

--- a/packages/balances/src/modules/SubstrateNativeModule.ts
+++ b/packages/balances/src/modules/SubstrateNativeModule.ts
@@ -298,6 +298,27 @@ export const SubNativeModule: NewBalanceModule<
       return { [nativeToken.id]: nativeToken }
     },
 
+    getPlaceholderBalance(tokenId, address): SubNativeBalance {
+      const match = /([\d\w]+)-substrate-native/.exec(tokenId)
+      const chainId = match?.[0]
+      if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
+
+      return {
+        source: "substrate-native",
+        status: "initializing",
+        address,
+        multiChainId: { subChainId: chainId },
+        chainId,
+        tokenId,
+        free: "0",
+        reserves: [{ label: "reserved", amount: "0" }],
+        locks: [
+          { label: "fees", amount: "0", includeInTransferable: true, excludeFromFeePayable: true },
+          { label: "misc", amount: "0" },
+        ],
+      }
+    },
+
     async subscribeBalances(addressesByToken, callback) {
       assert(chainConnectors.substrate, "This module requires a substrate chain connector")
 

--- a/packages/balances/src/modules/SubstrateNativeModule.ts
+++ b/packages/balances/src/modules/SubstrateNativeModule.ts
@@ -301,7 +301,6 @@ export const SubNativeModule: NewBalanceModule<
     getPlaceholderBalance(tokenId, address): SubNativeBalance {
       const match = /([\d\w-]+)-substrate-native/.exec(tokenId)
       const chainId = match?.[1]
-      console.log("token to chain : ", tokenId, chainId)
       if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
 
       return {

--- a/packages/balances/src/modules/SubstratePsp22Module.ts
+++ b/packages/balances/src/modules/SubstratePsp22Module.ts
@@ -201,7 +201,6 @@ export const SubPsp22Module: NewBalanceModule<
     getPlaceholderBalance(tokenId, address): SubPsp22Balance {
       const match = /([\d\w-]+)-substrate-psp22/.exec(tokenId)
       const chainId = match?.[1]
-      console.log("token to chain : ", tokenId, chainId)
       if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
 
       return {

--- a/packages/balances/src/modules/SubstratePsp22Module.ts
+++ b/packages/balances/src/modules/SubstratePsp22Module.ts
@@ -199,8 +199,9 @@ export const SubPsp22Module: NewBalanceModule<
     },
 
     getPlaceholderBalance(tokenId, address): SubPsp22Balance {
-      const match = /([\d\w]+)-substrate-psp22/.exec(tokenId)
-      const chainId = match?.[0]
+      const match = /([\d\w-]+)-substrate-psp22/.exec(tokenId)
+      const chainId = match?.[1]
+      console.log("token to chain : ", tokenId, chainId)
       if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
 
       return {

--- a/packages/balances/src/modules/SubstratePsp22Module.ts
+++ b/packages/balances/src/modules/SubstratePsp22Module.ts
@@ -202,6 +202,7 @@ export const SubPsp22Module: NewBalanceModule<
     async subscribeBalances(addressesByToken, callback) {
       let subscriptionActive = true
       const subscriptionInterval = 12_000 // 12_000ms == 12 seconds
+      const initDelay = 3_000 // 3000ms == 3 seconds
       const cache = new Map<string, BalanceJson>()
 
       const tokens = await chaindataProvider.tokens()
@@ -231,7 +232,8 @@ export const SubPsp22Module: NewBalanceModule<
           setTimeout(poll, subscriptionInterval)
         }
       }
-      setTimeout(poll, subscriptionInterval)
+
+      setTimeout(poll, initDelay)
 
       return () => {
         subscriptionActive = false

--- a/packages/balances/src/modules/SubstratePsp22Module.ts
+++ b/packages/balances/src/modules/SubstratePsp22Module.ts
@@ -198,6 +198,22 @@ export const SubPsp22Module: NewBalanceModule<
       return tokens
     },
 
+    getPlaceholderBalance(tokenId, address): SubPsp22Balance {
+      const match = /([\d\w]+)-substrate-psp22/.exec(tokenId)
+      const chainId = match?.[0]
+      if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
+
+      return {
+        source: "substrate-psp22",
+        status: "initializing",
+        address,
+        multiChainId: { subChainId: chainId },
+        chainId,
+        tokenId,
+        free: "0",
+      }
+    },
+
     // TODO: Don't create empty subscriptions
     async subscribeBalances(addressesByToken, callback) {
       let subscriptionActive = true

--- a/packages/balances/src/modules/SubstrateTokensModule.ts
+++ b/packages/balances/src/modules/SubstrateTokensModule.ts
@@ -190,8 +190,9 @@ export const SubTokensModule: NewBalanceModule<
     },
 
     getPlaceholderBalance(tokenId, address): SubTokensBalance {
-      const match = /([\d\w]+)-substrate-tokens/.exec(tokenId)
-      const chainId = match?.[0]
+      const match = /([\d\w-]+)-substrate-tokens/.exec(tokenId)
+      const chainId = match?.[1]
+      console.log("token to chain : ", tokenId, chainId)
       if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
 
       return {

--- a/packages/balances/src/modules/SubstrateTokensModule.ts
+++ b/packages/balances/src/modules/SubstrateTokensModule.ts
@@ -189,6 +189,24 @@ export const SubTokensModule: NewBalanceModule<
       return tokens
     },
 
+    getPlaceholderBalance(tokenId, address): SubTokensBalance {
+      const match = /([\d\w]+)-substrate-tokens/.exec(tokenId)
+      const chainId = match?.[0]
+      if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
+
+      return {
+        source: "substrate-tokens",
+        status: "initializing",
+        address,
+        multiChainId: { subChainId: chainId },
+        chainId,
+        tokenId,
+        free: "0",
+        locks: "0",
+        reserves: "0",
+      }
+    },
+
     // TODO: Don't create empty subscriptions
     async subscribeBalances(addressesByToken, callback) {
       const queries = await buildQueries(

--- a/packages/balances/src/modules/SubstrateTokensModule.ts
+++ b/packages/balances/src/modules/SubstrateTokensModule.ts
@@ -192,7 +192,6 @@ export const SubTokensModule: NewBalanceModule<
     getPlaceholderBalance(tokenId, address): SubTokensBalance {
       const match = /([\d\w-]+)-substrate-tokens/.exec(tokenId)
       const chainId = match?.[1]
-      console.log("token to chain : ", tokenId, chainId)
       if (!chainId) throw new Error(`Can't detect chainId for token ${tokenId}`)
 
       return {

--- a/packages/balances/src/modules/util/index.ts
+++ b/packages/balances/src/modules/util/index.ts
@@ -235,8 +235,7 @@ export const deriveStatuses = (
   balances: BalanceJson[]
 ): BalanceJson[] => {
   balances.forEach((balance) => {
-    if (balance.status === "live" || balance.status === "cache" || balance.status === "stale")
-      return balance
+    if (["live", "cache", "stale", "initializing"].includes(balance.status)) return balance
 
     if (validSubscriptionIds.size < 1) {
       balance.status = "cache"

--- a/packages/balances/src/types/balancetypes.ts
+++ b/packages/balances/src/types/balancetypes.ts
@@ -51,6 +51,8 @@ export type BalanceStatus =
   | "cache"
   // balance was retrieved from the chain but we're unable to create a new subscription
   | "stale"
+  // balance has never been retrieved yet
+  | "initializing"
 
 /** `IBalance` is a common interface which all balance types must implement. */
 export type IBalance = {

--- a/packages/chaindata-provider-extension/src/ChaindataProviderExtension.ts
+++ b/packages/chaindata-provider-extension/src/ChaindataProviderExtension.ts
@@ -679,8 +679,12 @@ export class ChaindataProviderExtension implements ChaindataProvider {
   }
 
   async getIsBuiltInEvmNetwork(evmNetworkId: EvmNetworkId) {
-    const evmNetwork = await fetchEvmNetwork(evmNetworkId)
-    return !!evmNetwork
+    try {
+      const evmNetwork = await fetchEvmNetwork(evmNetworkId)
+      return !!evmNetwork
+    } catch (e) {
+      return false
+    }
   }
 
   transaction<U>(

--- a/packages/chaindata-provider/src/constants.ts
+++ b/packages/chaindata-provider/src/constants.ts
@@ -1,7 +1,7 @@
 import { ChainId, EvmNetworkId, TokenId } from "./types"
 
 // @dev : temporarily change branch here when testing changes in chaindata
-const CHAINDATA_BRANCH = "feat/per-branch-data"
+const CHAINDATA_BRANCH = "main"
 
 //
 // Chaindata published files (dist folder)

--- a/packages/chaindata-provider/src/constants.ts
+++ b/packages/chaindata-provider/src/constants.ts
@@ -1,10 +1,13 @@
 import { ChainId, EvmNetworkId, TokenId } from "./types"
 
+// @dev : temporarily change branch here when testing changes in chaindata
+const CHAINDATA_BRANCH = "feat/per-branch-data"
+
 //
-// Chaindata (Published to GitHub Pages) Constants
+// Chaindata published files (dist folder)
 //
 
-export const chaindataUrl = "https://talismansociety.github.io/chaindata"
+export const chaindataUrl = `https://raw.githubusercontent.com/TalismanSociety/chaindata/${CHAINDATA_BRANCH}/dist`
 
 export const chaindataChainsAllUrl = `${chaindataUrl}/chains/all.json`
 export const chaindataChainsSummaryUrl = `${chaindataUrl}/chains/summary.json`
@@ -32,13 +35,13 @@ export const githubApi = "https://api.github.com"
 
 export const githubChaindataOrg = "TalismanSociety"
 export const githubChaindataRepo = "chaindata"
-export const githubChaindataBranch = "main"
+export const githubChaindataBranch = CHAINDATA_BRANCH
 
 export const githubChaindataBaseUrl = `https://raw.githubusercontent.com/${githubChaindataOrg}/${githubChaindataRepo}/${githubChaindataBranch}`
 
-export const githubChainsUrl = `${githubChaindataBaseUrl}/chaindata.json`
-export const githubTestnetChainsUrl = `${githubChaindataBaseUrl}/testnets-chaindata.json`
-export const githubEvmNetworksUrl = `${githubChaindataBaseUrl}/evm-networks.json`
+export const githubChainsUrl = `${githubChaindataBaseUrl}/data/chaindata.json`
+export const githubTestnetChainsUrl = `${githubChaindataBaseUrl}/data/testnets-chaindata.json`
+export const githubEvmNetworksUrl = `${githubChaindataBaseUrl}/data/evm-networks.json`
 
 export const githubChaindataChainsAssetsDir = "assets/chains"
 export const githubChaindataTokensAssetsDir = "assets/tokens"

--- a/packages/chaindata-provider/src/types/EvmNetwork.ts
+++ b/packages/chaindata-provider/src/types/EvmNetwork.ts
@@ -15,7 +15,7 @@ export type EvmNetwork = {
   // TODO: Create ethereum tokens store (and reference here by id).
   //       Or extend substrate tokens store to support both substrate and ethereum tokens.
   nativeToken: { id: TokenId } | null
-  // TODO remove tokens property, as tokens already reference their network
+  /** @deprecated tokens already reference their network */
   tokens: Array<{ id: TokenId }> | null
   explorerUrl: string | null
   rpcs: Array<EthereumRpc> | null

--- a/packages/token-rates/src/TokenRates.ts
+++ b/packages/token-rates/src/TokenRates.ts
@@ -32,8 +32,6 @@ export async function fetchTokenRates(tokens: Record<TokenId, IToken>) {
     // ignore testnet tokens
     .filter(({ isTestnet }) => !isTestnet)
 
-    // TODO enabled tokens only
-    .filter(({ isDefault }) => isDefault !== false)
     // ignore tokens which don't have a coingeckoId
     .filter(hasCoingeckoId)
 


### PR DESCRIPTION
- Suspense for all networks & balances, remove shimmers
- Fix subscription by params
- Fix add networks/tokens from dapps
- Fix remove custom networks/tokens
- Specify which chaindata branch to pull data from
- Buttons to enable/disable all networks & tokens 
- Provision balance rows on subscription startup with an "initializing" status, to let FE knows which ones are pending
- shimmers for initializing balances

TODO : 
- update subscribeByParams to leverage initializing rows