### PR TITLE
fix: maintain `TokenLogo` and `ChainLogo` aspect ratio

### DIFF
--- a/apps/extension/src/ui/domains/Asset/AssetLogo.tsx
+++ b/apps/extension/src/ui/domains/Asset/AssetLogo.tsx
@@ -31,8 +31,7 @@ export const AssetLogoBase = ({ id, className, url, rounded }: AssetLogoBaseProp
   const handleError = useCallback(() => setSrc(UNKNOWN_TOKEN_URL), [])
 
   const imgClassName = useMemo(
-    () =>
-      classNames("relative block h-[1em] w-[1em] shrink-0", rounded && "rounded-full", className),
+    () => classNames("relative block w-[1em] shrink-0", rounded && "rounded-full", className),
     [className, rounded]
   )
 

--- a/apps/extension/src/ui/domains/Asset/ChainLogo.tsx
+++ b/apps/extension/src/ui/domains/Asset/ChainLogo.tsx
@@ -24,7 +24,7 @@ export const ChainLogoBase: FC<ChainLogoBaseProps> = ({ id, logo, className }) =
   const handleError = useCallback(() => setSrc(UNKNOWN_NETWORK_URL), [])
 
   const imgClassName = useMemo(
-    () => classNames("relative block h-[1em] w-[1em] shrink-0", className),
+    () => classNames("relative block w-[1em] shrink-0", className),
     [className]
   )
 


### PR DESCRIPTION
<div align="center">

![image](https://github.com/TalismanSociety/talisman/assets/2741569/cc2e2ec3-0da5-4629-b7c5-4f3fe944a561)
**before**

![image](https://github.com/TalismanSociety/talisman/assets/2741569/cc01df81-9886-4c1f-91f4-943550115665)
**after**

</div>