### PR TITLE
Catch error in useAccountByAddress when invalid address given

### DIFF
--- a/apps/extension/src/ui/hooks/useAccountByAddress.tsx
+++ b/apps/extension/src/ui/hooks/useAccountByAddress.tsx
@@ -9,8 +9,14 @@ const filterByUnencodedAddress =
   (account: AccountJsonAny): boolean =>
     account.address === address
 
-const filterByEncodedAddress = (address: string) =>
-  filterByUnencodedAddress(encodeAnyAddress(address, 42))
+const filterByEncodedAddress = (address: string) => {
+  try {
+    return filterByUnencodedAddress(encodeAnyAddress(address, 42))
+  } catch (e) {
+    // address is not valid
+    return () => false
+  }
+}
 
 export const useAccountByAddress = (address?: string | null) => {
   const accounts = useAccounts()


### PR DESCRIPTION
Caused an error when `?account=all` in URL params