### PR TITLE
Allow blockeplorer to be null in wallet_addEthereumChain

### DIFF
--- a/apps/extension/src/core/domains/ethereum/helpers.ts
+++ b/apps/extension/src/core/domains/ethereum/helpers.ts
@@ -326,7 +326,10 @@ const schemaAddEthereumRequest = yup.object().shape({
     })
     .required(),
   rpcUrls: yup.array().of(yup.string().required().test("noScriptTag", testNoScriptTag)).required(),
-  blockExplorerUrls: yup.array().of(yup.string().required().test("noScriptTag", testNoScriptTag)),
+  blockExplorerUrls: yup
+    .array()
+    .of(yup.string().required().test("noScriptTag", testNoScriptTag))
+    .nullable(),
   iconUrls: yup.array().of(yup.string().test("noScriptTag", testNoScriptTag)),
 })
 


### PR DESCRIPTION
Follows viem's `AddEthereumChainParameter` more closely, and allows use with  https://metamask.github.io/test-dapp