### PR TITLE
build: use type import for types only library

### DIFF
--- a/.changeset/pink-turkeys-cough.md
+++ b/.changeset/pink-turkeys-cough.md
@@ -1,0 +1,5 @@
+---
+"@talismn/chaindata-provider-extension": patch
+---
+
+build: use type import for types only library

--- a/packages/chaindata-provider-extension/src/codegen.ts
+++ b/packages/chaindata-provider-extension/src/codegen.ts
@@ -30,6 +30,7 @@ const config: CodegenConfig = {
           // defaults to `any` - let's go with `unknown` instead :)
           JSON: "unknown",
         },
+        useTypeImports: true,
       },
       hooks: { afterAllFileWrite: ["prettier --write"] },
     },

--- a/packages/chaindata-provider-extension/src/graphql-codegen/gql.ts
+++ b/packages/chaindata-provider-extension/src/graphql-codegen/gql.ts
@@ -1,4 +1,4 @@
-import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core"
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core"
 
 /* eslint-disable */
 import * as types from "./graphql"

--- a/packages/chaindata-provider-extension/src/graphql-codegen/graphql.ts
+++ b/packages/chaindata-provider-extension/src/graphql-codegen/graphql.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core"
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core"
 export type Maybe<T> = T | null
 export type InputMaybe<T> = Maybe<T>
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }


### PR DESCRIPTION
This was causing build failure on the latest version of Vite