### PR TITLE
fix: responsive account name alignment in portfolio account picker

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/AccountSelect.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AccountSelect.tsx
@@ -295,7 +295,7 @@ const Item = forwardRef<HTMLDivElement, ItemProps>(function Item(
       {t("All Accounts")}
     </div>
   ) : (
-    <div className="flex items-center gap-2">
+    <div className="flex w-full items-center justify-center gap-2 lg:justify-start">
       <div className="overflow-hidden text-ellipsis whitespace-nowrap text-sm">{item.name}</div>
       {isAccount && <AccountTypeIcon className="text-primary" origin={item.origin} />}
     </div>

--- a/apps/extension/src/ui/domains/Portfolio/AccountSelect.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AccountSelect.tsx
@@ -295,7 +295,7 @@ const Item = forwardRef<HTMLDivElement, ItemProps>(function Item(
       {t("All Accounts")}
     </div>
   ) : (
-    <div className="flex w-full items-center gap-2">
+    <div className="flex items-center gap-2">
       <div className="overflow-hidden text-ellipsis whitespace-nowrap text-sm">{item.name}</div>
       {isAccount && <AccountTypeIcon className="text-primary" origin={item.origin} />}
     </div>


### PR DESCRIPTION
Fix is for fullscreen view at `md` breakpoint

<div align="center">

![before](https://github.com/TalismanSociety/talisman/assets/2741569/60f37c7f-e76c-4573-94e4-0b1a3859868d)
**before**

![after](https://github.com/TalismanSociety/talisman/assets/2741569/43d61621-4c36-4096-ba71-061dea9aae0d)
**after**

</div>