### PR TITLE
fix: invoke stopListening when an error is caught

### DIFF
--- a/apps/extension/src/ui/domains/Sign/SignDcentSubstrate.tsx
+++ b/apps/extension/src/ui/domains/Sign/SignDcentSubstrate.tsx
@@ -136,7 +136,7 @@ export const SignDcentSubstrate: FC<SignHardwareSubstrateProps> = ({
       // add prefix for ed25519 signature (0x00)
       return onSigned({ signature: `0x00${signed_tx.substring(2)}` })
     } catch (err) {
-      stopListening
+      stopListening()
       log.error("Failed to sign", { err })
       if (err instanceof DcentError) {
         if (err.code !== "user_cancel") setDisplayedErrorMessage(err.message)


### PR DESCRIPTION
Hey @0xKheops  seems like a bug here, the `stopListening` call wasn't invoked when an error is caught. feel free to close this if this was intended