### PR TITLE
fix: connected includes removed addreses

### DIFF
--- a/apps/extension/src/ui/hooks/useAuthorisedSiteById.tsx
+++ b/apps/extension/src/ui/hooks/useAuthorisedSiteById.tsx
@@ -25,13 +25,13 @@ const useAuthorisedSiteById = (id: AuthorizedSiteId, type: ProviderType) => {
 
     switch (type) {
       case "polkadot":
-        return connectedPolkadot
+        return connectedPolkadot.filter((address) => availableAddresses.includes(address))
       case "ethereum":
-        return connectedEthereum
+        return connectedEthereum.filter((address) => availableAddresses.includes(address))
       default:
         throw new Error("provider type not set")
     }
-  }, [sites, id, type])
+  }, [sites, id, type, availableAddresses])
 
   const handleUpdate = useCallback(
     (newAddresses: AuthorizedSiteAddresses | undefined) => {


### PR DESCRIPTION
This PR fixes a bug where the `connected` count is including removed addresses:

<img width="710" alt="Screenshot 2023-12-28 at 7 55 33 PM" src="https://github.com/TalismanSociety/talisman/assets/81092286/7576d48a-eefd-49e6-9d36-ffa7800d2e4c">


The proper fix should be to remove address from `sites[id].addresses` (or `ethAddresses`) when an address is removed.