### PR TITLE
fix: popup windows closing logic

### DIFF
--- a/apps/extension/src/core/domains/signing/__tests__/requestsStore.spec.ts
+++ b/apps/extension/src/core/domains/signing/__tests__/requestsStore.spec.ts
@@ -7,6 +7,7 @@ import { AccountsStore } from "@polkadot/extension-base/stores"
 import type { SignerPayloadJSON } from "@polkadot/types/types"
 import keyring from "@polkadot/ui-keyring"
 import { cryptoWaitReady } from "@polkadot/util-crypto"
+import { waitFor } from "@testing-library/dom"
 
 const mnemonic = "seed sock milk update focus rotate barely fade car face mechanic mercy"
 const password = "passw0rd"
@@ -21,7 +22,11 @@ const createAccount = () => {
 
 jest.mock("@core/libs/WindowManager", () => {
   return {
-    windowManager: { popupOpen: jest.fn() },
+    windowManager: {
+      popupOpen: jest.fn().mockImplementation(async () => {
+        return 1
+      }),
+    },
   }
 })
 
@@ -67,7 +72,8 @@ describe("Signing requests store", () => {
       },
       {} as chrome.runtime.Port
     )
-    expect(requestStore.getCounts().get("substrate-sign")).toBe(1)
+
+    await waitFor(() => expect(requestStore.getCounts().get("substrate-sign")).toBe(1))
     expect(windowManager.popupOpen).toBeCalled()
   })
 })

--- a/apps/extension/src/core/handlers/Extension.spec.ts
+++ b/apps/extension/src/core/handlers/Extension.spec.ts
@@ -12,6 +12,7 @@ import type { ExtDef } from "@polkadot/types/extrinsic/signedExtensions/types"
 import type { SignerPayloadJSON } from "@polkadot/types/types"
 import keyring from "@polkadot/ui-keyring"
 import { cryptoWaitReady, signatureVerify } from "@polkadot/util-crypto"
+import { waitFor } from "@testing-library/dom"
 import Browser from "webextension-polyfill"
 
 import { getMessageSenderFn } from "../../../tests/util"
@@ -174,7 +175,7 @@ describe("Extension", () => {
         {} as chrome.runtime.Port
       )
 
-      expect(requestStore.getCounts().get("substrate-sign")).toBe(1)
+      await waitFor(() => expect(requestStore.getCounts().get("substrate-sign")).toBe(1))
 
       const request = requestStore.allRequests("substrate-sign")[0]
 
@@ -251,7 +252,7 @@ describe("Extension", () => {
         {} as chrome.runtime.Port
       )
 
-      expect(requestStore.getCounts().get("substrate-sign")).toBe(1)
+      await waitFor(() => expect(requestStore.getCounts().get("substrate-sign")).toBe(1))
 
       const request = requestStore.allRequests("substrate-sign")[0]
       await expect(
@@ -321,7 +322,7 @@ describe("Extension", () => {
         {} as chrome.runtime.Port
       )
 
-      expect(requestStore.getCounts().get("substrate-sign")).toBe(1)
+      await waitFor(() => expect(requestStore.getCounts().get("substrate-sign")).toBe(1))
 
       const request = requestStore.allRequests("substrate-sign")[0]
       await expect(
@@ -411,7 +412,7 @@ describe("Extension", () => {
         {} as chrome.runtime.Port
       )
 
-      expect(requestStore.getCounts().get("substrate-sign")).toBe(1)
+      await waitFor(() => expect(requestStore.getCounts().get("substrate-sign")).toBe(1))
 
       const request = requestStore.allRequests("substrate-sign")[0]
       await expect(

--- a/apps/extension/src/core/libs/IconManager.ts
+++ b/apps/extension/src/core/libs/IconManager.ts
@@ -1,14 +1,13 @@
 import { requestStore } from "@core/libs/requests/store"
-import { windowManager } from "@core/libs/WindowManager"
 import Browser from "webextension-polyfill"
 
 class IconManager {
   constructor() {
     // update the icon when any of the request stores change
-    requestStore.observable.subscribe(() => this.updateIcon(true))
+    requestStore.observable.subscribe(() => this.updateIcon())
   }
 
-  private updateIcon(shouldClose?: boolean): void {
+  private updateIcon(): void {
     const counts = requestStore.getCounts()
     const signingCount =
       counts.get("eth-send") + counts.get("eth-sign") + counts.get("substrate-sign")
@@ -30,10 +29,6 @@ class IconManager {
       : ""
 
     Browser.browserAction.setBadgeText({ text })
-
-    if (shouldClose && text === "") {
-      windowManager.popupClose()
-    }
   }
 }
 

--- a/apps/extension/src/core/libs/WindowManager.ts
+++ b/apps/extension/src/core/libs/WindowManager.ts
@@ -160,7 +160,8 @@ class WindowManager {
       })
     }
 
-    return popup.id
+    // popup is undefined when running tests
+    return popup?.id
   }
 }
 

--- a/apps/extension/src/core/libs/WindowManager.ts
+++ b/apps/extension/src/core/libs/WindowManager.ts
@@ -99,9 +99,14 @@ class WindowManager {
     return true
   }
 
-  popupClose(): void {
-    this.#windows.forEach((id) => Browser.windows.remove(id))
-    this.#windows = []
+  async popupClose(id?: number) {
+    if (id) {
+      await Browser.windows.remove(id)
+      this.#windows = this.#windows.filter((wid) => wid !== id)
+    } else {
+      await Promise.all(this.#windows.map((wid) => Browser.windows.remove(wid)))
+      this.#windows = []
+    }
   }
 
   async popupOpen(argument?: string, onClose?: () => void) {
@@ -154,6 +159,8 @@ class WindowManager {
         }
       })
     }
+
+    return popup.id
   }
 }
 

--- a/apps/extension/src/core/libs/requests/store.ts
+++ b/apps/extension/src/core/libs/requests/store.ts
@@ -1,3 +1,4 @@
+import { TEST } from "@core/constants"
 import { genericSubscription } from "@core/handlers/subscriptions"
 import type { Port } from "@core/types/base"
 import { ReplaySubject, map } from "rxjs"
@@ -42,7 +43,7 @@ export class RequestStore {
   // `requests` is the primary list of items that need responding to by the user
   protected readonly requests: Record<
     string,
-    { request: AnyRespondableRequest; windowId: number }
+    { request: AnyRespondableRequest; windowId?: number } // windowId should always be set, except during ci tests
   > = {}
   // `observable` is kept up to date with the list of requests, and ensures that the front end
   // can easily set up a subscription to the data, and the state can show the correct message on the icon
@@ -109,7 +110,7 @@ export class RequestStore {
           reject(new Error("Cancelled"))
         })
         .then((windowId) => {
-          if (windowId === undefined) reject(new Error("Failed to open popup"))
+          if (windowId === undefined && !TEST) reject(new Error("Failed to open popup"))
           else {
             this.requests[id] = { request, windowId }
             this.observable.next(this.getAllRequests())


### PR DESCRIPTION
- Fixes #1181 

Changes : 
- Request store now keeps track of windowId for each request, in order to close only the corresponding window after completing a request
- Icon manager is not in charge of closing popups anymore