### PR TITLE
fix: faster QR scanning

### DIFF
--- a/apps/extension/src/ui/domains/Sign/Qr/QrSubstrate.tsx
+++ b/apps/extension/src/ui/domains/Sign/Qr/QrSubstrate.tsx
@@ -256,7 +256,7 @@ const SendPage = ({
   return (
     <>
       <div className="flex h-full flex-col items-center justify-end">
-        <div className="relative flex aspect-square w-full max-w-md items-center justify-center rounded-xl bg-white p-10">
+        <div className="relative flex aspect-square w-full max-w-md items-center justify-center rounded-xl bg-white p-12">
           <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
             <LoaderIcon className="animate-spin-slow text-body-secondary !text-3xl" />
           </div>


### PR DESCRIPTION
Fixes a problem that i found while investigating on issue 1198 (which i could not reproduce)

the white padding around the QR wasn't big enough, resulting in my android PV scanning only 1 frame every few seconds
with a bigger padding it now scans very fast, at least 5+ frames per sec