### PR TITLE
perf: better qr generation performance

### DIFF
--- a/apps/playground/src/components/Substrate/sign/SignMessageBig.tsx
+++ b/apps/playground/src/components/Substrate/sign/SignMessageBig.tsx
@@ -17,7 +17,7 @@ const SignMessageInner = () => {
   const [result, setResult] = useState<SignerResult>()
   const [error, setError] = useState<Error>()
   const [isProcessing, setIsProcessing] = useState<boolean>(false)
-  const [message] = useState(() => "Thanos was right.\n".repeat(1_000_000))
+  const [message] = useState(() => "Thanos was right.\n".repeat(10000))
 
   const handleSignMessageClick = useCallback(async () => {
     setError(undefined)


### PR DESCRIPTION
Enhances performance of the QR code generation, from 28s to 26s for a 33K frames test payload.

Basically It reduces the amount of re-renders & reduces the computation done on each render iteration, allowing more resources to be used on the QR generation