### PR TITLE
fix: substrate transactions stuck in pending state

### DIFF
--- a/apps/extension/src/core/domains/transactions/helpers.ts
+++ b/apps/extension/src/core/domains/transactions/helpers.ts
@@ -137,6 +137,11 @@ export const updateTransactionStatus = async (
   }
 }
 
+export const getTransactionStatus = async (hash: string) => {
+  const tx = await db.transactions.get(hash)
+  return tx?.status ?? "unknown"
+}
+
 export const updateTransactionsRestart = async () => {
   try {
     // mark all pending transactions as unknown


### PR DESCRIPTION
- Fixes #1195

Substrate transactions that are still `pending` after subscriptions closed will have their status set to `unknown`