### PR TITLE
fix: add custom token popup for known tokens

### DIFF
--- a/apps/extension/src/core/domains/tokens/handler.ts
+++ b/apps/extension/src/core/domains/tokens/handler.ts
@@ -98,9 +98,11 @@ export default class TokensHandler extends ExtensionHandler {
         return newTokenId
       }
 
-      case "pri(tokens.erc20.custom.remove)":
-        return chaindataProvider.removeCustomToken((request as RequestIdOnly).id)
-
+      case "pri(tokens.erc20.custom.remove)": {
+        const { id } = request as RequestIdOnly
+        await activeTokensStore.resetActive(id)
+        return chaindataProvider.removeCustomToken(id)
+      }
       default:
         throw new Error(`Unable to handle message of type ${type}`)
     }

--- a/apps/extension/src/core/domains/tokens/handler.ts
+++ b/apps/extension/src/core/domains/tokens/handler.ts
@@ -10,6 +10,7 @@ import { githubUnknownTokenLogoUrl } from "@talismn/chaindata-provider"
 import { MessageTypes, RequestTypes, ResponseType } from "core/types"
 
 import { assetDiscoveryScanner } from "../assetDiscovery/scanner"
+import { activeTokensStore } from "./store.activeTokens"
 
 export default class TokensHandler extends ExtensionHandler {
   public async handle<TMessageType extends MessageTypes>(
@@ -90,7 +91,11 @@ export default class TokensHandler extends ExtensionHandler {
           contractAddress,
         })
 
-        return chaindataProvider.addCustomToken(newToken)
+        const newTokenId = await chaindataProvider.addCustomToken(newToken)
+
+        if (newTokenId) await activeTokensStore.setActive(newTokenId, true)
+
+        return newTokenId
       }
 
       case "pri(tokens.erc20.custom.remove)":

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/ResetEvmNetworkButton.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/ResetEvmNetworkButton.tsx
@@ -4,7 +4,6 @@ import { useOpenClose } from "@talisman/hooks/useOpenClose"
 import { api } from "@ui/api"
 import { FC, useCallback } from "react"
 import { Trans, useTranslation } from "react-i18next"
-import { useNavigate } from "react-router-dom"
 import { ModalDialog } from "talisman-ui"
 import { Button, Modal } from "talisman-ui"
 
@@ -12,14 +11,12 @@ export const ResetEvmNetworkButton: FC<{ network: EvmNetwork | CustomEvmNetwork 
   network,
 }) => {
   const { t } = useTranslation("admin")
-  const navigate = useNavigate()
   const { isOpen, open, close } = useOpenClose()
 
   const handleConfirmReset = useCallback(async () => {
     if (!network) return
     try {
       await api.ethNetworkReset(network.id.toString())
-      navigate("/networks/ethereum")
     } catch (err) {
       notify({
         title: t("Failed to reset"),
@@ -27,7 +24,7 @@ export const ResetEvmNetworkButton: FC<{ network: EvmNetwork | CustomEvmNetwork 
         type: "error",
       })
     }
-  }, [network, navigate, t])
+  }, [network, t])
 
   const networkName = network?.name ?? t("N/A")
 


### PR DESCRIPTION
- allows the add token popup to show up for known tokens that are currently disabled
- enforces active state when adding custom networks, to prevent them from disappearing if reset to default chaindata state
- clear its active state after removing a custom token

