### PR TITLE
fix: evm network reset

### DIFF
--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/ResetEvmNetworkButton.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/ResetEvmNetworkButton.tsx
@@ -1,9 +1,11 @@
 import { CustomEvmNetwork, EvmNetwork } from "@core/domains/ethereum/types"
 import { notify } from "@talisman/components/Notifications"
 import { useOpenClose } from "@talisman/hooks/useOpenClose"
+import { sleep } from "@talismn/util"
 import { api } from "@ui/api"
-import { FC, useCallback } from "react"
+import { FC, useCallback, useEffect, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
+import { useNavigate } from "react-router-dom"
 import { ModalDialog } from "talisman-ui"
 import { Button, Modal } from "talisman-ui"
 
@@ -12,11 +14,15 @@ export const ResetEvmNetworkButton: FC<{ network: EvmNetwork | CustomEvmNetwork 
 }) => {
   const { t } = useTranslation("admin")
   const { isOpen, open, close } = useOpenClose()
+  const navigate = useNavigate()
 
   const handleConfirmReset = useCallback(async () => {
     if (!network) return
     try {
       await api.ethNetworkReset(network.id.toString())
+      close()
+      await sleep(350) // wait for atom to reflect changes
+      navigate("/networks/ethereum")
     } catch (err) {
       notify({
         title: t("Failed to reset"),
@@ -24,16 +30,20 @@ export const ResetEvmNetworkButton: FC<{ network: EvmNetwork | CustomEvmNetwork 
         type: "error",
       })
     }
-  }, [network, t])
+  }, [close, navigate, network, t])
 
-  const networkName = network?.name ?? t("N/A")
+  // keep name in memory to allow for popup closing animation
+  const [networkName, setNetworkName] = useState<string>(() => network?.name ?? t("N/A"))
+  useEffect(() => {
+    if (network) setNetworkName(network?.name ?? t("N/A"))
+  }, [network, t])
 
   return (
     <>
       <Button type="button" className="mt-8" onClick={open}>
         {t("Reset to defaults")}
       </Button>
-      <Modal isOpen={isOpen && !!network} onDismiss={close}>
+      <Modal isOpen={isOpen} onDismiss={close}>
         <ModalDialog title={t("Reset Network")} onClose={close}>
           <div className="text-body-secondary mt-4 space-y-16">
             <div className="text-base">

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Substrate/ResetSubNetworkButton.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Substrate/ResetSubNetworkButton.tsx
@@ -1,8 +1,9 @@
 import { notify } from "@talisman/components/Notifications"
 import { useOpenClose } from "@talisman/hooks/useOpenClose"
 import { Chain, CustomChain } from "@talismn/chaindata-provider"
+import { sleep } from "@talismn/util"
 import { api } from "@ui/api"
-import { FC, useCallback } from "react"
+import { FC, useCallback, useEffect, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { ModalDialog } from "talisman-ui"
@@ -17,6 +18,7 @@ export const ResetSubNetworkButton: FC<{ chain: Chain | CustomChain }> = ({ chai
     if (!chain) return
     try {
       await api.chainReset(chain.id)
+      await sleep(350) // wait for atom to reflect changes
       navigate("/networks/polkadot")
     } catch (err) {
       notify({
@@ -27,19 +29,23 @@ export const ResetSubNetworkButton: FC<{ chain: Chain | CustomChain }> = ({ chai
     }
   }, [chain, navigate, t])
 
-  const name = chain?.name ?? t("N/A")
+  // keep name in memory to allow for popup closing animation
+  const [networkName, setNetworkName] = useState<string>(() => chain?.name ?? t("N/A"))
+  useEffect(() => {
+    if (chain) setNetworkName(chain?.name ?? t("N/A"))
+  }, [chain, t])
 
   return (
     <>
       <Button type="button" className="mt-8" onClick={open}>
         {t("Reset to defaults")}
       </Button>
-      <Modal isOpen={isOpen && !!chain} onDismiss={close}>
+      <Modal isOpen={isOpen} onDismiss={close}>
         <ModalDialog title={t("Reset Network")} onClose={close}>
           <div className="text-body-secondary mt-4 space-y-16">
             <div className="text-base">
               <Trans t={t}>
-                Network <span className="text-body">{name}</span> will be reset to Talisman's
+                Network <span className="text-body">{networkName}</span> will be reset to Talisman's
                 default settings.
               </Trans>
             </div>

--- a/apps/extension/src/ui/hooks/useKnownEvmNetwork.ts
+++ b/apps/extension/src/ui/hooks/useKnownEvmNetwork.ts
@@ -32,7 +32,7 @@ export const useKnownEvmNetwork = (evmNetworkId: string | null | undefined) => {
   )
   const resetToTalismanDefault = useCallback(() => {
     if (!evmNetworkId || !evmNetwork) throw new Error(`EvmNetwork '${evmNetworkId}' not found`)
-    activeEvmNetworksStore.resetActive(evmNetworkId)
+    return activeEvmNetworksStore.resetActive(evmNetworkId)
   }, [evmNetwork, evmNetworkId])
 
   return {


### PR DESCRIPTION
couldn't come up with a safe way to update the form's value upon reset, so i've put back the logic to navigate to the networks list screen