### PR TITLE
feat: search token by address

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/Tokens/TokensPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Tokens/TokensPage.tsx
@@ -284,7 +284,10 @@ export const TokensPage = () => {
       )
 
     return filteredTokens.filter(
-      (t) => !lowerSearch || t.symbol.toLowerCase().includes(lowerSearch)
+      (t) =>
+        !lowerSearch ||
+        t.symbol.toLowerCase().includes(lowerSearch) ||
+        t.contractAddress.toLowerCase().includes(lowerSearch)
     )
   }, [activeTokens, evmNetworkId, filteredTokens, search])
 


### PR DESCRIPTION
when i wanted to add a token by address, it felt natural to paste the address in the search box

result: 

![image](https://github.com/TalismanSociety/talisman/assets/26880866/e58ade0c-0d46-4653-9dae-11a1af8af8ae)
