### PR TITLE
feat: token type pill on the token picker

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
@@ -35,6 +35,7 @@ import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { Fiat } from "@ui/domains/Asset/Fiat"
 import { TokenLogo } from "@ui/domains/Asset/TokenLogo"
 import Tokens from "@ui/domains/Asset/Tokens"
+import { TokenTypePill } from "@ui/domains/Asset/TokenTypePill"
 import useAccounts from "@ui/hooks/useAccounts"
 import { useActiveEvmNetworksState } from "@ui/hooks/useActiveEvmNetworksState"
 import { useActiveTokensState } from "@ui/hooks/useActiveTokensState"
@@ -77,35 +78,6 @@ const ANALYTICS_PAGE: AnalyticsPage = {
   feature: "Asset Discovery",
   featureVersion: 1,
   page: "Settings - Asset Discovery",
-}
-
-const TokenTypePill: FC<{ type: Token["type"]; className?: string }> = ({ type, className }) => {
-  const { t } = useTranslation("admin")
-
-  const label = useMemo(() => {
-    switch (type) {
-      case "evm-erc20":
-        return t("ERC20")
-      case "evm-native":
-        return t("Native")
-      default:
-        // unsupported for now
-        throw null
-    }
-  }, [t, type])
-
-  if (!label) return null
-
-  return (
-    <span
-      className={classNames(
-        "text-body-disabled rounded-sm border px-2 py-1 text-[1rem]",
-        className
-      )}
-    >
-      {label}
-    </span>
-  )
 }
 
 const AccountsTooltip: FC<{ addresses: Address[] }> = ({ addresses }) => {

--- a/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
+++ b/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
@@ -25,6 +25,7 @@ import { ChainLogoBase } from "./ChainLogo"
 import { Fiat } from "./Fiat"
 import { TokenLogo } from "./TokenLogo"
 import Tokens from "./Tokens"
+import { TokenTypePill } from "./TokenTypePill"
 
 type TokenRowProps = {
   token: Token
@@ -122,8 +123,9 @@ const TokenRow: FC<TokenRowProps> = ({
                 selected ? "text-body-secondary" : "text-body"
               )}
             >
-              <div>
-                {token.symbol}
+              <div className="flex items-center">
+                <span>{token.symbol}</span>
+                <TokenTypePill type={token.type} className="rounded-xs ml-3 px-1 py-0.5" />
                 {selected && <CheckCircleIcon className="ml-3 inline align-text-top" />}
               </div>
               <div className={classNames(isLoading && "animate-pulse")}>

--- a/apps/extension/src/ui/domains/Asset/TokenTypePill.tsx
+++ b/apps/extension/src/ui/domains/Asset/TokenTypePill.tsx
@@ -1,0 +1,36 @@
+import { Token } from "@talismn/chaindata-provider"
+import { classNames } from "@talismn/util"
+import { FC, useMemo } from "react"
+import { useTranslation } from "react-i18next"
+
+export const TokenTypePill: FC<{ type: Token["type"]; className?: string }> = ({
+  type,
+  className,
+}) => {
+  const { t } = useTranslation()
+
+  const label = useMemo(() => {
+    switch (type) {
+      case "evm-erc20":
+        return t("ERC20")
+      case "evm-native":
+        return t("Native")
+      default:
+        // unsupported for now
+        return null
+    }
+  }, [t, type])
+
+  if (!label) return null
+
+  return (
+    <span
+      className={classNames(
+        "text-body-disabled rounded-sm border px-2 py-1 text-[1rem]",
+        className
+      )}
+    >
+      {label}
+    </span>
+  )
+}


### PR DESCRIPTION
added a token type pill in the token picker as some ERC20 & native tokens have same symbol 

note: the token picker is used by send funds, copy address modal (for now), and buy tokens modal
note 2: the pill only displays for EVM Native & ERC20 tokens, substrate ones are ignored

![image](https://github.com/TalismanSociety/talisman/assets/26880866/83554579-9cfa-4105-bbee-edeaa7c7bbba)
