### PR TITLE
fix: tokenRates migration

### DIFF
--- a/apps/extension/src/core/db/upgrades/2024-01-25-upgradeRemoveSymbolFromNativeTokenId.ts
+++ b/apps/extension/src/core/db/upgrades/2024-01-25-upgradeRemoveSymbolFromNativeTokenId.ts
@@ -2,7 +2,7 @@ import { WalletTransaction } from "@core/domains/transactions"
 import { DbTokenRates } from "@talismn/token-rates"
 import { Transaction as DbTransaction } from "dexie"
 
-// For db version 8, Wallet version 1.21.0
+// For DB version 8, Wallet version 1.21.0
 export const upgradeRemoveSymbolFromNativeTokenId = async (tx: DbTransaction) => {
   await tx
     .table<WalletTransaction, string>("transactions")
@@ -15,16 +15,18 @@ export const upgradeRemoveSymbolFromNativeTokenId = async (tx: DbTransaction) =>
         wtx.tokenId = wtx.tokenId.replace(/-evm-native-.+$/, "-evm-native")
     })
 
-  await tx
-    .table<DbTokenRates, string>("tokenRates")
-    .toCollection()
-    .modify((tokenRate) => {
-      if (tokenRate?.tokenId?.includes?.("-substrate-native-")) {
+  const uniqueTokenRates = new Map(
+    (await tx.table<DbTokenRates, string>("tokenRates").toArray()).map((tokenRate) => {
+      if (tokenRate?.tokenId?.includes?.("-substrate-native-"))
         tokenRate.tokenId = tokenRate.tokenId.replace(/-substrate-native-.+$/, "-substrate-native")
-      }
 
-      if (tokenRate?.tokenId?.includes?.("-evm-native-")) {
+      if (tokenRate?.tokenId?.includes?.("-evm-native-"))
         tokenRate.tokenId = tokenRate.tokenId.replace(/-evm-native-.+$/, "-evm-native")
-      }
+
+      return [tokenRate.tokenId, tokenRate]
     })
+  )
+
+  await tx.table<DbTokenRates, string>("tokenRates").clear()
+  await tx.table<DbTokenRates, string>("tokenRates").bulkPut([...uniqueTokenRates.values()])
 }


### PR DESCRIPTION
Previous migration kills the crab in prod

New migration will only run for users who either (a) haven't upgraded yet, or (b) encountered the db error after upgrading