### PR TITLE
fix: allow signing eip712 message with invalid verifying contract

### DIFF
--- a/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessage.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessage.tsx
@@ -5,7 +5,7 @@ import { isHexString, stripHexPrefix } from "@ethereumjs/util"
 import { hexToString } from "@polkadot/util"
 import * as Sentry from "@sentry/browser"
 import { ParsedMessage } from "@spruceid/siwe-parser"
-import { classNames, isEthereumAddress } from "@talismn/util"
+import { classNames } from "@talismn/util"
 import { Message } from "@ui/domains/Sign/Message"
 import { useEvmNetwork } from "@ui/hooks/useEvmNetwork"
 import { dump as convertToYaml } from "js-yaml"
@@ -33,7 +33,8 @@ const useEthSignMessage = (request: EthSignRequest) => {
         ? parseInt(typedMessage.domain?.chainId)
         : undefined
       const ethChainId = request.ethChainId
-      const isInvalidVerifyingContract = verifyingAddress && !isEthereumAddress(verifyingAddress)
+      const isInvalidVerifyingContract =
+        verifyingAddress && verifyingAddress.toLowerCase().startsWith("javascript:")
       return {
         isTypedData,
         typedMessage,
@@ -118,8 +119,8 @@ export const EthSignBodyMessage: FC<EthSignBodyMessageProps> = ({ account, reque
           <SignParamAccountButton address={account.address} withIcon />
         </div>
         {!!verifyingAddress && !!evmNetwork && (
-          <div className="flex items-start p-1">
-            <div>{t("for contract")}</div>{" "}
+          <div className="flex max-w-full items-start p-1">
+            <div className="whitespace-nowrap">{t("for contract")}</div>{" "}
             <SignParamNetworkAddressButton address={verifyingAddress} network={evmNetwork} />
           </div>
         )}

--- a/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamButton.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamButton.tsx
@@ -1,4 +1,3 @@
-import { isEthereumAddress } from "@polkadot/util-crypto"
 import { CopyIcon, ExternalLinkIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
 import { copyAddress } from "@ui/util/copyAddress"
@@ -30,7 +29,7 @@ export const SignParamButton: FC<SignParamButtonProps> = ({
 
   const handleClick = useCallback(() => {
     if (url) window.open(url, "_blank")
-    else if (address && isEthereumAddress(address)) copyAddress(address)
+    else if (address) copyAddress(address)
   }, [address, url])
 
   return (
@@ -42,7 +41,9 @@ export const SignParamButton: FC<SignParamButtonProps> = ({
         className
       )}
     >
-      {iconPrefix && <div className="flex h-full flex-col justify-center">{iconPrefix}</div>}
+      {iconPrefix && (
+        <div className="flex h-full shrink-0 flex-col justify-center">{iconPrefix}</div>
+      )}
       <div className={classNames("max-w-full overflow-hidden text-ellipsis", contentClassName)}>
         {children}
       </div>

--- a/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamContractButton.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamContractButton.tsx
@@ -22,11 +22,11 @@ export const SignParamNetworkAddressButton: FC<SignParamNetworkAddressButtonProp
   className,
 }) => {
   const nativeToken = useToken(network.nativeToken?.id)
-  const isInvalidAddress = useMemo(() => !isEthereumAddress(address), [address])
+  const isInvalidAddress = useMemo(() => address.toLowerCase().startsWith("javascript:"), [address])
 
   return (
     <SignParamButton
-      explorerUrl={network.explorerUrl}
+      explorerUrl={isInvalidAddress ? undefined : network.explorerUrl}
       address={address}
       iconPrefix={
         <AssetLogo
@@ -45,8 +45,11 @@ export const SignParamNetworkAddressButton: FC<SignParamNetworkAddressButtonProp
           </TooltipTrigger>
           <TooltipContent>{address}</TooltipContent>
         </Tooltip>
-      ) : (
+      ) : // could be a text address. ex: swap DYM on https://portal.dymension.xyz/
+      isEthereumAddress(address) ? (
         <Address startCharCount={6} endCharCount={4} address={address} />
+      ) : (
+        address
       )}
     </SignParamButton>
   )

--- a/apps/extension/src/ui/domains/Sign/SignRequestContext/EthereumSignMessageRequestContext.ts
+++ b/apps/extension/src/ui/domains/Sign/SignRequestContext/EthereumSignMessageRequestContext.ts
@@ -2,7 +2,6 @@ import { KnownSigningRequestIdOnly } from "@core/domains/signing/types"
 import { log } from "@core/log"
 import { HexString } from "@polkadot/util/types"
 import { provideContext } from "@talisman/util/provideContext"
-import { isEthereumAddress } from "@talismn/util"
 import { api } from "@ui/api"
 import { useEvmNetwork } from "@ui/hooks/useEvmNetwork"
 import { useRequest } from "@ui/hooks/useRequest"
@@ -44,7 +43,8 @@ const useEthSignMessageRequestProvider = ({ id }: KnownSigningRequestIdOnly<"eth
       // for now only check signTypedData's verifying contract's address
       const typedMessage = isTypedData ? JSON.parse(request.request) : undefined
       const verifyingContract = typedMessage?.domain?.verifyingContract as string | undefined
-      if (verifyingContract && !isEthereumAddress(verifyingContract)) return false
+      if (verifyingContract && verifyingContract.toLowerCase().startsWith("javascript:"))
+        return false
     }
 
     return true

--- a/apps/extension/src/ui/util/copyAddress.ts
+++ b/apps/extension/src/ui/util/copyAddress.ts
@@ -3,7 +3,7 @@ import { notify } from "@talisman/components/Notifications"
 import { shortenAddress } from "@talisman/util/shortenAddress"
 
 export const copyAddress = async (address: string, title?: string) => {
-  if (!address) return
+  if (!address || address.toLowerCase().startsWith("javascript:")) return
 
   const toastId = `copy_${address}`
 


### PR DESCRIPTION
We introduced a validity check on the verifying contract of an EIP712 during latest audit.
The audit feedback was about possibility to execute arbitrary javascript when copying it's address, though we thought it would be best to check that the address is a valid EVM address, unlike metamask which doesn't.

It turns out that veryfing contract address may not always be a evm address.
Our valid address check breaks features on some dapps such as https://portal.dymension.xyz/ 

This PR removes the evm valid address check, in favor of a .startsWith("javascript:") check