### PR TITLE
fix: migration errors bundle

### DIFF
--- a/.changeset/large-experts-stare.md
+++ b/.changeset/large-experts-stare.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": patch
+---
+
+fix: clear balance db if migration error

--- a/apps/extension/src/ui/apps/popup/index.tsx
+++ b/apps/extension/src/ui/apps/popup/index.tsx
@@ -68,9 +68,10 @@ const Popup = () => {
         <AccountExportModal />
         <AccountExportPrivateKeyModal />
         <CopyAddressModal />
-        <DatabaseErrorAlert container="popup" />
         <BackupWarningDrawer />
       </Suspense>
+      {/* Render outside of suspense or it will never show in case of migration error */}
+      <DatabaseErrorAlert container="popup" />
     </FadeIn>
   )
 }

--- a/packages/balances/src/upgrades/2024-01-25-upgradeRemoveSymbolFromNativeTokenId.ts
+++ b/packages/balances/src/upgrades/2024-01-25-upgradeRemoveSymbolFromNativeTokenId.ts
@@ -1,20 +1,27 @@
 import { Transaction } from "dexie"
 
+import log from "../log"
 import { Balance, BalanceJson } from "../types"
 
 // for DB version 3, Wallet version 1.21.0
 export const upgradeRemoveSymbolFromNativeTokenId = async (tx: Transaction) => {
   const balancesTable = tx.table<BalanceJson & { id: string }, string>("balances")
 
-  await balancesTable.toCollection().modify((balance) => {
-    if (balance?.tokenId?.includes?.("-substrate-native-")) {
-      balance.tokenId = balance.tokenId.replace(/-substrate-native-.+$/, "-substrate-native")
-      balance.id = new Balance(balance).id
-    }
+  try {
+    await balancesTable.toCollection().modify((balance) => {
+      if (balance?.tokenId?.includes?.("-substrate-native-")) {
+        balance.tokenId = balance.tokenId.replace(/-substrate-native-.+$/, "-substrate-native")
+        balance.id = new Balance(balance).id
+      }
 
-    if (balance?.tokenId?.includes?.("-evm-native-")) {
-      balance.tokenId = balance.tokenId.replace(/-evm-native-.+$/, "-evm-native")
-      balance.id = new Balance(balance).id
-    }
-  })
+      if (balance?.tokenId?.includes?.("-evm-native-")) {
+        balance.tokenId = balance.tokenId.replace(/-evm-native-.+$/, "-evm-native")
+        balance.id = new Balance(balance).id
+      }
+    })
+  } catch (err) {
+    // error most likely due to duplicate ids => clear the db
+    log.error("Failed to upgrade balances native token ids", { err })
+    throw err
+  }
 }

--- a/packages/balances/src/upgrades/2024-01-25-upgradeRemoveSymbolFromNativeTokenId.ts
+++ b/packages/balances/src/upgrades/2024-01-25-upgradeRemoveSymbolFromNativeTokenId.ts
@@ -22,6 +22,6 @@ export const upgradeRemoveSymbolFromNativeTokenId = async (tx: Transaction) => {
   } catch (err) {
     // error most likely due to duplicate ids => clear the db
     log.error("Failed to upgrade balances native token ids", { err })
-    throw err
+    await balancesTable.clear()
   }
 }


### PR DESCRIPTION
- clears the database if there is an error occuring while changing id of balance entries as part of the db migration
- ensures the db error dialog can display