### PR TITLE
feat: settings routes structure

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/index.tsx
+++ b/apps/extension/src/ui/apps/dashboard/index.tsx
@@ -76,35 +76,68 @@ const DashboardInner = () => {
         </Route>
         <Route path="settings">
           <Route path="" element={<Navigate to="/settings/general" replace />} />
-          <Route path="general" element={<GeneralPage />} />
-          <Route path="language" element={<LanguagePage />} />
-          <Route path="currency" element={<CurrencySettingsPage />} />
+          <Route path="general">
+            <Route path="" element={<GeneralPage />} />
+            <Route path="language" element={<LanguagePage />} />
+            <Route path="currency" element={<CurrencySettingsPage />} />
+            <Route path="*" element={<Navigate to="" replace />} />
+          </Route>
           <Route path="address-book" element={<AddressBookPage />} />
           <Route path="connected-sites" element={<ConnectedSitesPage />} />
           <Route path="mnemonics" element={<MnemonicsPage />} />
           <Route path="accounts" element={<AccountsPage />} />
-          <Route path="security-privacy-settings" element={<SecurityPrivacyPage />} />
-          <Route path="change-password" element={<ChangePasswordPage />} />
-          <Route path="autolock" element={<AutoLockTimerPage />} />
-          <Route path="networks-tokens" element={<NetworksTokensPage />} />
-          <Route path="qr-metadata" element={<QrMetadataPage />} />
+          <Route path="security-privacy-settings">
+            <Route path="" element={<SecurityPrivacyPage />} />
+            <Route path="change-password" element={<ChangePasswordPage />} />
+            <Route path="autolock" element={<AutoLockTimerPage />} />
+            <Route path="*" element={<Navigate to="" replace />} />
+          </Route>
+          <Route path="networks-tokens">
+            <Route path="" element={<NetworksTokensPage />} />
+            <Route path="asset-discovery" element={<AssetDiscoveryPage />} />
+            <Route path="tokens">
+              <Route path="" element={<TokensPage />} />
+              <Route path="add" element={<AddCustomTokenPage />} />
+              <Route path=":id" element={<TokenPage />} />
+              <Route path="*" element={<Navigate to="" replace />} />
+            </Route>
+            <Route path="networks">
+              <Route path="" element={<Navigate to="ethereum" replace />} />
+              <Route path=":networksType" element={<NetworksPage />} />
+              <Route path=":networksType/add" element={<NetworkPage />} />
+              <Route path=":networksType/:id" element={<NetworkPage />} />
+              <Route path="*" element={<Navigate to="" replace />} />
+            </Route>
+            <Route path="qr-metadata" element={<QrMetadataPage />} />
+            <Route path="*" element={<Navigate to="" replace />} />
+          </Route>
           <Route path="about" element={<AboutPage />} />
           <Route path="analytics" element={<AnalyticsOptInPage />} />
-          <Route path="asset-discovery" element={<AssetDiscoveryPage />} />
+          {/* Old routes redirects */}
+          <Route
+            path="qr-metadata"
+            element={<Navigate to="networks-tokens/qr-metadata" replace />}
+          />
+          <Route
+            path="change-password"
+            element={<Navigate to="/settings/security-privacy-settings/change-password" replace />}
+          />
+          <Route
+            path="autolock"
+            element={<Navigate to="/settings/security-privacy-settings/autolock" replace />}
+          />
           <Route path="*" element={<Navigate to="" replace />} />
         </Route>
-        <Route path="tokens">
-          <Route path="" element={<TokensPage />} />
-          <Route path="add" element={<AddCustomTokenPage />} />
-          <Route path=":id" element={<TokenPage />} />
-        </Route>
-        <Route path="networks">
-          <Route path="" element={<Navigate to="/networks/ethereum" replace />} />
-          <Route path=":networksType" element={<NetworksPage />} />
-          <Route path=":networksType/add" element={<NetworkPage />} />
-          <Route path=":networksType/:id" element={<NetworkPage />} />
-          <Route path="*" element={<Navigate to="" replace />} />
-        </Route>
+        {/* Old routes redirects */}
+        <Route
+          path="networks"
+          element={<Navigate to="/settings/networks-tokens/networks" replace />}
+        />
+        <Route path="tokens" element={<Navigate to="/settings/networks-tokens/tokens" replace />} />
+        <Route
+          path="qr-metadata"
+          element={<Navigate to="/settings/networks-tokens/qr-metadata" replace />}
+        />
         <Route path="*" element={<Navigate to="/portfolio" replace />} />
       </Routes>
     </Suspense>

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/NetworkPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/NetworkPage.tsx
@@ -36,7 +36,7 @@ export const NetworkPage = () => {
   const isEvmNetwork = networksType === "ethereum"
 
   const handleSubmitted = useCallback(
-    () => navigate(`/networks/${networksType}`),
+    () => navigate(`/settings/networks-tokens/networks/${networksType}`),
     [navigate, networksType]
   )
 

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/useNetworksType.ts
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/useNetworksType.ts
@@ -10,7 +10,7 @@ export const useNetworksType = () => {
 
   const navigate = useNavigate()
   const setNetworksType = useCallback(
-    (networksType: ProviderType) => navigate(`/networks/${networksType}`),
+    (networksType: ProviderType) => navigate(`/settings/networks-tokens/networks/${networksType}`),
     [navigate]
   )
 

--- a/apps/extension/src/ui/apps/dashboard/routes/Portfolio/PortfolioAssets.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Portfolio/PortfolioAssets.tsx
@@ -60,9 +60,9 @@ const EnableNetworkMessage: FC<{ type?: "substrate" | "evm" }> = ({ type }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const handleClick = useCallback(() => {
-    if (type === "substrate") navigate("/networks/polkadot")
-    else if (type === "evm") navigate("/networks/ethereum")
-    else navigate("/networks")
+    if (type === "substrate") navigate("/settings/networks-tokens/networks/polkadot")
+    else if (type === "evm") navigate("/settings/networks-tokens/networks/ethereum")
+    else navigate("/settings/networks-tokens/networks")
   }, [navigate, type])
 
   return (

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/GeneralPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/GeneralPage.tsx
@@ -113,14 +113,14 @@ export const GeneralPage = () => {
           iconRight={ChevronRightIcon}
           title={t("Language")}
           subtitle={t("Change the wallet display language")}
-          to={`/settings/language`}
+          to={`/settings/general/language`}
         />
         <CtaButton
           iconLeft={DollarSignIcon}
           iconRight={ChevronRightIcon}
           title={t("Currency")}
           subtitle={t("Set currencies for viewing your portolio value")}
-          to={`/settings/currency`}
+          to={`/settings/general/currency`}
         />
         <Setting
           iconLeft={UserIcon}

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/NetworksTokensPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/NetworksTokensPage.tsx
@@ -32,7 +32,7 @@ export const NetworksTokensPage = () => {
           iconRight={ChevronRightIcon}
           title={t("Asset discovery")}
           subtitle={t("Scan for well-known tokens in your accounts and add them to Talisman")}
-          to={`/settings/asset-discovery`}
+          to={`/settings/networks-tokens/asset-discovery`}
         />
         <div className="via-primary/10 my-4 h-0.5 bg-gradient-to-r from-transparent to-transparent"></div>
         <Setting
@@ -60,21 +60,21 @@ export const NetworksTokensPage = () => {
           iconRight={ChevronRightIcon}
           title={t("Manage networks")}
           subtitle={t("Add, enable and disable networks")}
-          to={`/networks/ethereum`}
+          to={`/settings/networks-tokens/networks/ethereum`}
         />
         <CtaButton
           iconLeft={ListIcon}
           iconRight={ChevronRightIcon}
           title={t("Manage Ethereum tokens")}
           subtitle={t("Add or delete custom ERC20 tokens")}
-          to={`/tokens`}
+          to={`/settings/networks-tokens/tokens`}
         />
         <CtaButton
           iconLeft={PolkadotVaultIcon}
           iconRight={ChevronRightIcon}
           title={t("Polkadot Vault metadata")}
           subtitle={t("Register networks on your Polkadot Vault device, or update their metadata")}
-          to={`/settings/qr-metadata`}
+          to={`/settings/networks-tokens/qr-metadata`}
         />
       </div>
     </DashboardLayout>

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/SecurityPrivacyPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/SecurityPrivacyPage.tsx
@@ -41,7 +41,7 @@ export const SecurityPrivacyPage = () => {
               ? t("Change your Talisman password")
               : t("Please back up your recovery phrase before you change your password.")
           }
-          to={`/settings/change-password`}
+          to={`/settings/security-privacy-settings/change-password`}
           disabled={!allBackedUp}
         />
         <CtaButton
@@ -49,7 +49,7 @@ export const SecurityPrivacyPage = () => {
           iconRight={ChevronRightIcon}
           title={t("Auto-lock timer")}
           subtitle={t("Set a timer to automatically lock your Talisman wallet")}
-          to={`/settings/autolock`}
+          to={`/settings/security-privacy-settings/autolock`}
         />
         {useErrorTracking !== undefined && (
           <Setting

--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAssets.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAssets.tsx
@@ -33,9 +33,9 @@ import {
 const EnableNetworkMessage: FC<{ type?: "substrate" | "evm" }> = ({ type }) => {
   const { t } = useTranslation()
   const handleClick = useCallback(() => {
-    if (type === "substrate") api.dashboardOpen("/networks/polkadot")
-    else if (type === "evm") api.dashboardOpen("/networks/ethereum")
-    else api.dashboardOpen("/networks")
+    if (type === "substrate") api.dashboardOpen("/settings/networks-tokens/networks/polkadot")
+    else if (type === "evm") api.dashboardOpen("/settings/networks-tokens/networks/ethereum")
+    else api.dashboardOpen("/settings/networks-tokens/networks")
     window.close()
   }, [type])
 

--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioLearnMore.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioLearnMore.tsx
@@ -24,7 +24,7 @@ const newGoToFn = (analyticsAction: string, dashboardPath: string) => () => {
   return api.dashboardOpen(dashboardPath)
 }
 const goToSettingsAccounts = newGoToFn("Manage accounts", "/settings/accounts")
-const goToSettingsCurrency = newGoToFn("Change currencies", "/settings/currency")
+const goToSettingsCurrency = newGoToFn("Change currencies", "/settings/general/currency")
 const goToAddHardwareAccounts = newGoToFn(
   "Add hardware accounts",
   "/accounts/add?methodType=connect"

--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioWhatsNew.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioWhatsNew.tsx
@@ -131,7 +131,7 @@ export const PortfolioWhatsNewHeader = () => {
  *
  * You can add this to your markdown to get a button which links to any dashboard url:
  *
- *     <div class="button" data-app="dashboard" data-href="/networks/ethereum">Check it out</div>
+ *     <div class="button" data-app="dashboard" data-href="/settings/networks-tokens/networks/ethereum">Check it out</div>
  */
 const useWhatsNewNodes = (whatsNewHtml: string) => {
   /** A ref to the `dangerouslySetInnerHTML={{ __html: whatsNewHtml ?? "" }}` div element */

--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/assets/Whats New.md
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/assets/Whats New.md
@@ -2,15 +2,15 @@
 <!-- Update this ^ to change the version number shown in the header of the `What's New` view. -->
 
 **<span class="icon" data-icon="DiamondIcon"></span> Automatic asset discovery:** Talisman now automatically finds your ERC20 tokens and prompts you to add them to your portfolio.  
-<span class="button float-right" data-app="dashboard" data-href="/settings/asset-discovery">Check it out</span>
+<span class="button float-right" data-app="dashboard" data-href="/settings/networks-tokens/asset-discovery">Check it out</span>
 
 **<span class="icon" data-icon="SearchIcon"></span> Search for custom networks:** In addition to Talisman's default Ethereum networks, you can now easily add more. Search for any [Chainlist](https://chainid.network/) network you want to add by name or chain id.  
-<span class="button float-right" data-app="dashboard" data-href="/networks/ethereum">Check it out</span>
+<span class="button float-right" data-app="dashboard" data-href="/settings/networks-tokens/networks/ethereum">Check it out</span>
 
 **<span class="icon" data-icon="GlobeIcon"></span> Network selection:** Optimize performance by toggling off the networks you don't use.  
-<span class="button float-right" data-app="dashboard" data-href="/networks/polkadot">Check it out</span>
+<span class="button float-right" data-app="dashboard" data-href="/settings/networks-tokens/networks/polkadot">Check it out</span>
 
 **<span class="icon" data-icon="ListIcon"></span> Search for custom tokens:** In addition to Talisman's default Ethereum tokens, you can now easily add more. Search for any [Coingecko](https://www.coingecko.com/) token by symbol to add it to your portfolio.  
-<span class="button float-right" data-app="dashboard" data-href="/tokens">Check it out</span>
+<span class="button float-right" data-app="dashboard" data-href="/settings/networks-tokens/tokens">Check it out</span>
 
 **<span class="icon" data-icon="ZapIcon"></span> Blazing fast performance:** We've done a major overhaul of wallet performance. Talisman is now faster and smoother than ever before.

--- a/apps/extension/src/ui/domains/AssetDiscovery/AssetDiscoveryDashboardAlert.tsx
+++ b/apps/extension/src/ui/domains/AssetDiscovery/AssetDiscoveryDashboardAlert.tsx
@@ -56,7 +56,7 @@ export const AssetDiscoveryDashboardAlert = () => {
   const navigate = useNavigate()
 
   useEffect(() => {
-    if (!showAlert || location.pathname === "/settings/asset-discovery") {
+    if (!showAlert || location.pathname === "/settings/networks-tokens/asset-discovery") {
       toast.dismiss(ASSET_DISCOVERY_TOAST_ID)
       return
     }
@@ -72,7 +72,7 @@ export const AssetDiscoveryDashboardAlert = () => {
           autoClose: false,
           toastId: ASSET_DISCOVERY_TOAST_ID,
           onClick: () => {
-            navigate("/settings/asset-discovery")
+            navigate("/settings/networks-tokens/asset-discovery")
           },
           closeButton: () => (
             <Suspense>

--- a/apps/extension/src/ui/domains/AssetDiscovery/AssetDiscoveryPopupAlert.tsx
+++ b/apps/extension/src/ui/domains/AssetDiscovery/AssetDiscoveryPopupAlert.tsx
@@ -12,7 +12,7 @@ export const AssetDiscoveryPopupAlert = () => {
   const { t } = useTranslation()
 
   const handleGoToClick = useCallback(async () => {
-    await api.dashboardOpen("/settings/asset-discovery")
+    await api.dashboardOpen("/settings/networks-tokens/asset-discovery")
     window.close()
   }, [])
 

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/EvmNetworkForm.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/EvmNetworkForm.tsx
@@ -422,7 +422,7 @@ const ExistingNetworkModal: FC<{ evmNetworkId?: EvmNetworkId }> = ({ evmNetworkI
 
   const handleGoToClick = useCallback(() => {
     close()
-    navigate(`/networks/ethereum/${evmNetworkId}`, { replace: true })
+    navigate(`/settings/networks-tokens/networks/ethereum/${evmNetworkId}`, { replace: true })
   }, [close, evmNetworkId, navigate])
 
   return (

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/RemoveEvmNetworkButton.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/RemoveEvmNetworkButton.tsx
@@ -19,7 +19,7 @@ export const RemoveEvmNetworkButton: FC<{ network: EvmNetwork | CustomEvmNetwork
     if (!network) return
     try {
       await api.ethNetworkRemove(network.id.toString())
-      navigate("/networks/ethereum")
+      navigate("/settings/networks-tokens/networks/ethereum")
     } catch (err) {
       notify({
         title: t("Failed to remove"),

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/ResetEvmNetworkButton.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/ResetEvmNetworkButton.tsx
@@ -22,7 +22,7 @@ export const ResetEvmNetworkButton: FC<{ network: EvmNetwork | CustomEvmNetwork 
       await api.ethNetworkReset(network.id.toString())
       close()
       await sleep(350) // wait for atom to reflect changes
-      navigate("/networks/ethereum")
+      navigate("/settings/networks-tokens/networks/ethereum")
     } catch (err) {
       notify({
         title: t("Failed to reset"),

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Substrate/RemoveSubNetworkButton.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Substrate/RemoveSubNetworkButton.tsx
@@ -17,7 +17,7 @@ export const RemoveSubNetworkButton: FC<{ chain: Chain | CustomChain }> = ({ cha
     if (!chain) return
     try {
       await api.chainRemove(chain.id)
-      navigate("/networks/polkadot")
+      navigate("/settings/networks-tokens/networks/polkadot")
     } catch (err) {
       notify({
         title: t("Failed to remove"),

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Substrate/ResetSubNetworkButton.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Substrate/ResetSubNetworkButton.tsx
@@ -19,7 +19,7 @@ export const ResetSubNetworkButton: FC<{ chain: Chain | CustomChain }> = ({ chai
     try {
       await api.chainReset(chain.id)
       await sleep(350) // wait for atom to reflect changes
-      navigate("/networks/polkadot")
+      navigate("/settings/networks-tokens/networks/polkadot")
     } catch (err) {
       notify({
         title: t("Failed to reset"),

--- a/apps/extension/src/ui/domains/Sign/MetadataStatus.tsx
+++ b/apps/extension/src/ui/domains/Sign/MetadataStatus.tsx
@@ -57,7 +57,7 @@ export const MetadataStatus = ({ genesisHash, specVersion }: Props) => {
           <br />
           Please{" "}
           <a
-            href={`${window.location.origin}/dashboard.html#/networks/polkadot/add`}
+            href={`${window.location.origin}/dashboard.html#/settings/networks-tokens/networks/polkadot/add`}
             target="_blank"
             rel="noreferrer noopener"
             className="text-grey-200 hover:text-white"


### PR DESCRIPTION
Modified routes structure so that child screens are leafs of their parent screens.
This allows for the current section's link in sidebar to remain highlighted when browsing a level 2 settings page.

Note : added redirects from old urls to their associated new urls just in case i forgot to rewrite a link along the way