### PR TITLE
fix: send funds prevent address type mismatch

### DIFF
--- a/apps/extension/src/ui/domains/SendFunds/SendFundsRecipientPicker.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsRecipientPicker.tsx
@@ -3,6 +3,7 @@ import { ScrollContainer } from "@talisman/components/ScrollContainer"
 import { SearchInput } from "@talisman/components/SearchInput"
 import { convertAddress } from "@talisman/util/convertAddress"
 import { isValidAddress } from "@talisman/util/isValidAddress"
+import { isValidSubstrateAddress } from "@talisman/util/isValidSubstrateAddress"
 import { EyeIcon, LoaderIcon, TalismanHandIcon, UserIcon } from "@talismn/icons"
 import { useSendFundsWizard } from "@ui/apps/popup/pages/SendFunds/context"
 import useAccounts from "@ui/hooks/useAccounts"
@@ -29,7 +30,7 @@ export const SendFundsRecipientPicker = () => {
 
   const isValidAddressInput = useMemo(() => {
     if (!from) return isValidAddress(search)
-    return isFromEthereum ? isEthereumAddress(search) : isValidAddress(search)
+    return isFromEthereum ? isEthereumAddress(search) : isValidSubstrateAddress(search)
   }, [from, isFromEthereum, search])
 
   const [ensLookup, { isLookup: isEnsLookup, isFetching: isEnsFetching }] = useResolveEnsName(


### PR DESCRIPTION
fixed the recipient picker validation so a pasted EVM address can't be selected when transfering substrate assets