### PR TITLE
Fix simplelocalize in dev and yarn dev command issues

### DIFF
--- a/apps/extension/webpack/webpack.dev.js
+++ b/apps/extension/webpack/webpack.dev.js
@@ -18,7 +18,7 @@ const config = (env) =>
     devtool: "inline-cheap-module-source-map",
     mode: "development",
     watchOptions: {
-      ignored: ["**/node_modules", "**/dist"],
+      ignored: ["**/node_modules", "**/dist", "apps/extension/public/locales"],
     },
     plugins: [
       new SimpleLocalizeDownloadPlugin({ devMode: true }),

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "husky install",
     "dev": "concurrently --prefix \"{name}\" --prefix-colors auto \"npm:dev:*\"",
     "dev:balances-demo": "yarn workspace balances-demo dev",
-    "dev:extension": "yarn workspace extension dev",
+    "dev:extension": "preconstruct dev && yarn workspace extension dev",
     "dev:playground": "yarn workspace playground dev",
     "update:translations": "turbo run update:translations",
     "build": "turbo run build",


### PR DESCRIPTION
This PR
- updates the `SimpleLocalizeDownloadPlugin` to enable downloading and setting of supported languages in dev mode
- changes the `yarn dev:extension` command to include preconstruct by default