### PR TITLE
fix: equilibrium balances duplicates

### DIFF
--- a/.changeset/cuddly-glasses-destroy.md
+++ b/.changeset/cuddly-glasses-destroy.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": minor
+---
+
+fix: equilibrium/genshiro duplicated balances

--- a/packages/balances/src/modules/SubstrateEquilibriumModule.ts
+++ b/packages/balances/src/modules/SubstrateEquilibriumModule.ts
@@ -459,21 +459,23 @@ async function buildQueries(
             .map(({ id, free }: { id?: string; free?: string }) => [id, free])
         )
 
-        return Array.from(tokensByAddress.get(address) ?? []).map((token) => {
-          const free = tokenBalances[token.assetId] ?? "0"
-          return new Balance({
-            source: "substrate-equilibrium",
+        return Array.from(tokensByAddress.get(address) ?? [])
+          .filter((t) => t.chain.id === chainId)
+          .map((token) => {
+            const free = tokenBalances[token.assetId] ?? "0"
+            return new Balance({
+              source: "substrate-equilibrium",
 
-            status: "live",
+              status: "live",
 
-            address,
-            multiChainId: { subChainId: chainId },
-            chainId,
-            tokenId: token.id,
+              address,
+              multiChainId: { subChainId: chainId },
+              chainId,
+              tokenId: token.id,
 
-            free,
+              free,
+            })
           })
-        })
       }
 
       return { chainId, stateKey, decodeResult }


### PR DESCRIPTION
- Fixes #1315

Genshiro chain token balances were duplicated, duplicates were associated to equilibrium.

So DB contained invalid balance entries, ex : 
```json
{
  chainId:"equilibrium-polkadot", 
  tokenId:"genshiro-kusama.....",
  ...
}
```