### PR TITLE
fix: connect signet dead object

### DIFF
--- a/apps/extension/src/ui/util/signet/signet.ts
+++ b/apps/extension/src/ui/util/signet/signet.ts
@@ -15,8 +15,14 @@ export const signet = {
       if (!newTab) return reject("Failed to open new tab")
 
       const intervalId = setInterval(() => {
-        if (newTab.closed) reject("Canceled")
-      }, 500)
+        try {
+          if (newTab.closed) reject("Canceled")
+        } catch (e) {
+          // FireFox blocks access to newTab and throws an error
+          clearInterval(intervalId)
+          reject("Blocked by browser")
+        }
+      }, 2000)
 
       const url = new URL(signetUrl)
       const handleNewMessage = (event: MessageEvent) => {

--- a/apps/extension/src/ui/util/signet/signet.ts
+++ b/apps/extension/src/ui/util/signet/signet.ts
@@ -16,7 +16,10 @@ export const signet = {
 
       const intervalId = setInterval(() => {
         try {
-          if (newTab.closed) reject("Canceled")
+          if (newTab.closed) {
+            clearInterval(intervalId)
+            reject("Canceled")
+          }
         } catch (e) {
           // FireFox blocks access to newTab and throws an error
           clearInterval(intervalId)

--- a/apps/extension/src/ui/util/signet/signet.ts
+++ b/apps/extension/src/ui/util/signet/signet.ts
@@ -22,7 +22,7 @@ export const signet = {
           clearInterval(intervalId)
           reject("Blocked by browser")
         }
-      }, 2000)
+      }, 500)
 
       const url = new URL(signetUrl)
       const handleNewMessage = (event: MessageEvent) => {


### PR DESCRIPTION
Firefox blocks access to the opened tab. This PR handles that case gracefully by catching the error and toasting "Blocked by browser" message