### PR TITLE
fix: evm tx browser notification

### DIFF
--- a/.changeset/purple-bulldogs-grin.md
+++ b/.changeset/purple-bulldogs-grin.md
@@ -1,0 +1,5 @@
+---
+"extension-core": patch
+---
+
+evm tx success check for browser notification

--- a/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
+++ b/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
@@ -69,10 +69,9 @@ export const watchEthereumTransaction = async (
         )
       }
 
-      // success if associated to a block number
       if (withNotifications)
         await createNotification(
-          receipt.blockNumber && receipt.status ? "success" : "error",
+          receipt.status === "success" ? "success" : "error",
           networkName,
           txUrl
         )


### PR DESCRIPTION
Fixes old regression from ethers => viem migration

Noticed the while performing a swap that reverted. Browser/OS notification stated that transaction confirmed, while it didn't.