### PR TITLE
fix: copy modal - restrict to evm accounts for evm networks

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/layout/Sidebar/MainHeader.tsx
+++ b/apps/extension/src/ui/apps/dashboard/layout/Sidebar/MainHeader.tsx
@@ -29,7 +29,7 @@ export const MainHeader = () => {
   const handleCopyClick = useCallback(() => {
     openCopyAddressModal({
       address: account?.address,
-      chainId: chain?.id,
+      networkId: chain?.id,
     })
     genericEvent("open receive", { from: "sidebar" })
   }, [account?.address, chain?.id, genericEvent, openCopyAddressModal])

--- a/apps/extension/src/ui/apps/dashboard/routes/Portfolio/AccountContextMenu.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Portfolio/AccountContextMenu.tsx
@@ -86,7 +86,7 @@ export const AccountContextMenu = forwardRef<HTMLElement, Props>(function Accoun
   const copyAddress = useCallback(() => {
     if (!account) return
     genericEvent("open copy address", { from: analyticsFrom })
-    openCopyAddressModal({ address: account.address, chainId: chain?.id })
+    openCopyAddressModal({ address: account.address, networkId: chain?.id })
   }, [account, analyticsFrom, chain?.id, genericEvent, openCopyAddressModal])
 
   const { open: _openAccountRenameModal } = useAccountRenameModal()

--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAccounts.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAccounts.tsx
@@ -83,7 +83,7 @@ const CopyAddressButton: FC<{ option: AccountOption }> = ({ option }) => {
         })
         open({
           address: option.address,
-          chainId: chain?.id,
+          networkId: chain?.id,
         })
       }
     },

--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAssets.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAssets.tsx
@@ -107,7 +107,7 @@ const CopyAddressButton: FC<{ account?: AccountJsonAny }> = ({ account }) => {
   const copyAddress = useCallback(() => {
     openCopyAddressModal({
       address: account?.address,
-      chainId: chain?.id,
+      networkId: chain?.id,
     })
     genericEvent("open copy address", { from: "popup portfolio" })
   }, [account?.address, chain?.id, genericEvent, openCopyAddressModal])

--- a/apps/extension/src/ui/domains/CopyAddress/CopyAddressAccountForm.tsx
+++ b/apps/extension/src/ui/domains/CopyAddress/CopyAddressAccountForm.tsx
@@ -159,7 +159,7 @@ export const AccountsList: FC<AccountsListProps> = ({ selected, accounts, onSele
 }
 
 export const CopyAddressAccountForm = () => {
-  const { address, setAddress, chain } = useCopyAddressWizard()
+  const { address, setAddress, chain, evmNetwork } = useCopyAddressWizard()
   const { t } = useTranslation()
   const [search, setSearch] = useState("")
 
@@ -173,8 +173,9 @@ export const CopyAddressAccountForm = () => {
           (account) =>
             !chain ||
             (account.type && isAccountCompatibleWithChain(chain, account.type, account.genesisHash))
-        ),
-    [allAccounts, chain, search]
+        )
+        .filter((account) => !evmNetwork || account.type === "ethereum"),
+    [allAccounts, chain, evmNetwork, search]
   )
 
   return (

--- a/apps/extension/src/ui/domains/CopyAddress/CopyAddressCopyForm.tsx
+++ b/apps/extension/src/ui/domains/CopyAddress/CopyAddressCopyForm.tsx
@@ -123,14 +123,14 @@ const ExternalAddressWarning = () => {
 }
 
 const CopyButton = () => {
-  const { chainId, copy } = useCopyAddressWizard()
+  const { networkId, copy } = useCopyAddressWizard()
   const { isOpen, open, close } = useOpenClose()
 
   const handleCopyClick = useCallback(() => {
     // generic substrate format, show exchange warning
-    if (chainId === null) open()
+    if (networkId === null) open()
     else copy()
-  }, [chainId, copy, open])
+  }, [networkId, copy, open])
 
   const handleContinueClick = useCallback(() => {
     copy()
@@ -156,7 +156,7 @@ const CopyButton = () => {
 
 export const CopyAddressCopyForm = () => {
   const {
-    chainId,
+    networkId,
     formattedAddress,
     logo,
     chain,
@@ -184,12 +184,12 @@ export const CopyAddressCopyForm = () => {
               <AddressPillButton address={formattedAddress} onClick={goToAddressPage} />
             </div>
           </div>
-          {chainId !== undefined && (
+          {networkId !== undefined && (
             <div className="text-body-secondary flex h-16 w-full items-center justify-between">
               <div>{t("Network")}</div>
               <div>
                 <NetworkPillButton
-                  chainId={chainId}
+                  chainId={networkId}
                   onClick={goToNetworkOrTokenPage}
                   address={formattedAddress}
                 />
@@ -243,7 +243,7 @@ export const CopyAddressCopyForm = () => {
               </div>
             </div>
           )}
-          {!isEthereum && chainId === null && (
+          {!isEthereum && networkId === null && (
             <div className="text-body-secondary leading-paragraph flex flex-col items-center gap-1 text-center">
               <div>
                 <Trans

--- a/apps/extension/src/ui/domains/CopyAddress/types.ts
+++ b/apps/extension/src/ui/domains/CopyAddress/types.ts
@@ -1,8 +1,8 @@
 import { Address } from "@talismn/balances"
-import { ChainId } from "@talismn/chaindata-provider"
+import { ChainId, EvmNetworkId } from "@talismn/chaindata-provider"
 
 export type CopyAddressWizardInputs = {
-  chainId?: ChainId | null
+  networkId?: ChainId | EvmNetworkId | null
   address?: Address
   qr?: boolean
 }

--- a/apps/extension/src/ui/domains/CopyAddress/useCopyAddressModal.ts
+++ b/apps/extension/src/ui/domains/CopyAddress/useCopyAddressModal.ts
@@ -29,10 +29,10 @@ export const useCopyAddressModal = () => {
           return
         }
 
-        const chain = opts.chainId ? chainsMap[opts.chainId] : null
+        const chain = opts.networkId ? chainsMap[opts.networkId] : null
 
         // `chainId === null` is valid and means we want to display the substrate (generic) format
-        if ((opts.chainId === null || chain) && isValidSubstrateAddress(opts.address)) {
+        if ((opts.networkId === null || chain) && isValidSubstrateAddress(opts.address)) {
           const formatted = convertAddress(opts.address, chain?.prefix ?? null)
           copyAddress(formatted, onQrClick)
           return

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/CopyAddressIconButton.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/CopyAddressIconButton.tsx
@@ -2,7 +2,6 @@ import { ChainId, EvmNetworkId } from "@talismn/chaindata-provider"
 import { CopyIcon } from "@talismn/icons"
 import { useCopyAddressModal } from "@ui/domains/CopyAddress"
 import { useAnalytics } from "@ui/hooks/useAnalytics"
-import useChain from "@ui/hooks/useChain"
 import { FC, Suspense, useCallback } from "react"
 
 import { useSelectedAccount } from "../useSelectedAccount"
@@ -13,17 +12,16 @@ type CopyAddressButtonProps = {
 
 const CopyAddressButtonInner: FC<CopyAddressButtonProps> = ({ networkId }) => {
   const { account } = useSelectedAccount()
-  const chain = useChain(networkId)
   const { genericEvent } = useAnalytics()
   const { open } = useCopyAddressModal()
 
   const handleClick = useCallback(() => {
     open({
       address: account?.address,
-      chainId: chain?.id,
+      networkId,
     })
     genericEvent("open receive", { from: "asset details" })
-  }, [account?.address, genericEvent, open, chain?.id])
+  }, [account?.address, genericEvent, open, networkId])
 
   return (
     <button


### PR DESCRIPTION
on asset details page while no account is selected (ex: portfolio => all accounts => ETH), when clicking the copy button for an EVM chain, modal was prompting user to select from all accounts including substrate ones

this PR filters out substrate accounts if clicking the copy address button for an EVM network