### PR TITLE
fix: send funds recipient form - restrict onChainId options based on context

### DIFF
--- a/apps/extension/src/ui/domains/SendFunds/SendFundsRecipientPicker.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsRecipientPicker.tsx
@@ -36,7 +36,10 @@ export const SendFundsRecipientPicker = () => {
     return isFromEthereum ? isEthereumAddress(search) : isValidSubstrateAddress(search)
   }, [from, isFromEthereum, search])
 
-  const [nsLookup, { isNsLookup, isNsFetching }] = useResolveNsName(search)
+  const [nsLookup, { isNsLookup, isNsFetching }] = useResolveNsName(search, {
+    azns: !!chain,
+    ens: isFromEthereum,
+  })
 
   const normalize = useCallback(
     (addr = "") => {


### PR DESCRIPTION
prevents ENS resolution when sending substrate tokens