### PR TITLE
fix: popup scrollbars with 125% scale

### DIFF
--- a/.changeset/young-frogs-explode.md
+++ b/.changeset/young-frogs-explode.md
@@ -1,0 +1,5 @@
+---
+"talisman-ui": patch
+---
+
+fix: popup scrollbars

--- a/apps/extension/src/template.onboarding.html
+++ b/apps/extension/src/template.onboarding.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scrollable scrollable-800">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="./favicon.svg?v=<%= __webpack_hash__  %>" />
@@ -10,8 +10,7 @@
     <link rel="manifest" href="./manifest.json" />
     <title><%= htmlWebpackPlugin.options.title || 'Talisman'%></title>
     <style>
-      html,
-      body {
+      html {
         /* prevents bg flickering on page load */
         background: #121212;
       }

--- a/apps/extension/src/template.popup.html
+++ b/apps/extension/src/template.popup.html
@@ -14,6 +14,11 @@
         font-size: 10px;
         background: #121212;
       }
+      html,
+      body {
+        min-width: 400px;
+        min-height: 600px;
+      }
       #root {
         margin: 0 auto;
         width: 40rem;

--- a/apps/extension/src/template.popup.html
+++ b/apps/extension/src/template.popup.html
@@ -10,12 +10,20 @@
     <link rel="manifest" href="./manifest.json" />
     <title><%= htmlWebpackPlugin.options.title || 'Talisman'%></title>
     <style>
+      html,
+      body {
+        /* prevents bg flickering on page load */
+        background: #121212;
+      }
+
+      /* prevents tiny box on page load */
       html {
         font-size: 10px;
-        background: #121212;
       }
       html,
       body {
+        margin: 0;
+        padding: 0;
         min-width: 400px;
         min-height: 600px;
       }

--- a/apps/extension/src/template.popup.html
+++ b/apps/extension/src/template.popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="popup">
+<html lang="en" class="popup scrollable scrollable-800">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="./favicon.svg?v=<%= __webpack_hash__  %>" />
@@ -10,29 +10,21 @@
     <link rel="manifest" href="./manifest.json" />
     <title><%= htmlWebpackPlugin.options.title || 'Talisman'%></title>
     <style>
-      html,
-      body {
-        /* prevents bg flickering on page load */
-        background: #121212;
-      }
-
-      /* prevents tiny box on page load */
       html {
         font-size: 10px;
-      }
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-        overflow: auto !important;
-        min-width: 400px;
-        min-height: 600px;
+        background: #121212;
       }
       #root {
         margin: 0 auto;
         width: 40rem;
         height: 60rem;
         overflow: hidden;
+      }
+      /* no scrollbars if screen is large enough, prevents them from appearing on windows with 125% scale where only half a pixel might be missing */
+      @media screen and (min-width: 399px) and (min-height: 599px) {
+        html {
+          overflow: hidden;
+        }
       }
     </style>
   </head>

--- a/packages/talisman-ui/src/styles/styles.css
+++ b/packages/talisman-ui/src/styles/styles.css
@@ -14,13 +14,6 @@
     @apply leading-base text-body bg-black-primary font-sans text-base antialiased;
   }
 
-  html,
-  body {
-    /* this ensures we can apply clean borders to the popup */
-    /* might want to move this to popup class or html file */
-    @apply m-0 overflow-hidden p-0;
-  }
-
   /* hides the content of the page while fonts are preloading (using webfontloader) */
   #root.wf-loading {
     @apply hidden;


### PR DESCRIPTION
tested on : 
- mises
- linux brave & FF
- windows chrome, FF and edge

also made it so scrollbars are "dark" for popup and onboarding, as they appear in case window is too small.