### PR TITLE
fix: substrate tx minor ui fixes

### DIFF
--- a/apps/extension/src/ui/apps/popup/pages/Sign/substrate/FooterContent.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Sign/substrate/FooterContent.tsx
@@ -115,7 +115,7 @@ export const FooterContent = ({ withFee = false }: { withFee?: boolean }) => {
                 <Button disabled={processing} onClick={reject}>
                   {t("Cancel")}
                 </Button>
-                <Button disabled={processing} processing={processing} primary onClick={approve}>
+                <Button processing={processing} primary onClick={approve}>
                   {t("Approve")}
                 </Button>
               </div>

--- a/apps/extension/src/ui/apps/popup/pages/Sign/substrate/Transaction.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Sign/substrate/Transaction.tsx
@@ -59,7 +59,11 @@ export const PolkadotSignTransactionRequest: FC = () => {
             <div className="flex w-full flex-col gap-4">
               <div id="sign-alerts-inject"></div>
               <MetadataStatus genesisHash={genesisHash} specVersion={specVersion} />
-              {errorMessage && <SignAlertMessage type="error">{errorMessage}</SignAlertMessage>}
+              {errorMessage && (
+                <SignAlertMessage className="mb-6" type="error">
+                  {errorMessage}
+                </SignAlertMessage>
+              )}
             </div>
             {account && request && <FooterContent withFee />}
           </PopupFooter>


### PR DESCRIPTION
2 minor UI fixes on substrate tx form, noticed thanks to RPC issues : 
- spacing on error message that appears if tx can't be submitted
- processing state of the submit button