### PR TITLE
feat: avail testnet user extensions

### DIFF
--- a/.changeset/real-dogs-sneeze.md
+++ b/.changeset/real-dogs-sneeze.md
@@ -1,0 +1,6 @@
+---
+"extension-core": minor
+"@talismn/balances": minor
+---
+
+feat: custom user extensions support

--- a/apps/extension/src/ui/hooks/useExtrinsic.ts
+++ b/apps/extension/src/ui/hooks/useExtrinsic.ts
@@ -1,6 +1,7 @@
 import { isJsonPayload } from "@extension/core"
 import { getMetadataFromDef, getMetadataRpcFromDef } from "@extension/core"
 import { chaindataProvider } from "@extension/core"
+import { getUserExtensionsByChainId } from "@extension/core/domains/metadata/userExtensions"
 import { log } from "@extension/shared"
 import { typesBundle } from "@polkadot/apps-config/api"
 import { Metadata, TypeRegistry } from "@polkadot/types"
@@ -73,12 +74,13 @@ const getFrontEndTypeRegistry = async (
       const metadata: Metadata = new Metadata(registry, metadataValue)
       registry.setMetadata(metadata)
     }
-
-    if (signedExtensions || metadataDef.userExtensions)
-      registry.setSignedExtensions(signedExtensions, metadataDef.userExtensions)
+    registry.setSignedExtensions(signedExtensions, {
+      ...metadataDef.userExtensions,
+      ...getUserExtensionsByChainId(chain.id),
+    })
     if (metadataDef.types) registry.register(metadataDef.types)
   } else {
-    if (signedExtensions) registry.setSignedExtensions(signedExtensions)
+    registry.setSignedExtensions(signedExtensions, getUserExtensionsByChainId(chain.id))
   }
 
   return { registry, metadataRpc }

--- a/apps/extension/src/ui/hooks/useExtrinsic.ts
+++ b/apps/extension/src/ui/hooks/useExtrinsic.ts
@@ -1,4 +1,4 @@
-import { isJsonPayload } from "@extension/core"
+import { Chain, isJsonPayload } from "@extension/core"
 import { getMetadataFromDef, getMetadataRpcFromDef } from "@extension/core"
 import { chaindataProvider } from "@extension/core"
 import { getUserExtensionsByChainId } from "@extension/core/domains/metadata/userExtensions"
@@ -21,9 +21,10 @@ const getFrontEndTypeRegistry = async (
 ) => {
   const registry = new TypeRegistry()
 
-  const chain = await (isHex(chainIdOrHash)
+  // TODO remove type override once chaindata-provider is fixed
+  const chain = (await (isHex(chainIdOrHash)
     ? chaindataProvider.chainByGenesisHash(chainIdOrHash)
-    : chaindataProvider.chainById(chainIdOrHash))
+    : chaindataProvider.chainById(chainIdOrHash))) as Chain | null
 
   const genesisHash = (isHex(chainIdOrHash) ? chainIdOrHash : chain?.genesisHash) as HexString
 
@@ -76,11 +77,11 @@ const getFrontEndTypeRegistry = async (
     }
     registry.setSignedExtensions(signedExtensions, {
       ...metadataDef.userExtensions,
-      ...getUserExtensionsByChainId(chain.id),
+      ...getUserExtensionsByChainId(chain?.id),
     })
     if (metadataDef.types) registry.register(metadataDef.types)
   } else {
-    registry.setSignedExtensions(signedExtensions, getUserExtensionsByChainId(chain.id))
+    registry.setSignedExtensions(signedExtensions, getUserExtensionsByChainId(chain?.id))
   }
 
   return { registry, metadataRpc }

--- a/packages/balances/src/modules/SubstrateAssetsModule.ts
+++ b/packages/balances/src/modules/SubstrateAssetsModule.ts
@@ -1,4 +1,5 @@
 import { Metadata, TypeRegistry } from "@polkadot/types"
+import { ExtDef } from "@polkadot/types/extrinsic/signedExtensions/types"
 import { BN, assert } from "@polkadot/util"
 import { defineMethod } from "@substrate/txwrapper-core"
 import {
@@ -101,6 +102,7 @@ export type SubAssetsTransferParams = NewTransferParamsType<{
   transactionVersion: number
   tip?: string
   transferMethod: "transfer" | "transferKeepAlive" | "transferAll"
+  userExtensions?: ExtDef
 }>
 
 export const SubAssetsModule: NewBalanceModule<
@@ -305,6 +307,7 @@ export const SubAssetsModule: NewBalanceModule<
       transactionVersion,
       tip,
       transferMethod,
+      userExtensions,
     }) {
       const token = await chaindataProvider.tokenById(tokenId)
       assert(token, `Token ${tokenId} not found in store`)
@@ -344,7 +347,7 @@ export const SubAssetsModule: NewBalanceModule<
           tip: tip ? Number(tip) : 0,
           transactionVersion,
         },
-        { metadataRpc, registry }
+        { metadataRpc, registry, userExtensions }
       )
 
       return { type: "substrate", tx: unsigned }

--- a/packages/balances/src/modules/SubstrateEquilibriumModule.ts
+++ b/packages/balances/src/modules/SubstrateEquilibriumModule.ts
@@ -1,5 +1,6 @@
 import { Metadata, TypeRegistry } from "@polkadot/types"
 import { AbstractInt } from "@polkadot/types-codec"
+import { ExtDef } from "@polkadot/types/extrinsic/signedExtensions/types"
 import { assert } from "@polkadot/util"
 import { defineMethod } from "@substrate/txwrapper-core"
 import {
@@ -101,6 +102,7 @@ export type SubEquilibriumTransferParams = NewTransferParamsType<{
   transactionVersion: number
   tip?: string
   transferMethod: "transfer" | "transferKeepAlive" | "transferAll"
+  userExtensions?: ExtDef
 }>
 
 export const SubEquilibriumModule: NewBalanceModule<
@@ -276,6 +278,7 @@ export const SubEquilibriumModule: NewBalanceModule<
       transactionVersion,
       tip,
       transferMethod,
+      userExtensions,
     }) {
       const token = await chaindataProvider.tokenById(tokenId)
       assert(token, `Token ${tokenId} not found in store`)
@@ -320,7 +323,7 @@ export const SubEquilibriumModule: NewBalanceModule<
           tip: tip ? Number(tip) : 0,
           transactionVersion,
         },
-        { metadataRpc, registry }
+        { metadataRpc, registry, userExtensions }
       )
 
       return { type: "substrate", tx: unsigned }

--- a/packages/balances/src/modules/SubstrateNativeModule.ts
+++ b/packages/balances/src/modules/SubstrateNativeModule.ts
@@ -1,4 +1,5 @@
 import { TypeRegistry, createType, i128 } from "@polkadot/types"
+import { ExtDef } from "@polkadot/types/extrinsic/signedExtensions/types"
 import { assert, u8aToHex, u8aToString } from "@polkadot/util"
 import { defineMethod } from "@substrate/txwrapper-core"
 import { ChainConnector } from "@talismn/chain-connector"
@@ -166,6 +167,7 @@ export type SubNativeTransferParams = NewTransferParamsType<{
   transactionVersion: number
   tip?: string
   transferMethod: BalancesAllTransferMethods
+  userExtensions?: ExtDef
 }>
 
 export const SubNativeModule: NewBalanceModule<
@@ -407,6 +409,7 @@ export const SubNativeModule: NewBalanceModule<
       transactionVersion,
       tip,
       transferMethod,
+      userExtensions,
     }) {
       const token = await chaindataProvider.tokenById(tokenId)
       assert(token, `Token ${tokenId} not found in store`)
@@ -457,7 +460,7 @@ export const SubNativeModule: NewBalanceModule<
           tip: tip ? Number(tip) : 0,
           transactionVersion,
         },
-        { metadataRpc, registry }
+        { metadataRpc, registry, userExtensions }
       )
 
       return { type: "substrate", tx: unsigned }

--- a/packages/balances/src/modules/SubstratePsp22Module.ts
+++ b/packages/balances/src/modules/SubstratePsp22Module.ts
@@ -1,5 +1,6 @@
 import { Abi } from "@polkadot/api-contract"
 import { TypeRegistry } from "@polkadot/types"
+import { ExtDef } from "@polkadot/types/extrinsic/signedExtensions/types"
 import { assert, hexToNumber, hexToU8a, u8aToString } from "@polkadot/util"
 import { defineMethod } from "@substrate/txwrapper-core"
 import { ChainConnector } from "@talismn/chain-connector"
@@ -85,6 +86,7 @@ export type SubPsp22TransferParams = NewTransferParamsType<{
   transactionVersion: number
   tip?: string
   transferMethod: "transfer" | "transferKeepAlive" | "transferAll"
+  userExtensions?: ExtDef
 }>
 
 export const SubPsp22Module: NewBalanceModule<
@@ -277,6 +279,7 @@ export const SubPsp22Module: NewBalanceModule<
       specVersion,
       transactionVersion,
       tip,
+      userExtensions,
     }) {
       const token = await chaindataProvider.tokenById(tokenId)
       assert(token, `Token ${tokenId} not found in store`)
@@ -339,7 +342,7 @@ export const SubPsp22Module: NewBalanceModule<
           tip: tip ? Number(tip) : 0,
           transactionVersion,
         },
-        { metadataRpc, registry }
+        { metadataRpc, registry, userExtensions }
       )
 
       return { type: "substrate", tx: unsigned }

--- a/packages/balances/src/modules/SubstrateTokensModule.ts
+++ b/packages/balances/src/modules/SubstrateTokensModule.ts
@@ -1,4 +1,5 @@
 import { TypeRegistry } from "@polkadot/types"
+import { ExtDef } from "@polkadot/types/extrinsic/signedExtensions/types"
 import { assert } from "@polkadot/util"
 import { UnsignedTransaction, defineMethod } from "@substrate/txwrapper-core"
 import {
@@ -104,6 +105,7 @@ export type SubTokensTransferParams = NewTransferParamsType<{
   transactionVersion: number
   tip?: string
   transferMethod: "transfer" | "transferKeepAlive" | "transferAll"
+  userExtensions?: ExtDef
 }>
 
 export const SubTokensModule: NewBalanceModule<
@@ -253,6 +255,7 @@ export const SubTokensModule: NewBalanceModule<
       transactionVersion,
       tip,
       transferMethod,
+      userExtensions,
     }) {
       const token = await chaindataProvider.tokenById(tokenId)
       assert(token, `Token ${tokenId} not found in store`)
@@ -316,7 +319,7 @@ export const SubTokensModule: NewBalanceModule<
               },
               ...commonDefineMethodFields,
             },
-            { metadataRpc, registry }
+            { metadataRpc, registry, userExtensions }
           ),
         () =>
           defineMethod(
@@ -328,7 +331,7 @@ export const SubTokensModule: NewBalanceModule<
               },
               ...commonDefineMethodFields,
             },
-            { metadataRpc, registry }
+            { metadataRpc, registry, userExtensions }
           ),
       ]
 

--- a/packages/extension-core/src/domains/metadata/userExtensions.ts
+++ b/packages/extension-core/src/domains/metadata/userExtensions.ts
@@ -12,6 +12,8 @@ const USER_EXTENSIONS: Record<ChainId, ExtDef> = {
   },
 }
 
-export const getUserExtensionsByChainId = (chainId: ChainId): ExtDef | undefined => {
-  return USER_EXTENSIONS[chainId]
+export const getUserExtensionsByChainId = (
+  chainId: ChainId | null | undefined
+): ExtDef | undefined => {
+  return chainId ? USER_EXTENSIONS[chainId] : undefined
 }

--- a/packages/extension-core/src/domains/metadata/userExtensions.ts
+++ b/packages/extension-core/src/domains/metadata/userExtensions.ts
@@ -1,0 +1,17 @@
+import { ExtDef } from "@polkadot/types/extrinsic/signedExtensions/types"
+import { ChainId } from "@talismn/chaindata-provider"
+
+const USER_EXTENSIONS: Record<ChainId, ExtDef> = {
+  "avail-goldberg-testnet": {
+    CheckAppId: {
+      extrinsic: {
+        appId: "AvailCoreAppId",
+      },
+      payload: {},
+    },
+  },
+}
+
+export const getUserExtensionsByChainId = (chainId: ChainId): ExtDef | undefined => {
+  return USER_EXTENSIONS[chainId]
+}

--- a/packages/extension-core/src/domains/transfers/rpc/AssetTransfers.ts
+++ b/packages/extension-core/src/domains/transfers/rpc/AssetTransfers.ts
@@ -13,6 +13,7 @@ import { getExtrinsicDispatchInfo } from "../../../util/getExtrinsicDispatchInfo
 import { getRuntimeVersion } from "../../../util/getRuntimeVersion"
 import { getTypeRegistry } from "../../../util/getTypeRegistry"
 import { validateHexString } from "../../../util/validateHexString"
+import { getUserExtensionsByChainId } from "../../metadata/userExtensions"
 import { SignerPayloadJSON } from "../../signing/types"
 import {
   WalletTransactionTransferInfo,
@@ -221,6 +222,7 @@ export default class AssetTransfersRpc {
       // has to be cast to any because typing of the balance modules doesn't allow different types per module
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       transferMethod: method as any,
+      userExtensions: getUserExtensionsByChainId(chainId),
     })
 
     assert(transaction, `Failed to construct tx for token '${token.id}'`)

--- a/packages/extension-core/src/util/getTypeRegistry.ts
+++ b/packages/extension-core/src/util/getTypeRegistry.ts
@@ -4,6 +4,7 @@ import { getSpecAlias, getSpecTypes } from "@polkadot/types-known/util"
 import { hexToNumber, isHex } from "@polkadot/util"
 import { log } from "extension-shared"
 
+import { getUserExtensionsByChainId } from "../domains/metadata/userExtensions"
 import { chaindataProvider } from "../rpcs/chaindata"
 import { getMetadataDef, getMetadataFromDef, getMetadataRpcFromDef } from "./getMetadataDef"
 
@@ -71,11 +72,13 @@ export const getTypeRegistry = async (
       registry.setMetadata(metadata)
     }
 
-    if (signedExtensions || metadataDef.userExtensions)
-      registry.setSignedExtensions(signedExtensions, metadataDef.userExtensions)
+    registry.setSignedExtensions(signedExtensions, {
+      ...metadataDef.userExtensions,
+      ...getUserExtensionsByChainId(chain.id),
+    })
     if (metadataDef.types) registry.register(metadataDef.types)
   } else {
-    if (signedExtensions) registry.setSignedExtensions(signedExtensions)
+    registry.setSignedExtensions(signedExtensions, getUserExtensionsByChainId(chain.id))
   }
 
   return { registry, metadataRpc }

--- a/packages/extension-core/src/util/getTypeRegistry.ts
+++ b/packages/extension-core/src/util/getTypeRegistry.ts
@@ -2,6 +2,7 @@ import { typesBundle } from "@polkadot/apps-config/api"
 import { Metadata, TypeRegistry } from "@polkadot/types"
 import { getSpecAlias, getSpecTypes } from "@polkadot/types-known/util"
 import { hexToNumber, isHex } from "@polkadot/util"
+import { Chain } from "@talismn/chaindata-provider"
 import { log } from "extension-shared"
 
 import { getUserExtensionsByChainId } from "../domains/metadata/userExtensions"
@@ -27,9 +28,10 @@ export const getTypeRegistry = async (
 ) => {
   const registry = new TypeRegistry()
 
-  const chain = await (isHex(chainIdOrHash)
+  // TODO remove type override once chaindata-provider is fixed
+  const chain = (await (isHex(chainIdOrHash)
     ? chaindataProvider.chainByGenesisHash(chainIdOrHash)
-    : chaindataProvider.chainById(chainIdOrHash))
+    : chaindataProvider.chainById(chainIdOrHash))) as Chain | null
 
   // register typesBundle in registry for legacy (pre metadata v14) chains
   if (typesBundle.spec && chain?.specName && typesBundle.spec[chain.specName]) {
@@ -74,11 +76,11 @@ export const getTypeRegistry = async (
 
     registry.setSignedExtensions(signedExtensions, {
       ...metadataDef.userExtensions,
-      ...getUserExtensionsByChainId(chain.id),
+      ...getUserExtensionsByChainId(chain?.id),
     })
     if (metadataDef.types) registry.register(metadataDef.types)
   } else {
-    registry.setSignedExtensions(signedExtensions, getUserExtensionsByChainId(chain.id))
+    registry.setSignedExtensions(signedExtensions, getUserExtensionsByChainId(chain?.id))
   }
 
   return { registry, metadataRpc }


### PR DESCRIPTION
This PR allows to send funds, sign dapp txs and estimate fee on avail testnet.

However I couldn't get our extrinsic watch method to work on avail testnet.
The hash seems good as shown is this log, which is from send funds (where we actually send the tx ourselves) : 

![image](https://github.com/TalismanSociety/talisman/assets/26880866/d1648046-6137-4c83-a0fb-2cf68153ed68)
