### PR TITLE
fix: evm tx timeout

### DIFF
--- a/.changeset/flat-bees-retire.md
+++ b/.changeset/flat-bees-retire.md
@@ -1,0 +1,6 @@
+---
+"extension-core": patch
+"@talismn/util": patch
+---
+
+fix: evm tx timeouts

--- a/apps/extension/src/ui/domains/Ethereum/GasSettings/CustomGasSettingsFormEip1559.tsx
+++ b/apps/extension/src/ui/domains/Ethereum/GasSettings/CustomGasSettingsFormEip1559.tsx
@@ -334,7 +334,16 @@ export const CustomGasSettingsFormEip1559: FC<CustomGasSettingsFormEip1559Props>
       </div>
       <div className="grid grid-cols-2 gap-8 gap-y-14">
         <Indicator label="Base Fee">
-          {t("{{baseFee}} GWEI", { baseFee: baseFeeDisplay })}{" "}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span>{t("{{baseFee}} GWEI", { baseFee: baseFeeDisplay })}</span>
+            </TooltipTrigger>
+            {baseFeeDisplay.startsWith("<") && (
+              <TooltipContent>
+                {txDetails.baseFeePerGas ? `${formatGwei(txDetails.baseFeePerGas)} GWEI` : t("N/A")}
+              </TooltipContent>
+            )}
+          </Tooltip>{" "}
           <WithTooltip
             className="inline-flex h-[1.5rem] flex-col justify-center align-text-top"
             tooltip={t("The base fee is set by the network and changes depending on network usage")}

--- a/apps/extension/src/ui/domains/Ethereum/GasSettings/CustomGasSettingsFormEip1559.tsx
+++ b/apps/extension/src/ui/domains/Ethereum/GasSettings/CustomGasSettingsFormEip1559.tsx
@@ -338,9 +338,9 @@ export const CustomGasSettingsFormEip1559: FC<CustomGasSettingsFormEip1559Props>
             <TooltipTrigger asChild>
               <span>{t("{{baseFee}} GWEI", { baseFee: baseFeeDisplay })}</span>
             </TooltipTrigger>
-            {baseFeeDisplay.startsWith("<") && (
+            {baseFeeDisplay.startsWith("<") && !!txDetails.baseFeePerGas && (
               <TooltipContent>
-                {txDetails.baseFeePerGas ? `${formatGwei(txDetails.baseFeePerGas)} GWEI` : t("N/A")}
+                {t("{{baseFee}} GWEI", { baseFee: formatGwei(txDetails.baseFeePerGas) })}
               </TooltipContent>
             )}
           </Tooltip>{" "}

--- a/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
+++ b/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
@@ -77,8 +77,7 @@ export const watchEthereumTransaction = async (
         )
     } catch (err) {
       log.error("watchEthereumTransaction error: ", { err })
-      const error = err as Error
-      const isNotFound = error.message === "Transaction not found"
+      const isNotFound = err instanceof Error && err.message === "Transaction not found"
 
       // if not found, mark tx as unknown so user can still cancel/speed-up if necessary
       updateTransactionStatus(hash, isNotFound ? "unknown" : "error")

--- a/packages/extension-core/src/notifications/createNotification.ts
+++ b/packages/extension-core/src/notifications/createNotification.ts
@@ -40,11 +40,8 @@ const getNotificationOptions = (
       return {
         type: "basic",
         title: "Transaction not found",
-        message:
-          error?.shortMessage ??
-          error?.reason ??
-          error?.message ??
-          `Transaction not found on ${networkName}.`,
+        message: `We aren't able to determine the status of this transaction.`,
+
         iconUrl: "/images/tx-nok.png",
       }
   }

--- a/packages/extension-core/src/notifications/createNotification.ts
+++ b/packages/extension-core/src/notifications/createNotification.ts
@@ -3,7 +3,7 @@ import Browser from "webextension-polyfill"
 
 import { ensureNotificationClickHandler } from "./ensureNotificationClickHandler"
 
-export type NotificationType = "submitted" | "success" | "error"
+export type NotificationType = "submitted" | "success" | "error" | "not_found"
 
 const getNotificationOptions = (
   type: NotificationType,
@@ -34,6 +34,17 @@ const getNotificationOptions = (
           error?.reason ??
           error?.message ??
           `Failed transaction on ${networkName}.`,
+        iconUrl: "/images/tx-nok.png",
+      }
+    case "not_found":
+      return {
+        type: "basic",
+        title: "Transaction not found",
+        message:
+          error?.shortMessage ??
+          error?.reason ??
+          error?.message ??
+          `Transaction not found on ${networkName}.`,
         iconUrl: "/images/tx-nok.png",
       }
   }

--- a/packages/util/src/throwAfter.ts
+++ b/packages/util/src/throwAfter.ts
@@ -1,2 +1,2 @@
 export const throwAfter = (ms: number, reason: string) =>
-  new Promise<void>((_, reject) => setTimeout(() => reject(new Error(reason)), ms))
+  new Promise<never>((_, reject) => setTimeout(() => reject(new Error(reason)), ms))


### PR DESCRIPTION
This PR aims at marking timed out EVM transaction as "unknown" instead of "error", which will allow the user to access the cancel/speed-up features.

Also fixed 2 minor bugs along the way.