### PR TITLE
fix: spec version parsing for papi payloads

### DIFF
--- a/apps/extension/src/ui/apps/popup/pages/Sign/substrate/Transaction.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Sign/substrate/Transaction.tsx
@@ -1,4 +1,5 @@
 import { isJsonPayload } from "@extension/core"
+import { hexToNumber } from "@polkadot/util"
 import { AppPill } from "@talisman/components/AppPill"
 import { validateHexString } from "@talismn/util"
 import { classNames } from "@talismn/util"
@@ -26,7 +27,7 @@ export const PolkadotSignTransactionRequest: FC = () => {
     return payload && isJsonPayload(payload)
       ? {
           genesisHash: validateHexString(payload.genesisHash),
-          specVersion: parseInt(payload.specVersion, 16),
+          specVersion: hexToNumber(payload.specVersion),
         }
       : {}
   }, [payload])


### PR DESCRIPTION
Fixes specVersion property parsing from payloads created with PAPI.
Our Transaction sign UI assumed specVersion is a hex string (because that's it's only type in pjs api), but PAPI sends it as a number. This fixes the parsing of that field to handle both scenarios.

This message shouldn't appear anymore if specVersion is passed as number : 
![image](https://github.com/TalismanSociety/talisman/assets/26880866/df4469e0-229c-4203-bb23-a940f5309662)
