### PR TITLE
fix: dashboard account select hidden balances

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/AccountSelect.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AccountSelect.tsx
@@ -310,7 +310,9 @@ const Item = forwardRef<HTMLDivElement, ItemProps>(function Item(
         )}
       >
         {name}
-        <Fiat amount={item?.total !== undefined ? item.total : totalFiat} isBalance noCountUp />
+        <div>
+          <Fiat amount={item?.total !== undefined ? item.total : totalFiat} isBalance noCountUp />
+        </div>
       </div>
       {(button || (isFolder && !collapsed)) && (
         <ChevronDownIcon className={classNames("shrink-0 text-lg", button && "hidden lg:block")} />


### PR DESCRIPTION
before: 
![image](https://github.com/TalismanSociety/talisman/assets/26880866/3bf3bbd0-4b2b-4cee-878f-334c7d5eb382)

after:
![image](https://github.com/TalismanSociety/talisman/assets/26880866/0d2411c0-02fe-4bae-8001-188c0109d024)
