### PR TITLE
fix: enforce priority fee on opstack networks

### DIFF
--- a/apps/extension/src/ui/domains/Ethereum/opStack.ts
+++ b/apps/extension/src/ui/domains/Ethereum/opStack.ts
@@ -1,0 +1,41 @@
+import { gasPriceOracleABI, gasPriceOracleAddress } from "@eth-optimism/contracts-ts"
+import { EvmNetworkId } from "extension-core"
+import { log } from "extension-shared"
+import { Hex, PublicClient, getContract } from "viem"
+
+export const OP_STACK_L1_FEE_ORACLE: Record<number, `0x${string}`> = {
+  10: gasPriceOracleAddress[420], // OP Mainnet,
+  420: gasPriceOracleAddress[420], // OP Goerli
+  7777777: gasPriceOracleAddress[420], // Zora Mainnet
+  999: gasPriceOracleAddress[420], // Zora Goerli
+  8453: gasPriceOracleAddress[420], // Base Mainnet
+  84531: gasPriceOracleAddress[420], // Base Goerli
+  534351: "0x5300000000000000000000000000000000000002", // Scroll Sepolia Testnet
+  534352: "0x5300000000000000000000000000000000000002", // Scroll Mainnet
+  60808: gasPriceOracleAddress[420], // BOB mainnet
+  111: gasPriceOracleAddress[420], // BOB testnet
+}
+
+export const isOpStackEvmNetwork = (evmNetworkId: EvmNetworkId) => {
+  return Number(evmNetworkId) in OP_STACK_L1_FEE_ORACLE
+}
+
+export const getOpStackEthL1DataFee = async (
+  publicClient: PublicClient,
+  serializedTx: Hex
+): Promise<bigint> => {
+  try {
+    const address = (publicClient.chain && OP_STACK_L1_FEE_ORACLE[publicClient.chain.id]) || null
+    if (!address) return 0n
+
+    const contract = getContract({
+      address,
+      abi: gasPriceOracleABI,
+      client: { public: publicClient },
+    })
+    return await contract.read.getL1Fee([serializedTx])
+  } catch (err) {
+    log.error(err)
+    throw new Error("Failed to get L1 data fee", { cause: err })
+  }
+}

--- a/apps/extension/src/ui/domains/Ethereum/useEthEstimateL1DataFee.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthEstimateL1DataFee.ts
@@ -1,38 +1,9 @@
-import { gasPriceOracleABI, gasPriceOracleAddress } from "@eth-optimism/contracts-ts"
 import { getTransactionSerializable } from "@extension/core"
-import { log } from "@extension/shared"
 import { useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
-import { Hex, PublicClient, TransactionRequest, getContract, serializeTransaction } from "viem"
+import { PublicClient, TransactionRequest, serializeTransaction } from "viem"
 
-const OP_STACK_L1_FEE_ORACLE: Record<number, `0x${string}`> = {
-  10: gasPriceOracleAddress[420], // OP Mainnet,
-  420: gasPriceOracleAddress[420], // OP Goerli
-  7777777: gasPriceOracleAddress[420], // Zora Mainnet
-  999: gasPriceOracleAddress[420], // Zora Goerli
-  8453: gasPriceOracleAddress[420], // Base Mainnet
-  84531: gasPriceOracleAddress[420], // Base Goerli
-  534351: "0x5300000000000000000000000000000000000002", // Scroll Sepolia Testnet
-  534352: "0x5300000000000000000000000000000000000002", // Scroll Mainnet
-}
-
-const getEthL1DataFee = async (
-  publicClient: PublicClient,
-  serializedTx: Hex,
-  contractAddress: `0x${string}`
-): Promise<bigint> => {
-  try {
-    const contract = getContract({
-      address: contractAddress,
-      abi: gasPriceOracleABI,
-      client: { public: publicClient },
-    })
-    return await contract.read.getL1Fee([serializedTx])
-  } catch (err) {
-    log.error(err)
-    throw new Error("Failed to get L1 data fee", { cause: err })
-  }
-}
+import { getOpStackEthL1DataFee } from "./opStack"
 
 export const useEthEstimateL1DataFee = (
   publicClient: PublicClient | undefined,
@@ -51,9 +22,7 @@ export const useEthEstimateL1DataFee = (
     queryFn: () => {
       if (!publicClient?.chain?.id || !serialized) return null
 
-      return OP_STACK_L1_FEE_ORACLE[publicClient.chain.id]
-        ? getEthL1DataFee(publicClient, serialized, OP_STACK_L1_FEE_ORACLE[publicClient.chain.id])
-        : 0n
+      return getOpStackEthL1DataFee(publicClient, serialized)
     },
     keepPreviousData: true,
     refetchInterval: 6_000,

--- a/apps/playground/src/components/Ethereum/shared/talismanChains.ts
+++ b/apps/playground/src/components/Ethereum/shared/talismanChains.ts
@@ -15,6 +15,7 @@ import {
   moonbeam,
   moonriver,
   optimism,
+  optimismSepolia,
   polygon,
   sepolia,
 } from "wagmi/chains"
@@ -135,4 +136,5 @@ export const talismanChains = [
   manta,
   mantaTestnet,
   bob,
+  optimismSepolia,
 ] as const

--- a/apps/playground/src/components/Ethereum/shared/talismanChains.ts
+++ b/apps/playground/src/components/Ethereum/shared/talismanChains.ts
@@ -97,6 +97,20 @@ const karura: Chain = {
   },
 }
 
+const bob: Chain = {
+  id: 60808,
+  name: "BOB",
+  nativeCurrency: {
+    name: "ETH",
+    symbol: "ETH",
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: { http: ["https://rpc.gobob.xyz/"] },
+    public: { http: ["https://rpc.gobob.xyz/"] },
+  },
+}
+
 export const talismanChains = [
   moonbeam,
   moonbaseAlpha,
@@ -120,4 +134,5 @@ export const talismanChains = [
   base,
   manta,
   mantaTestnet,
+  bob,
 ] as const


### PR DESCRIPTION
OP stack transactions will always use a minimum of 1 wei as maxPriorityPerGas

This fixes the "transaction underpriced: gas tip cap 0, minimum needed 1" error that occurs when submiting a tx on BOB.
Problem seems to be global to opstack chains, I was able to reproduce it on op sepolia.