### PR TITLE
Remove _metamask hack from injected provider

### DIFF
--- a/apps/extension/src/inject/ethereum/getInjectableEvmProvider.ts
+++ b/apps/extension/src/inject/ethereum/getInjectableEvmProvider.ts
@@ -52,10 +52,6 @@ export const getInjectableEvmProvider = (sendRequest: SendRequest) => {
     chainId: null,
     selectedAddress: null,
 
-    // MM's experimental methods
-    // if this object is missing, some dapps won't prompt for login
-    _metamask: {},
-
     // MM's internal state object.
     // We need to mimic it because web3onboard uses it (ex: https://de.fi => "Enter App" button)
     _state: {


### PR DESCRIPTION
Tested on:
- aave
- opensea
- uniswap
- sushiswap
- stellaswap
- blur
- coingecko (watch asset)
- polygonscan (watch asset)
