### PR TITLE
Throw better error when Talisman not onboarded on evm dapps

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
@@ -113,9 +113,7 @@ const useBlockExplorerUrl = (token: Token | null) => {
   const evmNetwork = useEvmNetwork(token?.evmNetwork?.id)
 
   return useMemo(() => {
-    if (isErc20Token(token) && evmNetwork?.explorerUrl)
-      return urlJoin(evmNetwork.explorerUrl, "token", token.contractAddress)
-    if (isUniswapV2Token(token) && evmNetwork?.explorerUrl)
+    if ((isErc20Token(token) || isUniswapV2Token(token)) && evmNetwork?.explorerUrl)
       return urlJoin(evmNetwork.explorerUrl, "token", token.contractAddress)
 
     return null

--- a/packages/extension-core/src/domains/app/store.app.ts
+++ b/packages/extension-core/src/domains/app/store.app.ts
@@ -1,4 +1,3 @@
-import { assert } from "@polkadot/util"
 import { DEBUG, IS_FIREFOX } from "extension-shared"
 import { gt } from "semver"
 import Browser from "webextension-polyfill"
@@ -6,6 +5,7 @@ import Browser from "webextension-polyfill"
 import { migratePasswordV2ToV1 } from "../../libs/migrations/legacyMigrations"
 import { StorageProvider } from "../../libs/Store"
 import { StakingSupportedChain } from "../staking/types"
+import { TalismanNotOnboardedError } from "./utils"
 
 type ONBOARDED_TRUE = "TRUE"
 type ONBOARDED_FALSE = "FALSE"
@@ -50,9 +50,6 @@ export const DEFAULT_APP_STATE: AppStoreData = {
 }
 
 export class AppStore extends StorageProvider<AppStoreData> {
-  // keeps track of 'onboarding requests' per session so that each dapp can only cause the onboarding tab to focus once
-  onboardingRequestsByUrl: { [url: string]: boolean } = {}
-
   constructor() {
     super("app", DEFAULT_APP_STATE)
 
@@ -85,10 +82,9 @@ export class AppStore extends StorageProvider<AppStoreData> {
   }
 
   async ensureOnboarded() {
-    assert(
-      await this.getIsOnboarded(),
-      "Talisman extension has not been configured yet. Please continue with onboarding."
-    )
+    const isOnboarded = await this.getIsOnboarded()
+    if (!isOnboarded) throw new TalismanNotOnboardedError()
+
     return true
   }
 

--- a/packages/extension-core/src/domains/app/utils.ts
+++ b/packages/extension-core/src/domains/app/utils.ts
@@ -1,0 +1,5 @@
+export class TalismanNotOnboardedError extends Error {
+  constructor() {
+    super("Talisman extension has not been configured yet. Please continue with onboarding.")
+  }
+}

--- a/packages/extension-core/src/handlers/index.ts
+++ b/packages/extension-core/src/handlers/index.ts
@@ -3,7 +3,6 @@ import { PORT_EXTENSION } from "extension-shared"
 import { log } from "extension-shared"
 import { Runtime } from "webextension-polyfill"
 
-import { TalismanNotOnboardedError } from "../domains/app/utils"
 import { cleanupEvmErrorMessage, getEvmErrorCause } from "../domains/ethereum/errors"
 import { MessageTypes, TransportRequestMessage } from "../types"
 import { AnyEthRequest } from "../types/domains"
@@ -109,10 +108,6 @@ const talismanHandler = <TMessageType extends MessageTypes>(
         // this means that the user has done something like close the tab
         port.disconnect()
         return
-      }
-
-      if (error instanceof TalismanNotOnboardedError) {
-        safePostMessage(port, { id, error: error.message })
       }
 
       if (["pub(eth.request)", "pri(eth.request)"].includes(message)) {

--- a/packages/extension-core/src/index.ts
+++ b/packages/extension-core/src/index.ts
@@ -7,6 +7,7 @@ export { db, MIGRATION_ERROR_MSG } from "./db"
 
 export { settingsStore, type SettingsStoreData } from "./domains/app/store.settings"
 export { appStore, DEFAULT_APP_STATE, type AppStoreData } from "./domains/app/store.app"
+export { TalismanNotOnboardedError } from "./domains/app/utils"
 export { passwordStore } from "./domains/app/store.password"
 export { remoteConfigStore } from "./domains/app/store.remoteConfig"
 export { addressBookStore, type AddressBookContact } from "./domains/app/store.addressBook"


### PR DESCRIPTION
We now throw a `EthProviderRpcError` with code `ETH_ERROR_EIP1993_UNAUTHORIZED` when Talisman is not onboarded and a request is sent from an EVM dapp