### PR TITLE
chore: update extension id in firefox manifest

### DIFF
--- a/apps/extension/public/manifest/firefox.json
+++ b/apps/extension/public/manifest/firefox.json
@@ -5,7 +5,7 @@
   "browser_specific_settings": {
     "gecko": {
       "strict_min_version": "109.0",
-      "id": "{58bfaba9-469a-4df1-bce0-836763f2cda6}"
+      "id": "{f5727e03-b26c-41e0-95dd-7e315ff16410}"
     }
   }
 }


### PR DESCRIPTION
ID has to be the same as the existing one