### PR TITLE
chore: fix sentry in the backend

### DIFF
--- a/apps/extension/src/common/PortMessageService.ts
+++ b/apps/extension/src/common/PortMessageService.ts
@@ -35,6 +35,8 @@ export interface Handler {
 
 export type Handlers = Record<string, Handler>
 
+export class PortMessageError extends Error {}
+
 export default class PortMessageService {
   handlers: Handlers = {}
   idCounter = 0
@@ -177,7 +179,8 @@ export default class PortMessageService {
             data.rpcData
           )
         )
-      } else handler.reject(new Error(data.error))
+      } else
+        handler.reject(new PortMessageError("Unable to complete action", { cause: data.error }))
     } else handler.resolve(data.response)
   }
 }

--- a/apps/extension/src/sentry.ts
+++ b/apps/extension/src/sentry.ts
@@ -39,7 +39,7 @@ export const initSentryFrontend = () => {
 
       // Print to console instead of Sentry in DEBUG/development builds
       if (DEBUG) {
-        console.error("[DEBUG] Sentry event occurred", event) // eslint-disable-line no-console
+        console.error("[DEBUG - UI] Sentry event occurred", event) // eslint-disable-line no-console
         return null
       }
 

--- a/packages/extension-core/src/background.ts
+++ b/packages/extension-core/src/background.ts
@@ -2,18 +2,17 @@ import { AccountsStore } from "@polkadot/extension-base/stores"
 import keyring from "@polkadot/ui-keyring"
 import { assert } from "@polkadot/util"
 import { cryptoWaitReady } from "@polkadot/util-crypto"
-import * as Sentry from "@sentry/browser"
 import { watCryptoWaitReady } from "@talismn/scale"
 import { DEBUG, PORT_CONTENT, PORT_EXTENSION } from "extension-shared"
 
-import { initSentry } from "./config/sentry"
+import { sentry } from "./config/sentry"
 import { passwordStore } from "./domains/app/store.password"
 import talismanHandler from "./handlers"
 import { IconManager } from "./libs/IconManager"
 import { MigrationRunner, migrations } from "./libs/migrations"
 import { migrateConnectAllSubstrate } from "./libs/migrations/legacyMigrations"
 
-initSentry()
+sentry.init()
 
 chrome.action.setBadgeBackgroundColor({ color: "#d90000" })
 
@@ -51,7 +50,7 @@ const migrationSub = passwordStore.isLoggedIn.subscribe(async (isLoggedIn) => {
   if (isLoggedIn === "TRUE") {
     const password = await passwordStore.getPassword()
     if (!password) {
-      Sentry.captureMessage("Unable to run migrations, no password present")
+      sentry.captureMessage("Unable to run migrations, no password present")
       return
     }
     // instantiate the migrations runner with migrations to run
@@ -110,7 +109,7 @@ Promise.all([
       },
     })
   })
-  .catch(Sentry.captureException)
+  .catch(sentry.captureException)
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const iconManager = new IconManager()

--- a/packages/extension-core/src/domains/app/helpers.ts
+++ b/packages/extension-core/src/domains/app/helpers.ts
@@ -1,10 +1,10 @@
 import { KeyringPair } from "@polkadot/keyring/types"
 import keyring from "@polkadot/ui-keyring"
 import { KeyringJson } from "@polkadot/ui-keyring/types"
-import * as Sentry from "@sentry/browser"
 import { log } from "extension-shared"
 import { Err, Ok, Result } from "ts-results"
 
+import { sentry } from "../../config/sentry"
 import {
   MnemonicErrors,
   MnemonicsStoreData,
@@ -56,7 +56,7 @@ const migratePairs = async (
       successfulPairs.push(pair)
     })
   } catch (error) {
-    Sentry.captureException(error)
+    sentry.captureException(error)
     log.error("Error migrating pairs: ", error)
     return Err("Error re-encrypting keypairs")
   }
@@ -85,7 +85,7 @@ const migrateMnemonic = async (
 
     return Ok(result)
   } catch (error) {
-    Sentry.captureException(error)
+    sentry.captureException(error)
     return Err(MnemonicErrors.UnableToEncrypt)
   }
 }

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
@@ -1,11 +1,11 @@
 import { checkHost } from "@polkadot/phishing"
-import * as Sentry from "@sentry/browser"
 import { Dexie } from "dexie"
 import metamaskInitialData from "eth-phishing-detect/src/config.json"
 import MetamaskDetector from "eth-phishing-detect/src/detector"
 import { log } from "extension-shared"
 import { decompressFromUTF16 } from "lz-string"
 
+import { sentry } from "../../../config/sentry"
 import { db } from "../../../db"
 import { getHostName } from "../helpers"
 
@@ -129,7 +129,7 @@ export default class ParaverseProtector {
           !(cause.name !== Dexie.errnames.DatabaseClosed)
         ) {
           const error = new Error("Failed to persist phishing list", { cause })
-          Sentry.captureException(error)
+          sentry.captureException(error)
         }
       })
     }

--- a/packages/extension-core/src/domains/encrypt/handler.ts
+++ b/packages/extension-core/src/domains/encrypt/handler.ts
@@ -1,8 +1,8 @@
 import { assert, u8aToHex, u8aToU8a } from "@polkadot/util"
 import { Keypair } from "@polkadot/util-crypto/types"
-import * as Sentry from "@sentry/browser"
 import { log } from "extension-shared"
 
+import { sentry } from "../../config/sentry"
 import { getPairForAddressSafely } from "../../handlers/helpers"
 import { talismanAnalytics } from "../../libs/Analytics"
 import { ExtensionHandler } from "../../libs/Handler"
@@ -50,7 +50,7 @@ export default class EncryptHandler extends ExtensionHandler {
     if (result.ok) return true
 
     log.log(result.val)
-    Sentry.captureException(result.val)
+    sentry.captureException(result.val)
     throw new Error("Unable to encrypt message.")
   }
 
@@ -84,7 +84,7 @@ export default class EncryptHandler extends ExtensionHandler {
     if (result.ok) return true
 
     log.log(result.val)
-    Sentry.captureException(result.val)
+    sentry.captureException(result.val)
     throw new Error("Unable to decrypt message.")
   }
 

--- a/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
+++ b/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
@@ -1,5 +1,4 @@
 import { assert } from "@polkadot/util"
-import * as Sentry from "@sentry/browser"
 import { EvmNetworkId } from "@talismn/chaindata-provider"
 import { sleep, throwAfter } from "@talismn/util"
 import { log } from "extension-shared"
@@ -7,6 +6,7 @@ import { nanoid } from "nanoid"
 import urlJoin from "url-join"
 import { Hex, TransactionReceipt, TransactionRequest } from "viem"
 
+import { sentry } from "../../config/sentry"
 import { createNotification } from "../../notifications"
 import { chainConnectorEvm } from "../../rpcs/chain-connector-evm"
 import { chaindataProvider } from "../../rpcs/chaindata"
@@ -96,6 +96,6 @@ export const watchEthereumTransaction = async (
       else console.error("Failed to watch transaction", { err })
     }
   } catch (err) {
-    Sentry.captureException(err, { tags: { ethChainId: evmNetworkId } })
+    sentry.captureException(err, { tags: { ethChainId: evmNetworkId } })
   }
 }

--- a/packages/extension-core/src/domains/transactions/watchSubstrateTransaction.ts
+++ b/packages/extension-core/src/domains/transactions/watchSubstrateTransaction.ts
@@ -3,11 +3,11 @@ import { Hash } from "@polkadot/types/interfaces"
 import { assert } from "@polkadot/util"
 import { xxhashAsHex } from "@polkadot/util-crypto"
 import { HexString } from "@polkadot/util/types"
-import * as Sentry from "@sentry/browser"
 import { SignerPayloadJSON } from "@substrate/txwrapper-core"
 import { log } from "extension-shared"
 import { Err, Ok, Result } from "ts-results"
 
+import { sentry } from "../../config/sentry"
 import { NotificationType, createNotification } from "../../notifications"
 import { chainConnector } from "../../rpcs/chain-connector"
 import { settingsStore } from "../app/store.settings"
@@ -142,7 +142,7 @@ const watchExtrinsicStatus = async (
           cause: error,
         })
         log.error(err)
-        Sentry.captureException(err, { extra: { chainId } })
+        sentry.captureException(err, { extra: { chainId } })
         return
       }
 
@@ -165,7 +165,7 @@ const watchExtrinsicStatus = async (
         )
         if (timeout !== null) clearTimeout(timeout)
       } catch (error) {
-        Sentry.captureException(error, { extra: { chainId } })
+        sentry.captureException(error, { extra: { chainId } })
       }
     }
   )
@@ -183,7 +183,7 @@ const watchExtrinsicStatus = async (
           cause: error,
         })
         log.error(err)
-        Sentry.captureException(err, { extra: { chainId } })
+        sentry.captureException(err, { extra: { chainId } })
         return
       }
 
@@ -214,7 +214,7 @@ const watchExtrinsicStatus = async (
           if (timeout !== null) clearTimeout(timeout)
         }
       } catch (error) {
-        Sentry.captureException(error, { extra: { chainId } })
+        sentry.captureException(error, { extra: { chainId } })
       }
     }
   )
@@ -273,7 +273,7 @@ export const watchSubstrateTransaction = async (
   }).catch((err) => {
     // eslint-disable-next-line no-console
     console.warn("Failed to watch extrinsic", { err })
-    Sentry.captureException(err, { extra: { chainId: chain.id, chainName: chain.name } })
+    sentry.captureException(err, { extra: { chainId: chain.id, chainName: chain.name } })
   })
 
   return hash

--- a/packages/extension-core/src/domains/transfers/handler.ts
+++ b/packages/extension-core/src/domains/transfers/handler.ts
@@ -1,9 +1,9 @@
 import { assert } from "@polkadot/util"
-import * as Sentry from "@sentry/browser"
 import { isEthereumAddress, planckToTokens } from "@talismn/util"
 import { log } from "extension-shared"
 import { privateKeyToAccount } from "viem/accounts"
 
+import { sentry } from "../../config/sentry"
 import { getPairForAddressSafely, getPairFromAddress } from "../../handlers/helpers"
 import { ExtensionHandler } from "../../libs/Handler"
 import { chainConnectorEvm } from "../../rpcs/chain-connector-evm"
@@ -189,7 +189,7 @@ export default class AssetTransferHandler extends ExtensionHandler {
     } catch (err) {
       const error = err as Error & { reason?: string; error?: Error }
       log.error(error.message, { err })
-      Sentry.captureException(err, { extra: { tokenId, evmNetworkId } })
+      sentry.captureException(err, { extra: { tokenId, evmNetworkId } })
       throw new Error(error?.error?.message ?? error.reason ?? "Failed to send transaction")
     }
   }
@@ -260,7 +260,7 @@ export default class AssetTransferHandler extends ExtensionHandler {
     } else {
       const error = result.val as Error & { reason?: string; error?: Error }
       log.error("Failed to send transaction", { err: result.val })
-      Sentry.captureException(result.val, { tags: { tokenId, evmNetworkId } })
+      sentry.captureException(result.val, { tags: { tokenId, evmNetworkId } })
       throw new Error(error?.error?.message ?? error.reason ?? "Failed to send transaction")
     }
   }

--- a/packages/extension-core/src/handlers/RpcState.ts
+++ b/packages/extension-core/src/handlers/RpcState.ts
@@ -11,8 +11,8 @@ import type {
 import type { ProviderMeta } from "@polkadot/extension-inject/types"
 import type { ProviderInterface, ProviderInterfaceCallback } from "@polkadot/rpc-provider/types"
 import { assert } from "@polkadot/util"
-import * as Sentry from "@sentry/browser"
 
+import { sentry } from "../config/sentry"
 import { UnknownJsonRpcResponse } from "../domains/talisman/types"
 import { Port } from "../types/base"
 
@@ -76,7 +76,7 @@ export default class RpcState {
       const provider = this.#injectedProviders.get(port)
 
       if (provider) {
-        provider.disconnect().catch(Sentry.captureException)
+        provider.disconnect().catch(sentry.captureException)
       }
 
       this.#injectedProviders.delete(port)

--- a/packages/extension-core/src/handlers/Tabs.ts
+++ b/packages/extension-core/src/handlers/Tabs.ts
@@ -18,9 +18,9 @@ import type { SignerPayloadJSON, SignerPayloadRaw } from "@polkadot/types/types"
 import keyring from "@polkadot/ui-keyring"
 import { accounts as accountsObservable } from "@polkadot/ui-keyring/observable/accounts"
 import { assert, isNumber } from "@polkadot/util"
-import * as Sentry from "@sentry/browser"
 import { log } from "extension-shared"
 
+import { sentry } from "../config/sentry"
 import { db } from "../db"
 import { filterAccountsByAddresses, getPublicAccounts } from "../domains/accounts/helpers"
 import { RequestAccountList } from "../domains/accounts/types"
@@ -255,7 +255,7 @@ export default class Tabs extends TabsHandler {
 
     port.onDisconnect.addListener((): void => {
       unsubscribe(id)
-      this.rpcUnsubscribe({ ...request, subscriptionId }, port).catch(Sentry.captureException)
+      this.rpcUnsubscribe({ ...request, subscriptionId }, port).catch(sentry.captureException)
     })
 
     return true
@@ -296,7 +296,7 @@ export default class Tabs extends TabsHandler {
           chrome.tabs.update(id, { url }).catch((err: Error) => {
             // eslint-disable-next-line no-console
             console.error("Failed to redirect tab to phishing page", { err })
-            Sentry.captureException(err, { extra: { url } })
+            sentry.captureException(err, { extra: { url } })
           })
         )
     })
@@ -306,7 +306,7 @@ export default class Tabs extends TabsHandler {
     const isInDenyList = await protector.isPhishingSite(url)
 
     if (isInDenyList) {
-      Sentry.captureEvent({
+      sentry.captureEvent({
         message: "Redirect from phishing site",
         extra: { url },
       })

--- a/packages/extension-core/src/libs/WindowManager.ts
+++ b/packages/extension-core/src/libs/WindowManager.ts
@@ -117,9 +117,7 @@ class WindowManager {
 
     const { left, top } = {
       top: 100 + (currWindow?.top ?? 0),
-      left:
-        (currWindow?.width ? (currWindow.left ?? 0) + currWindow.width : window.screen.availWidth) -
-        500,
+      left: currWindow?.width ? (currWindow.left ?? 0) + currWindow.width - 500 : 500,
     }
 
     const popupCreateArgs: chrome.windows.CreateData = {

--- a/packages/extension-core/src/notifications/createNotification.ts
+++ b/packages/extension-core/src/notifications/createNotification.ts
@@ -1,5 +1,4 @@
-import * as Sentry from "@sentry/browser"
-
+import { sentry } from "../config/sentry"
 import { ensureNotificationClickHandler } from "./ensureNotificationClickHandler"
 
 export type NotificationType = "submitted" | "success" | "error" | "not_found"
@@ -63,6 +62,6 @@ export const createNotification = async (
     const options = getNotificationOptions(type, networkName, error)
     chrome.notifications.create(url, options)
   } catch (err) {
-    Sentry.captureException(err)
+    sentry.captureException(err)
   }
 }

--- a/packages/extension-core/src/util/getMetadataDef.ts
+++ b/packages/extension-core/src/util/getMetadataDef.ts
@@ -2,10 +2,10 @@ import { TypeRegistry } from "@polkadot/types"
 import { OpaqueMetadata } from "@polkadot/types/interfaces"
 import { assert, isHex, u8aToNumber } from "@polkadot/util"
 import { HexString } from "@polkadot/util/types"
-import * as Sentry from "@sentry/browser"
 import { ChainId } from "@talismn/chaindata-provider"
 import { DEBUG, encodeMetadataRpc, log } from "extension-shared"
 
+import { sentry } from "../config/sentry"
 import { db } from "../db"
 import { metadataUpdatesStore } from "../domains/metadata/metadataUpdates"
 import { TalismanMetadataDef } from "../domains/substrate/types"
@@ -141,7 +141,7 @@ export const getMetadataDef = async (
       const message = `Failed to update metadata for chain ${genesisHash}`
       const error = new Error(message, { cause })
       log.error(error)
-      Sentry.captureException(error, { extra: { genesisHash } })
+      sentry.captureException(error, { extra: { genesisHash } })
     }
     metadataUpdatesStore.set(genesisHash, false)
   }


### PR DESCRIPTION
Replace calls to `Sentry.captureException` with our own homebrewed method which calls the sentry scope directly, this is needed due to the custom configuration in the service worker.
