### PR TITLE
fix: use Error type for cause of `Unable to complete action` error

### DIFF
--- a/apps/extension/src/common/PortMessageService.ts
+++ b/apps/extension/src/common/PortMessageService.ts
@@ -196,7 +196,9 @@ export default class PortMessageService {
           )
         )
       } else
-        handler.reject(new PortMessageError("Unable to complete action", { cause: data.error }))
+        handler.reject(
+          new PortMessageError("Unable to complete action", { cause: new Error(data.error) })
+        )
     } else handler.resolve(data.response)
   }
 }


### PR DESCRIPTION
A fix for https://talisman.sentry.io/issues/5570357350 and https://talisman.sentry.io/issues/5568629235