### PR TITLE
fix: dashboard accounts fiat value wrapping bug

### DIFF
--- a/apps/extension/src/ui/domains/Asset/Fiat.tsx
+++ b/apps/extension/src/ui/domains/Asset/Fiat.tsx
@@ -41,7 +41,7 @@ export const Fiat = ({
     <span
       ref={refReveal}
       className={classNames(
-        "fiat",
+        "fiat whitespace-nowrap",
         isRevealable && "balance-revealable",
         isRevealed && "balance-reveal",
         className


### PR DESCRIPTION
<div align="center">

**before**
<img width="701" alt="Screenshot 2024-07-16 at 12 33 52" src="https://github.com/user-attachments/assets/174e097e-b60d-46a8-86fa-635663e1c8fc">


**after**
<img width="699" alt="Screenshot 2024-07-16 at 12 35 00" src="https://github.com/user-attachments/assets/04d8aa7c-1a5f-415f-8627-fcb9cfdc325c">


</div>