### PR TITLE
fix: qr code scanning broken in production builds

### DIFF
--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddQr/Scan.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddQr/Scan.tsx
@@ -1,8 +1,9 @@
+import { ExternalLinkIcon } from "@talismn/icons"
+import { useTranslation } from "react-i18next"
+
 import { POLKADOT_VAULT_DOCS_URL } from "@extension/shared"
 import { HeaderBlock } from "@talisman/components/HeaderBlock"
-import { ExternalLinkIcon } from "@talismn/icons"
 import { ScanQr } from "@ui/domains/Sign/Qr/ScanQr"
-import { useTranslation } from "react-i18next"
 
 import { useAccountAddQr } from "./context"
 
@@ -106,26 +107,29 @@ export const Scan = () => {
             enable={state.enable}
             error={!!state.cameraError}
             onScan={(scanned) => dispatch({ method: "onScan", scanned })}
-            onError={(error) =>
-              [
+            onError={(error) => {
+              const cameraErrors = [
                 "AbortError",
                 "NotAllowedError",
                 "NotFoundError",
                 "NotReadableError",
                 "OverconstrainedError",
                 "SecurityError",
-              ].includes(error.name)
-                ? dispatch({
-                    method: "setCameraError",
-                    error: error.name ?? error.message ?? "error",
-                  })
-                : dispatch({
-                    method: "setScanError",
-                    error: error.message.startsWith("Invalid prefix received")
-                      ? t("QR code is not valid")
-                      : error.message ?? "Unknown error",
-                  })
-            }
+              ]
+              if (cameraErrors.includes(error.name))
+                return dispatch({
+                  method: "setCameraError",
+                  error: error.name ?? error.message ?? "error",
+                })
+
+              dispatch({
+                method: "setScanError",
+                error: error.message.startsWith("Invalid prefix received")
+                  ? t("QR code is not valid")
+                  : error.message ?? "Unknown error",
+              })
+              console.error("QR code scanning error", error) // eslint-disable-line no-console
+            }}
           />
           {state.scanError && (
             <div className="text-alert-error bg-alert-error/10 mt-6 inline-block w-[260px] rounded p-4 text-center text-xs font-light">

--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddQr/context.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddQr/context.tsx
@@ -1,16 +1,14 @@
-import { AssetDiscoveryMode } from "@extension/core"
-import { VerifierCertificateType } from "@extension/core"
 import { HexString } from "@polkadot/util/types"
+import { decodeAnyAddress, sleep } from "@talismn/util"
+import { useCallback, useReducer } from "react"
+import { useTranslation } from "react-i18next"
+
+import { AssetDiscoveryMode, VerifierCertificateType } from "@extension/core"
 import { notify, notifyUpdate } from "@talisman/components/Notifications"
 import { provideContext } from "@talisman/util/provideContext"
-import { decodeAnyAddress } from "@talismn/util"
-import { sleep } from "@talismn/util"
 import { api } from "@ui/api"
 import { useHasVerifierCertificateMnemonic } from "@ui/hooks/useHasVerifierCertificateMnemonic"
 import { useQrCodeAccounts } from "@ui/hooks/useQrCodeAccounts"
-import { useReducer } from "react"
-import { useCallback } from "react"
-import { useTranslation } from "react-i18next"
 
 import { AccountAddPageProps } from "../types"
 
@@ -80,7 +78,7 @@ export const reducer = (state: AddQrState, action: Action): AddQrState => {
 
       if (!scanned) return state
       if (!scanned.isAddress)
-        return { type: "SCAN", enable: true, scanError: "QR code is not valid" }
+        return { type: "SCAN", enable: true, scanError: "QR code does not contain an address" }
 
       const { content: address, genesisHash } = scanned
 

--- a/apps/extension/src/ui/domains/Sign/Qr/ScanQr.tsx
+++ b/apps/extension/src/ui/domains/Sign/Qr/ScanQr.tsx
@@ -121,7 +121,7 @@ const Scanner = ({
     codeReader
       .decodeFromVideoDevice(selectedVideoInput, preview.current, (result, error, controls) => {
         if (!abortedSignalSet) {
-          aborted.signal.addEventListener("abort", () => controls.stop())
+          aborted.signal.addEventListener("abort", () => controls.stop(), { once: true })
           abortedSignalSet = true
         }
         if (aborted.signal.aborted) return


### PR DESCRIPTION
The QR code reader lib we're using ([ZXing](https://www.npmjs.com/package/@zxing/browser)) uses [ts-custom-error](https://www.npmjs.com/package/ts-custom-error#minification-and-transpilation-mangle-custom-error-names) to define its custom `Error` types.

A known issue with this lib is that the error names are mangled by terser/uglify/other code minifiers: 
[#minification-and-transpilation-mangle-custom-error-names](https://www.npmjs.com/package/ts-custom-error#minification-and-transpilation-mangle-custom-error-names)

This broke our detection of the `NotFoundException` error, which we need to ignore in order to continue scanning a video feed which doesn't immediately have a QR code visible in the frame.