### PR TITLE
fix: analytics improvements

### DIFF
--- a/apps/extension/src/ui/domains/SendFunds/SendFundsHardwareSubstrate.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsHardwareSubstrate.tsx
@@ -1,12 +1,13 @@
-import { SignerPayloadJSON, roundToFirstInteger } from "@extension/core"
-import { log } from "@extension/shared"
 import { HexString } from "@polkadot/util/types"
 import { planckToTokens } from "@talismn/util"
+import { useCallback, useState } from "react"
+
+import { privacyRoundCurrency, SignerPayloadJSON } from "@extension/core"
+import { log } from "@extension/shared"
 import { api } from "@ui/api"
 import { useSendFundsWizard } from "@ui/apps/popup/pages/SendFunds/context"
 import { useIsKnownAddress } from "@ui/hooks/useIsKnownAddress"
 import useToken from "@ui/hooks/useToken"
-import { useCallback, useState } from "react"
 
 import { SignHardwareSubstrate } from "../Sign/SignHardwareSubstrate"
 import { useSendFunds } from "./useSendFunds"
@@ -36,7 +37,7 @@ export const SendFundsHardwareSubstrate = () => {
           options: {
             toAddress: to,
             amount: token
-              ? roundToFirstInteger(Number(planckToTokens(amount, token.decimals)))
+              ? privacyRoundCurrency(Number(planckToTokens(amount, token.decimals)))
               : "unknown",
             tokenId,
             chainId: token?.chain?.id || "unknown",

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsQrSubstrate.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsQrSubstrate.tsx
@@ -1,6 +1,10 @@
-import { AccountJsonQr, roundToFirstInteger } from "@extension/core"
 import { HexString } from "@polkadot/util/types"
 import { planckToTokens } from "@talismn/util"
+import { useCallback, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Button } from "talisman-ui"
+
+import { AccountJsonQr, privacyRoundCurrency } from "@extension/core"
 import { api } from "@ui/api"
 import { useSendFundsWizard } from "@ui/apps/popup/pages/SendFunds/context"
 import { QrSubstrate } from "@ui/domains/Sign/Qr/QrSubstrate"
@@ -8,9 +12,6 @@ import { useAccountByAddress } from "@ui/hooks/useAccountByAddress"
 import useChain from "@ui/hooks/useChain"
 import { useIsKnownAddress } from "@ui/hooks/useIsKnownAddress"
 import useToken from "@ui/hooks/useToken"
-import { useCallback, useState } from "react"
-import { useTranslation } from "react-i18next"
-import { Button } from "talisman-ui"
 
 import { useSendFunds } from "./useSendFunds"
 
@@ -44,7 +45,7 @@ const SendFundsQrSubstrate = () => {
           options: {
             toAddress: to,
             amount: token
-              ? roundToFirstInteger(Number(planckToTokens(amount, token.decimals)))
+              ? privacyRoundCurrency(Number(planckToTokens(amount, token.decimals)))
               : "unknown",
             tokenId,
             chainId: token?.chain?.id || "unknown",

--- a/apps/extension/src/ui/domains/SendFunds/useSendFunds.ts
+++ b/apps/extension/src/ui/domains/SendFunds/useSendFunds.ts
@@ -12,7 +12,7 @@ import {
   AccountType,
   AssetTransferMethod,
   getEthTransferTransactionBase,
-  roundToFirstInteger,
+  privacyRoundCurrency,
   serializeGasSettings,
   serializeTransactionRequest,
   SignerPayloadJSON,
@@ -593,7 +593,7 @@ const useSendFundsProvider = () => {
 
       api.analyticsCapture({
         eventName: "asset transfer fiat value",
-        options: { value: roundToFirstInteger(value.fiat("usd") ?? 0) ?? "0" },
+        options: { value: privacyRoundCurrency(value.fiat("usd") ?? 0) ?? "0" },
       })
 
       if (token.chain?.id && chain?.genesisHash) {

--- a/packages/extension-core/src/config/posthog.ts
+++ b/packages/extension-core/src/config/posthog.ts
@@ -1,5 +1,6 @@
+import type { Properties } from "posthog-js"
 import { DEBUG } from "extension-shared"
-import posthog, { Properties } from "posthog-js"
+import posthog from "posthog-js"
 
 const unsafeProperties = [
   "$os",

--- a/packages/extension-core/src/config/posthog.ts
+++ b/packages/extension-core/src/config/posthog.ts
@@ -30,26 +30,53 @@ const talismanProperties = {
   testBuild: DEBUG || ["dev", "qa", "ci"].includes(process.env.BUILD as string),
 }
 
+/**
+ * Initializes the posthog client.
+ *
+ * It is recommended to call `setPosthogOptInPreference` with the user's opt-in preference before calling this.
+ */
 export const initPosthog = () => {
-  if (process.env.POSTHOG_AUTH_TOKEN) {
-    posthog.init(process.env.POSTHOG_AUTH_TOKEN, {
-      api_host: "https://app.posthog.com",
-      autocapture: false,
-      capture_pageview: false,
-      disable_session_recording: true,
-      persistence: "localStorage",
-      ip: false,
-      sanitize_properties: (properties) => {
-        // We can remove all the posthog user profiling properties except for those that are required for PostHog to work
-        const requiredProperties = Object.keys(properties).reduce((result, key) => {
-          if (!unsafeProperties.includes(key)) result[key] = properties[key]
-          return result
-        }, {} as Properties)
-        return {
-          ...requiredProperties,
-          ...talismanProperties,
-        }
-      },
-    })
+  if (!process.env.POSTHOG_AUTH_TOKEN) return
+
+  posthog.init(process.env.POSTHOG_AUTH_TOKEN, {
+    api_host: "https://app.posthog.com",
+    autocapture: false,
+    capture_pageview: false,
+    disable_session_recording: true,
+    persistence: "localStorage",
+    ip: false,
+    sanitize_properties: (properties) => {
+      // We can remove all the posthog user profiling properties except for those that are required for PostHog to work
+      const requiredProperties = Object.keys(properties).reduce((result, key) => {
+        if (!unsafeProperties.includes(key)) result[key] = properties[key]
+        return result
+      }, {} as Properties)
+      return {
+        ...requiredProperties,
+        ...talismanProperties,
+      }
+    },
+  })
+}
+
+/**
+ * Configures the user's opt-in preference on the posthog client.
+ *
+ * @param optInPreference `true` if the user has explicitly opted in, `false` if the user has explicitly opted out, otherwise `undefined`.
+ */
+export const setPosthogOptInPreference = (optInPreference: boolean | undefined) => {
+  const posthogOptedIn = posthog.has_opted_in_capturing()
+  const posthogOptedOut = posthog.has_opted_out_capturing()
+
+  switch (optInPreference) {
+    case true:
+      if (!posthogOptedIn || posthogOptedOut) posthog.opt_in_capturing()
+      break
+    case false:
+      if (posthogOptedIn || !posthogOptedOut) posthog.opt_out_capturing()
+      break
+    case undefined:
+      if (posthogOptedIn || posthogOptedOut) posthog.clear_opt_in_out_capturing()
+      break
   }
 }

--- a/packages/extension-core/src/domains/accounts/types.ts
+++ b/packages/extension-core/src/domains/accounts/types.ts
@@ -9,8 +9,8 @@ import { KeypairType } from "@polkadot/util-crypto/types"
 import { TokenId } from "@talismn/chaindata-provider"
 import { NsLookupType } from "@talismn/on-chain-id"
 
-import { Address } from "../../types/base"
 import type { RequestAccountsCatalogAction, Trees } from "./helpers.catalog"
+import { Address } from "../../types/base"
 
 export type { ResponseAccountExport, AccountJson }
 export type { RequestAccountsCatalogAction } from "./helpers.catalog"

--- a/packages/extension-core/src/domains/app/store.app.ts
+++ b/packages/extension-core/src/domains/app/store.app.ts
@@ -31,6 +31,7 @@ export type AppStoreData = {
   dismissedAssetDiscoveryAlertScanId?: string
   isAssetDiscoveryScanPending?: boolean
   showLedgerPolkadotGenericMigrationAlert?: boolean
+  posthogDistinctId?: string
 }
 
 const ANALYTICS_VERSION = "1.5.0"

--- a/packages/extension-core/src/domains/transfers/helpers.ts
+++ b/packages/extension-core/src/domains/transfers/helpers.ts
@@ -2,7 +2,7 @@ import keyring from "@polkadot/ui-keyring"
 import BigNumber from "bignumber.js"
 
 import { talismanAnalytics } from "../../libs/Analytics"
-import { roundToFirstInteger } from "../../util/roundToFirstInteger"
+import { privacyRoundCurrency } from "../../util/privacyRoundCurrency"
 import { addressBookStore } from "../app/store.addressBook"
 
 type TransferAnalyticsBaseArgs = {
@@ -36,7 +36,7 @@ export const transferAnalytics = async ({
     ...network,
     hardware,
     tokenId,
-    amount: roundToFirstInteger(new BigNumber(amount).toNumber()),
+    amount: privacyRoundCurrency(new BigNumber(amount).toNumber()),
     internal: isOwnAccount || isContact,
     recipientType: isOwnAccount ? "ownAccount" : isContact ? "contact" : "external",
   })

--- a/packages/extension-core/src/index.ts
+++ b/packages/extension-core/src/index.ts
@@ -71,6 +71,6 @@ export * from "./libs/requests/types"
 
 export * from "./util/abi"
 export { isJsonPayload, isRawPayload } from "./util/isJsonPayload"
-export { roundToFirstInteger } from "./util/roundToFirstInteger"
+export { privacyRoundCurrency } from "./util/privacyRoundCurrency"
 
 export * from "./domains/nfts/exports"

--- a/packages/extension-core/src/libs/Analytics.ts
+++ b/packages/extension-core/src/libs/Analytics.ts
@@ -1,242 +1,53 @@
-import keyring from "@polkadot/ui-keyring"
+import type { Properties } from "posthog-js"
 import { DEBUG } from "extension-shared"
-import posthog, { Properties } from "posthog-js"
+import posthog from "posthog-js"
 
-import { initPosthog } from "../config/posthog"
-import { db } from "../db"
-import { AccountType } from "../domains/accounts/types"
-import { appStore } from "../domains/app/store.app"
+import { initPosthog, setPosthogOptInPreference } from "../config/posthog"
 import { settingsStore } from "../domains/app/store.settings"
-import { balancePool } from "../domains/balances/pool"
-import { Balance, Balances } from "../domains/balances/types"
-import { getNftCollectionFloorUsd } from "../domains/nfts"
-import { nftsStore$ } from "../domains/nfts/store"
-import { chaindataProvider } from "../rpcs/chaindata"
-import { hasGhostsOfThePast } from "../util/hasGhostsOfThePast"
-import { roundToFirstInteger } from "../util/roundToFirstInteger"
-
-const REPORTING_PERIOD = 24 * 3600 * 1000 // 24 hours
-
-const ensurePosthogPreferences = (useAnalyticsTracking: boolean | undefined) => {
-  if (useAnalyticsTracking === undefined) {
-    if (posthog.has_opted_in_capturing() || posthog.has_opted_out_capturing())
-      posthog.clear_opt_in_out_capturing()
-  } else if (
-    useAnalyticsTracking &&
-    (!posthog.has_opted_in_capturing() || posthog.has_opted_out_capturing())
-  ) {
-    posthog.opt_in_capturing()
-  } else if (
-    !useAnalyticsTracking &&
-    (posthog.has_opted_in_capturing() || !posthog.has_opted_out_capturing())
-  ) {
-    posthog.opt_out_capturing()
-  }
-}
+import { withGeneralReport } from "./GeneralReport"
 
 class TalismanAnalytics {
-  lastGeneralReport: undefined | number
-  enabled = Boolean(process.env.POSTHOG_AUTH_TOKEN)
+  #enabled = Boolean(process.env.POSTHOG_AUTH_TOKEN)
 
   constructor() {
-    if (!this.enabled) return
+    if (!this.#enabled) return
 
-    this.init().then(() => {
-      settingsStore.observable.subscribe(({ useAnalyticsTracking }) => {
-        ensurePosthogPreferences(useAnalyticsTracking)
-      })
+    // subscribe posthog opt-in preferences to settingsStore.useAnalyticsTracking changes
+    settingsStore.observable.subscribe(({ useAnalyticsTracking }) =>
+      setPosthogOptInPreference(useAnalyticsTracking)
+    )
 
-      appStore.observable.subscribe(({ analyticsReportSent }) => {
-        this.lastGeneralReport = analyticsReportSent || Date.now()
-      })
+    // set posthog opt-in preferences to current value of settingsStore.useAnalyticsTracking
+    settingsStore.get("useAnalyticsTracking").then((useAnalyticsTracking) => {
+      setPosthogOptInPreference(useAnalyticsTracking)
+
+      // init posthog (*after* opt-in preferences have been set)
+      initPosthog()
     })
   }
 
-  async init() {
-    const allowTracking = await settingsStore.get("useAnalyticsTracking")
-    initPosthog()
-    ensurePosthogPreferences(allowTracking)
-  }
-
   async capture(eventName: string, properties?: Properties) {
-    if (!this.enabled) return
-
-    // have to put this manual check here because posthog is buggy and will not respect our settings
-    // https://github.com/PostHog/posthog-js/issues/336
-    const allowTracking = await settingsStore.get("useAnalyticsTracking")
-
-    // we need to allow tracking during onboarding, while value is not defined
-    // so we need to explicitely check for false
-    if (allowTracking === false) return
+    if (!this.#enabled) return
 
     try {
-      let sendProperties = properties
-      if (this.lastGeneralReport && Date.now() > this.lastGeneralReport + REPORTING_PERIOD) {
-        const generalData = await this.getGeneralReport()
-        sendProperties = { ...properties, $set: { ...(properties?.$set || {}), ...generalData } }
-        appStore.set({ analyticsReportSent: Date.now() })
-      }
-      posthog.capture(eventName, sendProperties)
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      DEBUG && console.log("error ", { e })
+      // have to put this manual check here because posthog is buggy and will not respect our settings
+      // https://github.com/PostHog/posthog-js/issues/336
+      const allowTracking = await settingsStore.get("useAnalyticsTracking")
+
+      // we need to allow tracking during onboarding, while value is not defined
+      // so we need to explicitly check for false
+      if (allowTracking === false) return
+
+      const captureProperties = await withGeneralReport(properties)
+      posthog.capture(eventName, captureProperties)
+    } catch (cause) {
+      const error = new Error("Failed to capture posthog event", { cause })
+      DEBUG && console.error(error) // eslint-disable-line no-console
     }
   }
 
   async captureDelayed(eventName: string, properties?: Properties, delaySeconds = 900) {
-    setTimeout(() => {
-      this.capture(eventName, properties)
-    }, delaySeconds * 1000 * Math.random())
-  }
-
-  async getGeneralReport() {
-    /*
-    // This should get sent at most once per 24 hours, whenever any other events get sent
-    */
-    const allowTracking = await settingsStore.get("useAnalyticsTracking")
-    const onboarded = await appStore.getIsOnboarded()
-    if (!allowTracking || !onboarded) return
-
-    // accounts
-    const accounts = keyring.getAccounts()
-    let accountBreakdown: Record<Lowercase<AccountType>, number> = {
-      talisman: 0,
-      ledger: 0,
-      qr: 0,
-      dcent: 0,
-      watched: 0,
-      signet: 0,
-    }
-
-    let ownedAddressesLower: string[] = []
-
-    // cache chains, evmNetworks, tokens, tokenRates and balances here to prevent lots of fetch calls
-    try {
-      /* eslint-disable no-var */
-      var chains = await chaindataProvider.chainsById()
-      var evmNetworks = await chaindataProvider.evmNetworksById()
-      var tokens = await chaindataProvider.tokensById()
-      var tokenRates = Object.fromEntries(
-        ((await db.tokenRates.toArray()) || []).map(({ tokenId, rates }) => [tokenId, rates])
-      )
-
-      // account type breakdown
-      accountBreakdown = accounts.reduce((result, account) => {
-        const accountType = (
-          account.meta.origin as AccountType
-        ).toLowerCase() as Lowercase<AccountType>
-        result[accountType] += 1
-        return result
-      }, accountBreakdown)
-
-      // consider only accounts that are not watched accounts
-      const ownedAddresses = accounts
-        .filter((account) => account.meta.origin !== "WATCHED")
-        .map((account) => account.address)
-
-      ownedAddressesLower = ownedAddresses.map((a) => a.toLowerCase())
-
-      // balances + balances fiat sum estimate
-      var balances = new Balances(
-        Object.values(balancePool.balances).filter((balance) =>
-          ownedAddresses.includes(balance.address)
-        ),
-        {
-          chains,
-          evmNetworks,
-          tokens,
-          tokenRates,
-        }
-      )
-      /* eslint-enable no-var */
-    } catch (cause) {
-      const error = new Error("Failed to access db to build general analyics report", { cause })
-      // eslint-disable-next-line no-console
-      DEBUG && console.error(error)
-      throw error
-    }
-
-    // balances top 5 tokens/networks
-    // get Balance list per chain/evmNetwork and token
-    const balancesPerChainToken: Record<string, Balance[]> = balances.each
-      .filter(Boolean)
-      .filter(
-        (balance) =>
-          (balance.chain === null || !("isCustom" in balance.chain && balance.chain.isCustom)) &&
-          (balance.token === null || !("isCustom" in balance.token && balance.token.isCustom))
-      )
-      .reduce((result, balance) => {
-        const key = `${balance.chainId || balance.evmNetworkId}-${balance.tokenId}`
-
-        if (!result[key]) result[key] = []
-        result[key].push(balance)
-
-        return result
-      }, {} as { [key: string]: Balance[] })
-
-    // get fiat sum object for those arrays of Balances
-    const sortedFiatSumPerChainToken = await Promise.all(
-      Object.values(balancesPerChainToken).map(async (balances) => {
-        const balancesInstance = new Balances(balances, { chains, evmNetworks, tokens, tokenRates })
-        return {
-          balance: balancesInstance.sum.fiat("usd").total,
-          chainId: balancesInstance.sorted[0].chainId || balancesInstance.sorted[0].evmNetworkId,
-          tokenId: balancesInstance.sorted[0].tokenId,
-        }
-      })
-    ).then((fiatBalances) => fiatBalances.sort((a, b) => b.balance - a.balance))
-
-    const topChainTokens = sortedFiatSumPerChainToken
-      .filter(({ balance }) => balance > 0)
-      .map(({ chainId, tokenId }) => ({ chainId, tokenId }))
-      .slice(0, 5)
-
-    const topToken = topChainTokens[0]
-
-    const hasGhosts = await hasGhostsOfThePast()
-    const hasGhostsNft = Object.values(hasGhosts).some((g) => g)
-
-    const ownedNfts = nftsStore$.value.nfts.filter((nft) =>
-      nft.owners.some((o) => ownedAddressesLower.includes(o.address.toLowerCase()))
-    )
-    const ownedCollections = nftsStore$.value.collections.filter((c) =>
-      ownedNfts.some((n) => n.collectionId === c.id)
-    )
-
-    const nftsCount = ownedNfts.length
-    const floorByCollectionId = Object.fromEntries(
-      ownedCollections
-        .map((collection) => [collection.id, getNftCollectionFloorUsd(collection)] as const)
-        .filter(([, floor]) => !!floor)
-    )
-    const nftsTotalValue = ownedNfts.reduce(
-      (total, nft) => total + (floorByCollectionId[nft.collectionId] ?? 0),
-      0
-    )
-    const topNftCollections = Object.entries(floorByCollectionId)
-      .sort((c1, c2) => (c2[1] ?? 0) - (c1[1] ?? 0))
-      .slice(0, 20)
-      .map(([collectionId]) => ownedCollections.find((c) => c.id === collectionId)?.name)
-
-    return {
-      accountBreakdown,
-      accountsCount: keyring.getAccounts().filter(({ meta }) => meta.origin !== AccountType.Watched)
-        .length,
-      totalFiatValue: roundToFirstInteger(balances.sum.fiat("usd").total),
-      topToken: topToken ? `${topToken.chainId}: ${topToken.tokenId}` : undefined,
-      tokens: sortedFiatSumPerChainToken
-        .filter((token, index) => token.balance > 1 || index < 10)
-        .map((token) => ({
-          ...token,
-          balance: roundToFirstInteger(token.balance),
-        })),
-      hasGhostsOfThePast: hasGhostsNft,
-      topChainTokens,
-
-      nftsCount,
-      nftsTotalValue,
-      topNftCollections,
-    }
+    setTimeout(() => this.capture(eventName, properties), delaySeconds * 1000 * Math.random())
   }
 }
 

--- a/packages/extension-core/src/libs/GeneralReport.ts
+++ b/packages/extension-core/src/libs/GeneralReport.ts
@@ -188,5 +188,8 @@ async function getGeneralReport() {
     nftsTotalValue,
     topNftCollections,
     hasGhostsOfThePast: hasGhostsNft,
+
+    // util
+    lastGeneralReport: Math.trunc(Date.now() / 1000),
   }
 }

--- a/packages/extension-core/src/libs/GeneralReport.ts
+++ b/packages/extension-core/src/libs/GeneralReport.ts
@@ -13,7 +13,7 @@ import { getNftCollectionFloorUsd } from "../domains/nfts"
 import { nftsStore$ } from "../domains/nfts/store"
 import { chaindataProvider } from "../rpcs/chaindata"
 import { hasGhostsOfThePast } from "../util/hasGhostsOfThePast"
-import { roundToFirstInteger } from "../util/roundToFirstInteger"
+import { privacyRoundCurrency } from "../util/privacyRoundCurrency"
 
 const REPORTING_PERIOD = 24 * 3600 * 1000 // 24 hours
 
@@ -128,10 +128,10 @@ async function getGeneralReport() {
     }))
     .sort((a, b) => b.balance - a.balance)
 
-  const totalFiatValue = roundToFirstInteger(balances.sum.fiat("usd").total)
+  const totalFiatValue = privacyRoundCurrency(balances.sum.fiat("usd").total)
   const tokensBreakdown = sortedFiatSumPerChainToken
     .filter((token, index) => token.balance > 1 || index < TOP_BALANCES_COUNT)
-    .map((token) => ({ ...token, balance: roundToFirstInteger(token.balance) }))
+    .map((token) => ({ ...token, balance: privacyRoundCurrency(token.balance) }))
 
   const topChainTokens = sortedFiatSumPerChainToken
     .filter(({ balance }) => balance > 0)

--- a/packages/extension-core/src/libs/GeneralReport.ts
+++ b/packages/extension-core/src/libs/GeneralReport.ts
@@ -1,0 +1,192 @@
+import keyring from "@polkadot/ui-keyring"
+import { DEBUG } from "extension-shared"
+import groupBy from "lodash/groupBy"
+import { type Properties } from "posthog-js"
+
+import { db } from "../db"
+import { AccountType } from "../domains/accounts/types"
+import { appStore } from "../domains/app/store.app"
+import { settingsStore } from "../domains/app/store.settings"
+import { balancePool } from "../domains/balances/pool"
+import { Balances } from "../domains/balances/types"
+import { getNftCollectionFloorUsd } from "../domains/nfts"
+import { nftsStore$ } from "../domains/nfts/store"
+import { chaindataProvider } from "../rpcs/chaindata"
+import { hasGhostsOfThePast } from "../util/hasGhostsOfThePast"
+import { roundToFirstInteger } from "../util/roundToFirstInteger"
+
+const REPORTING_PERIOD = 24 * 3600 * 1000 // 24 hours
+
+//
+// This should get sent at most once per 24 hours, whenever any other events get sent
+//
+export async function withGeneralReport(properties?: Properties) {
+  const analyticsReportSent = await appStore.get("analyticsReportSent")
+
+  // on first run, note down the timestamp but don't make a report
+  if (typeof analyticsReportSent !== "number") {
+    await appStore.set({ analyticsReportSent: Date.now() })
+    return properties
+  }
+
+  // on subsequent runs, do nothing if the diff between the recorded timestamp and now is less than REPORTING_PERIOD
+  if (Date.now() - analyticsReportSent < REPORTING_PERIOD) return properties
+
+  // and when the diff is greater, make a report
+  const generalReport = await getGeneralReport()
+  await appStore.set({ analyticsReportSent: Date.now() })
+  return { ...properties, $set: { ...(properties?.$set ?? {}), ...generalReport } }
+}
+
+async function getGeneralReport() {
+  const [allowTracking, onboarded] = await Promise.all([
+    settingsStore.get("useAnalyticsTracking"),
+    appStore.getIsOnboarded(),
+  ])
+  if (!allowTracking || !onboarded) return
+
+  //
+  // accounts
+  //
+
+  const accounts = keyring.getAccounts()
+
+  const ownedAccounts = accounts.filter(({ meta }) => meta.origin !== AccountType.Watched)
+  const ownedAccountsCount = ownedAccounts.length
+  const ownedAddresses = ownedAccounts.map((account) => account.address)
+  const ownedAddressesLower = ownedAddresses.map((a) => a.toLowerCase())
+
+  const watchedAccounts = accounts.filter(({ meta }) => meta.origin === AccountType.Watched)
+  const watchedAccountsCount = watchedAccounts.length
+
+  // account type breakdown
+  const accountBreakdown: Record<Lowercase<AccountType>, number> = {
+    talisman: 0,
+    qr: 0,
+    ledger: 0,
+    dcent: 0,
+    watched: 0,
+    signet: 0,
+  }
+  for (const account of accounts) {
+    const origin = account.meta.origin as AccountType | undefined
+    const type = origin?.toLowerCase?.() as Lowercase<AccountType> | undefined
+    if (type) accountBreakdown[type] = (accountBreakdown[type] ?? 0) + 1
+  }
+
+  //
+  // tokens
+  //
+
+  // cache chains, evmNetworks, tokens, tokenRates and balances here to prevent lots of fetch calls
+  try {
+    /* eslint-disable-next-line no-var */
+    var [chains, evmNetworks, tokens, tokenRates] = await Promise.all([
+      chaindataProvider.chainsById(),
+      chaindataProvider.evmNetworksById(),
+      chaindataProvider.tokensById(),
+      db.tokenRates
+        .toArray()
+        .then((dbTokenRates) =>
+          Object.fromEntries((dbTokenRates ?? []).map(({ tokenId, rates }) => [tokenId, rates]))
+        ),
+    ])
+
+    /* eslint-disable-next-line no-var */
+    var balances = new Balances(
+      Object.values(balancePool.balances).filter((balance) =>
+        ownedAddresses.includes(balance.address)
+      ),
+      { chains, evmNetworks, tokens, tokenRates }
+    )
+  } catch (cause) {
+    const error = new Error("Failed to access db to build general analyics report", { cause })
+    DEBUG && console.error(error) // eslint-disable-line no-console
+    throw error
+  }
+
+  // balances top 10 tokens/networks
+  const TOP_BALANCES_COUNT = 10
+  // get balance list per chain/evmNetwork and token
+  const balancesPerChainToken = groupBy(
+    balances.each.filter(
+      (balance) =>
+        balance &&
+        (balance.chain === null || !("isCustom" in balance.chain && balance.chain.isCustom)) &&
+        (balance.token === null || !("isCustom" in balance.token && balance.token.isCustom))
+    ),
+    (balance) => `${balance.chainId ?? balance.evmNetworkId}-${balance.tokenId}`
+  )
+
+  // get fiat sum object for those arrays of balances
+  const sortedFiatSumPerChainToken = Object.values(balancesPerChainToken)
+    .map((balances) => new Balances(balances, { chains, evmNetworks, tokens, tokenRates }))
+    .map((balances) => ({
+      balance: balances.sum.fiat("usd").total,
+      chainId: balances.sorted[0].chainId ?? balances.sorted[0].evmNetworkId,
+      tokenId: balances.sorted[0].tokenId,
+    }))
+    .sort((a, b) => b.balance - a.balance)
+
+  const totalFiatValue = roundToFirstInteger(balances.sum.fiat("usd").total)
+  const tokensBreakdown = sortedFiatSumPerChainToken
+    .filter((token, index) => token.balance > 1 || index < TOP_BALANCES_COUNT)
+    .map((token) => ({ ...token, balance: roundToFirstInteger(token.balance) }))
+
+  const topChainTokens = sortedFiatSumPerChainToken
+    .filter(({ balance }) => balance > 0)
+    .map(({ chainId, tokenId }) => ({ chainId, tokenId }))
+    .slice(0, 5)
+
+  const topToken = topChainTokens[0]
+    ? `${topChainTokens[0].chainId}: ${topChainTokens[0].tokenId}`
+    : undefined
+
+  //
+  // nfts
+  //
+
+  const hasGhosts = await hasGhostsOfThePast()
+  const hasGhostsNft = Object.values(hasGhosts).some((g) => g)
+
+  const ownedNfts = nftsStore$.value.nfts.filter((nft) =>
+    nft.owners.some((o) => ownedAddressesLower.includes(o.address.toLowerCase()))
+  )
+  const ownedCollections = nftsStore$.value.collections.filter((c) =>
+    ownedNfts.some((n) => n.collectionId === c.id)
+  )
+
+  const nftsCount = ownedNfts.length
+  const floorByCollectionId = Object.fromEntries(
+    ownedCollections
+      .map((collection) => [collection.id, getNftCollectionFloorUsd(collection)] as const)
+      .filter(([, floor]) => !!floor)
+  )
+  const nftsTotalValue = ownedNfts.reduce(
+    (total, nft) => total + (floorByCollectionId[nft.collectionId] ?? 0),
+    0
+  )
+  const topNftCollections = Object.entries(floorByCollectionId)
+    .sort((c1, c2) => (c2[1] ?? 0) - (c1[1] ?? 0))
+    .slice(0, 20)
+    .map(([collectionId]) => ownedCollections.find((c) => c.id === collectionId)?.name)
+
+  return {
+    // accounts
+    accountBreakdown,
+    accountsCount: ownedAccountsCount,
+    watchedAccountsCount,
+
+    // tokens
+    totalFiatValue,
+    tokens: tokensBreakdown,
+    topChainTokens,
+    topToken,
+
+    // nfts
+    nftsCount,
+    nftsTotalValue,
+    topNftCollections,
+    hasGhostsOfThePast: hasGhostsNft,
+  }
+}

--- a/packages/extension-core/src/util/privacyRoundCurrency.spec.ts
+++ b/packages/extension-core/src/util/privacyRoundCurrency.spec.ts
@@ -1,0 +1,29 @@
+import { privacyRoundCurrency } from "./privacyRoundCurrency"
+
+describe("privacyRoundCurrency", () => {
+  test("test known inputs match expected outputs", () => {
+    const tests: Array<[input: number, expectedOutput: string]> = [
+      [0.000000000000000000001234, "0"],
+      [0.00000000000000000001234, "0.00000000000000000001"],
+      [0.00001234, "0.00001"],
+      [0.0001234, "0.0001"],
+      [0.001234, "0.001"],
+      [0.01234, "0.01"],
+      [0.12345, "0.1"],
+      [1.12345, "1"],
+      [12.3456, "12"],
+      [123.456, "123"],
+      [1_234.56, "1230"],
+      [1_789.56, "1790"],
+      [12_345.67, "12300"],
+      [123_456.78, "123000"],
+      [1_234_567.89, "1230000"],
+      // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+      [1_234_567_891_234_567_891_234_567_891_234_567.89, "1230000000000000000000000000000000"],
+    ]
+
+    for (const [input, expectedOutput] of tests) {
+      expect(privacyRoundCurrency(input)).toEqual(expectedOutput)
+    }
+  })
+})

--- a/packages/extension-core/src/util/privacyRoundCurrency.ts
+++ b/packages/extension-core/src/util/privacyRoundCurrency.ts
@@ -1,0 +1,30 @@
+import BigNumber from "bignumber.js"
+
+/**
+ * Rounds a currency value (e.g. tokens / USD) to provide user privacy.
+ *
+ * @example
+ * 0.00001234   -> 0.00001
+ * 0.0001234    -> 0.0001
+ * 0.001234     -> 0.001
+ * 0.01234      -> 0.01
+ * 0.12345      -> 0.1
+ * 1.12345      -> 1
+ * 12.3456      -> 12
+ * 123.456      -> 123
+ * 1,234.56     -> 1,230
+ * 1,789.56     -> 1,790
+ * 12,345.67    -> 12,300
+ * 123,456.78   -> 123,000
+ * 1,234,567.89 -> 1,230,000
+ */
+export const privacyRoundCurrency = (amount: number) => {
+  // For amounts at or below 1, round to 1 significant digit
+  if (amount <= 1) return BigNumber(amount).precision(1).toString()
+
+  // For amounts below 1,000, round to the nearest whole number
+  if (amount < 1_000) return Math.round(amount).toString()
+
+  // For amounts at 1,000 and above, round to 3 significant digits
+  return BigNumber(amount).precision(3).toString()
+}

--- a/packages/extension-core/src/util/privacyRoundCurrency.ts
+++ b/packages/extension-core/src/util/privacyRoundCurrency.ts
@@ -20,11 +20,11 @@ import BigNumber from "bignumber.js"
  */
 export const privacyRoundCurrency = (amount: number) => {
   // For amounts at or below 1, round to 1 significant digit
-  if (amount <= 1) return BigNumber(amount).precision(1).toString()
+  if (amount <= 1) return BigNumber(amount).precision(1).toString(10)
 
   // For amounts below 1,000, round to the nearest whole number
-  if (amount < 1_000) return Math.round(amount).toString()
+  if (amount < 1_000) return BigNumber(amount).toFixed(0)
 
   // For amounts at 1,000 and above, round to 3 significant digits
-  return BigNumber(amount).precision(3).toString()
+  return BigNumber(amount).precision(3).toString(10)
 }

--- a/packages/extension-core/src/util/roundToFirstInteger.ts
+++ b/packages/extension-core/src/util/roundToFirstInteger.ts
@@ -1,8 +1,0 @@
-/*
-// provides an estimate rounded to the nearest first integer
-// ie 18.25 => 20, 3250465.242452 => 3000000
-*/
-export const roundToFirstInteger = (value: number) => {
-  const intLength = value.toFixed(0).length
-  return Number(value.toPrecision(intLength - (intLength - 1)))
-}


### PR DESCRIPTION
- Improved privacy-rounding function
- Removed unnecessary subscription on `appStore` in `Analytics` class
- Decoupled `GeneralReport` logic out from the core `Analytics` class
- Added new analytics props:
  - `watchedAccountsCount`
  - `lastGeneralReport`
- Fixed `GeneralReport` bugs & edge cases:
  - Include all account types in accountBreakdown (including types not included in `AccountType` enum)
  - Fetch async data in parallel instead of in sequence
  - Don't run sync processing as async tasks
  - Include a real error message when db access fails

---

Some more issues I found during testing:
- Each restart of the wallet generates a new user UUID, which leads to double-counting of assets ([fixed](https://github.com/TalismanSociety/talisman/pull/1573/commits/54bc375047f8df9ef9388adc1247ad18a683a181))
- GeneralReports are be generated from the current state of the balances pool, regardless of whether or not it is ready or still initialising ([fixed](https://github.com/TalismanSociety/talisman/pull/1573/commits/f8d0254361718094c9ed24750a062a4557ba818b))
- Same for NFTs