### PR TITLE
fix: allow signing when `Extrinsic` type is invalid

### DIFF
--- a/packages/extension-core/src/domains/transfers/rpc/AssetTransfers.ts
+++ b/packages/extension-core/src/domains/transfers/rpc/AssetTransfers.ts
@@ -73,7 +73,7 @@ export default class AssetTransfersRpc {
     try {
       await chainConnector.send(chain.id, "author_submitExtrinsic", [tx.toHex()])
     } catch (err) {
-      dismissTransaction(hash)
+      hash && dismissTransaction(hash)
       throw err
     }
 


### PR DESCRIPTION
Workaround for https://github.com/freeverseio/laos/issues/710
Fixes signing, at the expense of no ledger support or tx watching in the wallet