### PR TITLE
fix: improved general report reliability

### DIFF
--- a/packages/extension-core/src/domains/app/store.app.ts
+++ b/packages/extension-core/src/domains/app/store.app.ts
@@ -1,6 +1,7 @@
 import { DEBUG, IS_FIREFOX } from "extension-shared"
 import { gt } from "semver"
 
+import { GeneralReport } from "../../libs/GeneralReport"
 import { migratePasswordV2ToV1 } from "../../libs/migrations/legacyMigrations"
 import { StorageProvider } from "../../libs/Store"
 import { StakingSupportedChain } from "../staking/types"
@@ -20,7 +21,8 @@ export type AppStoreData = {
   hideBraveWarning: boolean
   hasBraveWarningBeenShown: boolean
   analyticsRequestShown: boolean
-  analyticsReportSent?: number
+  analyticsReportCreatedAt?: number
+  analyticsReport?: GeneralReport
   hideBackupWarningUntil?: number
   hasSpiritKey: boolean
   hideStakingBanner: StakingSupportedChain[]


### PR DESCRIPTION
New report logic:

- Any analytics event kicks off a general report
- General report is completed async, so that it doesn't block the kickoff event
- General report sets up balances and nft subscriptions, then waits a maximum of 30s for those subscriptions to fully hydrate
  - If they take longer than 30s, we continue to build the report with whatever data has hydrated so far
- Background restarts / browser quits / etc will result in the general report being cancelled,  
  but the kickoff event is still sent
- Once general report is completed, it is stored locally.  
  At this point it is primed and ready to go, so background restarts / browser quits / etc won't affect the next step
- Completed general report is included in the next analytics event, and when this happens it is cleared from storage