### PR TITLE
feat: erc20 approval set max instead of infinite

### DIFF
--- a/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyErc20Approve.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyErc20Approve.tsx
@@ -1,8 +1,9 @@
-import { EvmAddress } from "@extension/core"
-import { TOKEN_APPROVALS_URL, log } from "@extension/shared"
-import { notify } from "@talisman/components/Notifications"
 import { FC, useCallback, useMemo } from "react"
 import { Trans, useTranslation } from "react-i18next"
+
+import { EvmAddress } from "@extension/core"
+import { log, TOKEN_APPROVALS_URL } from "@extension/shared"
+import { notify } from "@talisman/components/Notifications"
 
 import { SignAlertMessage } from "../SignAlertMessage"
 import { SignContainer } from "../SignContainer"
@@ -98,6 +99,7 @@ export const EthSignBodyErc20Approve: FC = () => {
         <div>{isRevoke ? t("from spending") : t("to spend")}</div>
         {!isRevoke && (
           <SignParamAllowanceButton
+            account={account.address as EvmAddress}
             allowance={allowance}
             token={erc20Token}
             spender={spender}

--- a/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamAllowanceButton.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamAllowanceButton.tsx
@@ -62,7 +62,7 @@ const isValidAmount =
     }
   }
 
-const useErc20Balance = (account: EvmAddress, token: Erc20TokenInfo) => {
+const useFetchErc20Balance = (account: EvmAddress, token: Erc20TokenInfo) => {
   const client = usePublicClient(token.evmNetworkId)
 
   return useQuery({
@@ -142,7 +142,7 @@ const EditAllowanceForm: FC<{
     [handleSubmit, submit]
   )
 
-  const { data: balance } = useErc20Balance(account, token)
+  const { data: balance } = useFetchErc20Balance(account, token)
   const max = useMemo(
     () => (balance ? formatUnits(balance, token.decimals) : ""),
     [balance, token.decimals]

--- a/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamAllowanceButton.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamAllowanceButton.tsx
@@ -1,16 +1,8 @@
-import { BalanceFormatter, EvmAddress, EvmNetworkId } from "@extension/core"
-import { log } from "@extension/shared"
 import { yupResolver } from "@hookform/resolvers/yup"
-import { notify } from "@talisman/components/Notifications"
-import { shortenAddress } from "@talisman/util/shortenAddress"
 import { Address } from "@talismn/balances"
 import { EditIcon } from "@talismn/icons"
 import { formatDecimals, tokensToPlanck } from "@talismn/util"
-import { Fiat } from "@ui/domains/Asset/Fiat"
-import { useAnalytics } from "@ui/hooks/useAnalytics"
-import { useSelectedCurrency } from "@ui/hooks/useCurrency"
-import { useErc20Token } from "@ui/hooks/useErc20Token"
-import { useTokenRates } from "@ui/hooks/useTokenRates"
+import { useQuery } from "@tanstack/react-query"
 import { FC, FormEventHandler, useCallback, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { Trans, useTranslation } from "react-i18next"
@@ -26,8 +18,19 @@ import {
   TooltipTrigger,
   useOpenClose,
 } from "talisman-ui"
-import { formatUnits, hexToBigInt, parseUnits } from "viem"
+import { formatUnits, getContract, hexToBigInt, parseAbi, parseUnits } from "viem"
 import * as yup from "yup"
+
+import { abiErc20, BalanceFormatter, EvmAddress, EvmNetworkId } from "@extension/core"
+import { log } from "@extension/shared"
+import { notify } from "@talisman/components/Notifications"
+import { shortenAddress } from "@talisman/util/shortenAddress"
+import { Fiat } from "@ui/domains/Asset/Fiat"
+import { usePublicClient } from "@ui/domains/Ethereum/usePublicClient"
+import { useAnalytics } from "@ui/hooks/useAnalytics"
+import { useSelectedCurrency } from "@ui/hooks/useCurrency"
+import { useErc20Token } from "@ui/hooks/useErc20Token"
+import { useTokenRates } from "@ui/hooks/useTokenRates"
 
 export const ERC20_UNLIMITED_ALLOWANCE = hexToBigInt(
   "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
@@ -59,13 +62,33 @@ const isValidAmount =
     }
   }
 
+const useErc20Balance = (account: EvmAddress, token: Erc20TokenInfo) => {
+  const client = usePublicClient(token.evmNetworkId)
+
+  return useQuery({
+    queryKey: ["useErc20Balance", account, token, client?.key],
+    queryFn: async () => {
+      if (!account || !token || !client) return null
+
+      const contract = getContract({
+        address: token.contractAddress,
+        abi: parseAbi(abiErc20),
+        client: { public: client },
+      })
+
+      return contract.read.balanceOf([account])
+    },
+  })
+}
+
 const EditAllowanceForm: FC<{
+  account: EvmAddress
   token: Erc20TokenInfo
   spender: Address
   allowance: bigint
   onCancel: () => void
   onSubmit: (limit: bigint) => void | Promise<void>
-}> = ({ token, spender, allowance, onSubmit, onCancel }) => {
+}> = ({ account, token, spender, allowance, onSubmit, onCancel }) => {
   const { t } = useTranslation()
   const { genericEvent } = useAnalytics()
 
@@ -88,7 +111,6 @@ const EditAllowanceForm: FC<{
     register,
     handleSubmit,
     setValue,
-    watch,
     formState: { errors, isValid, isDirty, isSubmitting },
   } = useForm<FormData>({
     mode: "all",
@@ -120,11 +142,15 @@ const EditAllowanceForm: FC<{
     [handleSubmit, submit]
   )
 
-  const handleUnlimitedClick = useCallback(() => {
-    setValue("limit", "", { shouldValidate: true, shouldDirty: true, shouldTouch: true })
-  }, [setValue])
+  const { data: balance } = useErc20Balance(account, token)
+  const max = useMemo(
+    () => (balance ? formatUnits(balance, token.decimals) : ""),
+    [balance, token.decimals]
+  )
 
-  const limit = watch("limit")
+  const handleMaxClick = useCallback(() => {
+    setValue("limit", max, { shouldValidate: true, shouldDirty: true, shouldTouch: true })
+  }, [max, setValue])
 
   return (
     <form onSubmit={submitWithoutBubbleUp} className="bg-grey-800 rounded-t-xl p-12 ">
@@ -146,12 +172,8 @@ const EditAllowanceForm: FC<{
           after={
             <div className="flex items-center gap-4">
               <span className="text-body-disabled">{token.symbol}</span>
-              <PillButton
-                disabled={limit === ""}
-                onClick={handleUnlimitedClick}
-                className="hover:bg-grey-750"
-              >
-                {t("Unlimited")}
+              <PillButton disabled={!max} onClick={handleMaxClick} className="hover:bg-grey-750">
+                {t("Max")}
               </PillButton>
             </div>
           }
@@ -177,11 +199,12 @@ const EditAllowanceForm: FC<{
 }
 
 export const SignParamAllowanceButton: FC<{
+  account: EvmAddress
   spender: EvmAddress
   allowance: bigint
   token: Erc20TokenInfo
   onChange: (limit: bigint) => void | Promise<void>
-}> = ({ spender, allowance, token, onChange }) => {
+}> = ({ account, spender, allowance, token, onChange }) => {
   const { isOpen, open, close } = useOpenClose()
 
   const erc20 = useErc20Token(token.evmNetworkId, token.contractAddress)
@@ -237,6 +260,7 @@ export const SignParamAllowanceButton: FC<{
       </Tooltip>
       <Drawer anchor="bottom" containerId="main" isOpen={isOpen} onDismiss={close}>
         <EditAllowanceForm
+          account={account}
           token={token}
           spender={spender}
           allowance={allowance}


### PR DESCRIPTION
In ERC20 Approval sign tx form, modifies the edit value drawer to provide a Max button instead of an Infinite button.

If clicked, the approval value will be set to the account's current balance.