### PR TITLE
fix: update astar-gas-station.herokuapp.com into official astar api

### DIFF
--- a/apps/extension/src/ui/hooks/useTip.ts
+++ b/apps/extension/src/ui/hooks/useTip.ts
@@ -1,5 +1,6 @@
-import { ChainId } from "@extension/core"
 import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { ChainId } from "@extension/core"
 
 export type TipOptionName = "low" | "medium" | "high"
 export type TipOptions = Record<TipOptionName, string>
@@ -23,15 +24,15 @@ const getAstarTipOptions: TipOptionsResolver = async (response) => {
 // each gas station has a different response shape
 const gasStations: Record<ChainId, GasStationInfo> = {
   astar: {
-    url: "https://astar-gas-station.herokuapp.com/api/astar/gasnow",
+    url: "https://gas.astar.network/api/gasnow?network=astar",
     resolver: getAstarTipOptions,
   },
   shiden: {
-    url: "https://astar-gas-station.herokuapp.com/api/shiden/gasnow",
+    url: "https://gas.astar.network/api/gasnow?network=shiden",
     resolver: getAstarTipOptions,
   },
   shibuya: {
-    url: "https://astar-gas-station.herokuapp.com/api/shibuya/gasnow",
+    url: "https://gas.astar.network/api/gasnow?network=shibuya",
     resolver: getAstarTipOptions,
   },
 }


### PR DESCRIPTION
refs: https://github.com/TalismanSociety/talisman/issues/1601

I changed api from `https://astar-gas-station.herokuapp.com/api/astar/gasnow` to `https://gas.astar.network/api/gasnow?network=astar` according to [Astar official api docs](https://docs.astar.network/docs/build/integrations/api/gas_api/)

In that case, official api has more data than heroku api
```
https://gas.astar.network/api/gasnow?network=astar
{
    "code": 200,
    "data": {
        "average": "935245620061",
        "fast": "935245620061",
        "slow": "780871350051",
        "fastest": "935245620061",
        "eip1559": {
            "priorityFeePerGas": {
                "average": "935245620061",
                "fast": "935245620061",
                "slow": "780871350051",
                "fastest": "935245620061"
            },
            "maxPriorityFeePerGas": "3000000000",
            "baseFeePerGas": "779000000000",
            "maxFeePerGas": "782000000000"
        },
        "tip": {
            "average": "935245620061000",
            "fast": "935245620061000",
            "slow": "780871350051000",
            "fastest": "935245620061000"
        },
        "timestamp": 1725859885563
    }
}
```
```
https://astar-gas-station.herokuapp.com/api/astar/gasnow
{
    "code": 200,
    "data": {
        "slow": "1046189511219",
        "average": "1295390646909",
        "fast": "1466793170256",
        "timestamp": 1726101813226,
        "eip1559": {
            "priorityFeePerGas": {
                "slow": "266818161168",
                "average": "516019296858",
                "fast": "687421820205"
            },
            "baseFeePerGas": "779371350051"
        },
        "tip": {
            "slow": "266818161168000",
            "average": "516019296858000",
            "fast": "687421820205000"
        }
    }
}
```
imo, they updated api currently without change of even official docs.


