### PR TITLE
fix(ui-updates-202409): slightly changed currency switcher design

### DIFF
--- a/apps/extension/src/ui/apps/popup/components/TotalFiatBalance.tsx
+++ b/apps/extension/src/ui/apps/popup/components/TotalFiatBalance.tsx
@@ -66,7 +66,7 @@ export const TotalFiatBalance = ({ className, mouseOver, disabled }: Props) => {
         <div className="flex w-full max-w-full items-center gap-2">
           <button
             className={classNames(
-              "bg-grey-700/20 border-grey-200 text-grey-200 hover:text-body hover:bg-body/10 hover:border-body pointer-events-auto flex size-16 shrink-0 items-center justify-center rounded-full border text-center transition-colors duration-100 ease-out",
+              "bg-grey-700/20 text-grey-200 hover:text-body hover:bg-body/10 pointer-events-auto flex size-16 shrink-0 items-center justify-center rounded-full text-center shadow-[inset_0px_0px_1px_rgb(228_228_228_/_1)] transition-[box-shadow,color,background-color] duration-200 ease-out hover:shadow-[inset_0px_0px_2px_rgb(250_250_250_/_1)]",
               currencyConfig[currency]?.symbol?.length === 2 && "text-xs",
               currencyConfig[currency]?.symbol?.length > 2 && "text-[1rem]"
             )}

--- a/apps/extension/src/ui/domains/Portfolio/DashboardPortfolioHeader.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/DashboardPortfolioHeader.tsx
@@ -137,7 +137,7 @@ export const DashboardPortfolioHeader: FC<{ className?: string }> = ({ className
         <div className="flex w-full max-w-full items-center gap-6">
           <button
             className={classNames(
-              "bg-grey-700/20 border-grey-200 text-grey-200 hover:text-body hover:border-body hover:bg-body/10 pointer-events-auto flex size-[4.4rem] shrink-0 items-center justify-center rounded-full border text-center text-lg leading-none transition-colors duration-100 ease-out",
+              "bg-grey-700/20 text-grey-200 hover:text-body hover:bg-body/10 pointer-events-auto flex size-[4.4rem] shrink-0 items-center justify-center rounded-full text-center text-lg leading-none shadow-[inset_0px_0px_1px_rgb(228_228_228_/_1)] transition-[box-shadow,color,background-color] duration-200 ease-out hover:shadow-[inset_0px_0px_2px_rgb(250_250_250_/_1)]",
               currencyConfig[currency]?.symbol?.length === 2 && "text-md",
               currencyConfig[currency]?.symbol?.length > 2 && "text-base"
             )}


### PR DESCRIPTION
Left: previous
Right: new
Top: default state
Bottom: hover state

<img width="879" alt="Screenshot 2024-10-07 at 09 36 46" src="https://github.com/user-attachments/assets/01048df9-f69a-466b-a1ff-50d6717b59ed">

<img width="876" alt="Screenshot 2024-10-07 at 09 37 31" src="https://github.com/user-attachments/assets/b54a6dbc-3493-414b-8c1c-909fb1cbaeda">
