### PR TITLE
fix: accounts logostack nowrap

### DIFF
--- a/apps/extension/src/ui/domains/Account/AccountsLogoStack.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountsLogoStack.tsx
@@ -24,7 +24,7 @@ export const AccountsLogoStack = ({ addresses, className, max = 4 }: Props) => {
   )
 
   return (
-    <div className={classNames("shrink-0 pl-[0.25em]", className)}>
+    <div className={classNames("shrink-0 whitespace-nowrap pl-[0.25em]", className)}>
       {visibleAccounts.map((account) => (
         <AccountsLogoStackItem key={account.address} account={account} />
       ))}


### PR DESCRIPTION
prevents logostacks to wrap over 2 lines in sidebar