### PR TITLE
fix: tx history values text align

### DIFF
--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -401,6 +401,7 @@ const TransactionRowBase: FC<{
         <div className="relative flex grow flex-col items-end justify-center">
           <div
             className={classNames(
+              "text-right",
               isCtxMenuOpen ? "opacity-0" : "opacity-100",
               enabled && "group-hover:opacity-0"
             )}


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/f1c030b0-c598-4795-a5ce-629614669d1c)

after:
![image](https://github.com/user-attachments/assets/ffcc556f-3c25-4d64-b116-8f88a4fc039d)
