### PR TITLE
fix: capture label for signing substrate messages

### DIFF
--- a/packages/extension-core/src/domains/signing/handler.ts
+++ b/packages/extension-core/src/domains/signing/handler.ts
@@ -129,10 +129,13 @@ export default class SigningHandler extends ExtensionHandler {
         signature = request.sign(registry, pair).signature
       }
 
-      talismanAnalytics.captureDelayed("sign transaction approve", {
-        ...analyticsProperties,
-        networkType: "substrate",
-      })
+      talismanAnalytics.captureDelayed(
+        isJsonPayload(payload) ? "sign transaction approve" : "sign approve",
+        {
+          ...analyticsProperties,
+          networkType: "substrate",
+        },
+      )
 
       resolve({
         id,
@@ -221,11 +224,14 @@ export default class SigningHandler extends ExtensionHandler {
         ? "qr"
         : undefined
 
-    talismanAnalytics.captureDelayed("sign transaction approve", {
-      ...analyticsProperties,
-      networkType: "substrate",
-      hardwareType,
-    })
+    talismanAnalytics.captureDelayed(
+      isJsonPayload(payload) ? "sign transaction approve" : "sign approve",
+      {
+        ...analyticsProperties,
+        networkType: "substrate",
+        hardwareType,
+      },
+    )
 
     return true
   }


### PR DESCRIPTION
For substrate signing requests, the wallet was sending a "sign transaction approve" capture for both transactions and text messages (such as SIWS).
Fixed it so it will send "sign approve" instead for text messages, which is consistent with what we do with Ethereum.