### PR TITLE
feat: disable analytics on FF

### DIFF
--- a/apps/extension/src/sentry.ts
+++ b/apps/extension/src/sentry.ts
@@ -45,7 +45,7 @@ export const initSentryFrontend = () => {
       }
 
       const errorTracking = await firstValueFrom(useErrorTracking)
-      return !IS_FIREFOX && errorTracking ? event : null
+      return errorTracking ? event : null
     },
     beforeBreadcrumb: (breadCrumb) => {
       if (breadCrumb.data?.url) {

--- a/apps/extension/src/sentry.ts
+++ b/apps/extension/src/sentry.ts
@@ -5,7 +5,7 @@ import {
   trackIndexedDbErrorExtras,
   triggerIndexedDbUnavailablePopup,
 } from "extension-core"
-import { DEBUG } from "extension-shared"
+import { DEBUG, IS_FIREFOX } from "extension-shared"
 import { firstValueFrom, ReplaySubject } from "rxjs"
 
 const normalizeUrl = (url: string) => {
@@ -18,7 +18,7 @@ settingsStore.observable.subscribe((settings) => useErrorTracking.next(settings.
 
 export const initSentryFrontend = () => {
   SentryReact.init({
-    enabled: true,
+    enabled: !IS_FIREFOX,
     environment: process.env.BUILD,
     dsn: process.env.SENTRY_DSN,
     integrations: [SentryReact.browserTracingIntegration()],
@@ -45,7 +45,7 @@ export const initSentryFrontend = () => {
       }
 
       const errorTracking = await firstValueFrom(useErrorTracking)
-      return errorTracking ? event : null
+      return !IS_FIREFOX && errorTracking ? event : null
     },
     beforeBreadcrumb: (breadCrumb) => {
       if (breadCrumb.data?.url) {

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/SecurityPrivacyPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/SecurityPrivacyPage.tsx
@@ -7,6 +7,7 @@ import {
   LockIcon,
   ShieldZapIcon,
 } from "@talismn/icons"
+import { IS_FIREFOX } from "extension-shared"
 import { Trans, useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { CtaButton, Toggle, Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
@@ -15,7 +16,7 @@ import { HeaderBlock } from "@talisman/components/HeaderBlock"
 import { Setting } from "@talisman/components/Setting"
 import { Spacer } from "@talisman/components/Spacer"
 import { useMnemonicBackup } from "@ui/hooks/useMnemonicBackup"
-import { useSetting } from "@ui/state"
+import { useFeatureFlag, useSetting } from "@ui/state"
 
 import { DashboardLayout } from "../../layout"
 
@@ -25,6 +26,8 @@ const Content = () => {
   const [useErrorTracking, setUseErrorTracking] = useSetting("useErrorTracking")
   const [autoRiskScan, setAutoRiskScan] = useSetting("autoRiskScan")
   const navigate = useNavigate()
+
+  const withRiskAnalysis = useFeatureFlag("RISK_ANALYSIS")
 
   const { allBackedUp } = useMnemonicBackup()
 
@@ -55,83 +58,89 @@ const Content = () => {
           subtitle={t("Set a timer to automatically lock your Talisman wallet")}
           to={`/settings/security-privacy-settings/autolock`}
         />
-        <Setting
-          iconLeft={ShieldZapIcon}
-          title={
-            <span className="inline-flex items-center gap-[0.3em]">
-              <span>{t("Auto risk scan")}</span>
-              <Tooltip>
-                <TooltipTrigger className="inline-block">
-                  <InfoIcon />
-                </TooltipTrigger>
-                <TooltipContent>
-                  {t(
-                    "This service is only available for some Ethereum networks, please visit Blowfish website for more information.",
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </span>
-          }
-          subtitle={
-            <Trans t={t}>
-              Automatically assess risks of Ethereum transactions and messages via{" "}
-              <a
-                className="text-grey-200 hover:text-body"
-                href="https://blowfish.xyz"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                Blowfish
-              </a>
-            </Trans>
-          }
-        >
-          <Toggle checked={autoRiskScan} onChange={(e) => setAutoRiskScan(e.target.checked)} />
-        </Setting>
-        <Setting
-          iconLeft={AlertCircleIcon}
-          title={t("Error reporting")}
-          subtitle={
-            <Trans t={t}>
-              Send anonymised error reports to Talisman (via{" "}
-              <a
-                className="text-grey-200 hover:text-body"
-                href="https://www.sentry.io"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                Sentry
-              </a>
-              )
-            </Trans>
-          }
-        >
-          <Toggle
-            checked={useErrorTracking}
-            onChange={(e) => setUseErrorTracking(e.target.checked)}
-          />
-        </Setting>
-        <Setting
-          iconLeft={ActivityIcon}
-          title={t("Analytics")}
-          subtitle={
-            <Trans t={t}>
-              Opt in to collection of anonymised usage data.{" "}
-              <button
-                type="button"
-                className="text-grey-200 hover:text-body"
-                onClick={() => navigate("/settings/analytics")}
-              >
-                Learn More
-              </button>
-            </Trans>
-          }
-        >
-          <Toggle
-            checked={useAnalyticsTracking}
-            onChange={(e) => setUseAnalyticsTracking(e.target.checked)}
-          />
-        </Setting>
+        {withRiskAnalysis && (
+          <Setting
+            iconLeft={ShieldZapIcon}
+            title={
+              <span className="inline-flex items-center gap-[0.3em]">
+                <span>{t("Auto risk scan")}</span>
+                <Tooltip>
+                  <TooltipTrigger className="inline-block">
+                    <InfoIcon />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t(
+                      "This service is only available for some Ethereum networks, please visit Blowfish website for more information.",
+                    )}
+                  </TooltipContent>
+                </Tooltip>
+              </span>
+            }
+            subtitle={
+              <Trans t={t}>
+                Automatically assess risks of Ethereum transactions and messages via{" "}
+                <a
+                  className="text-grey-200 hover:text-body"
+                  href="https://blowfish.xyz"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  Blowfish
+                </a>
+              </Trans>
+            }
+          >
+            <Toggle checked={autoRiskScan} onChange={(e) => setAutoRiskScan(e.target.checked)} />
+          </Setting>
+        )}
+        {!IS_FIREFOX && (
+          <>
+            <Setting
+              iconLeft={AlertCircleIcon}
+              title={t("Error reporting")}
+              subtitle={
+                <Trans t={t}>
+                  Send anonymised error reports to Talisman (via{" "}
+                  <a
+                    className="text-grey-200 hover:text-body"
+                    href="https://www.sentry.io"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    Sentry
+                  </a>
+                  )
+                </Trans>
+              }
+            >
+              <Toggle
+                checked={useErrorTracking}
+                onChange={(e) => setUseErrorTracking(e.target.checked)}
+              />
+            </Setting>
+            <Setting
+              iconLeft={ActivityIcon}
+              title={t("Analytics")}
+              subtitle={
+                <Trans t={t}>
+                  Opt in to collection of anonymised usage data.{" "}
+                  <button
+                    type="button"
+                    className="text-grey-200 hover:text-body"
+                    onClick={() => navigate("/settings/analytics")}
+                  >
+                    Learn More
+                  </button>
+                </Trans>
+              }
+            >
+              <Toggle
+                checked={useAnalyticsTracking}
+                onChange={(e) => setUseAnalyticsTracking(e.target.checked)}
+              />
+            </Setting>
+          </>
+        )}
       </div>
     </>
   )

--- a/apps/extension/src/ui/apps/onboard/routes/Password.tsx
+++ b/apps/extension/src/ui/apps/onboard/routes/Password.tsx
@@ -1,5 +1,6 @@
 import { yupResolver } from "@hookform/resolvers/yup"
 import { classNames } from "@talismn/util"
+import { IS_FIREFOX } from "extension-shared"
 import { useCallback, useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
@@ -86,7 +87,7 @@ export const PasswordPage = () => {
   }, [setValue])
 
   const navigateNext = useCallback(() => {
-    navigate(isResettingWallet ? "/accounts/add" : `/privacy`)
+    navigate(isResettingWallet || IS_FIREFOX ? "/accounts/add" : `/privacy`)
   }, [navigate, isResettingWallet])
 
   const submit = useCallback(

--- a/apps/extension/src/ui/apps/onboard/routes/Privacy.tsx
+++ b/apps/extension/src/ui/apps/onboard/routes/Privacy.tsx
@@ -67,15 +67,16 @@ export const PrivacyPage = () => {
               always adjust these settings, or opt out completely at any time.
             </p>
             <p>
+              Read our{" "}
               <a
                 onClick={handleLearnMoreClick}
                 className="text-body"
                 href={PRIVACY_POLICY_URL}
                 target="_blank"
               >
-                Learn more
+                Privacy Policy
               </a>{" "}
-              about what we track and how we use this data.
+              to learn more about what we track and how we use this data.
             </p>
           </div>
         </Trans>

--- a/packages/extension-core/src/domains/analytics/store.ts
+++ b/packages/extension-core/src/domains/analytics/store.ts
@@ -66,7 +66,7 @@ class AnalyticsStore extends StorageProvider<AnalyticsData> {
     eventTimestamp?: number,
   ) {
     const enabled = await settingsStore.get("useAnalyticsTracking")
-    if (!IS_FIREFOX || enabled === false) return
+    if (IS_FIREFOX || enabled === false) return
 
     log.debug("AnalyticsStore.capture", { eventName, rawProperties, eventTimestamp })
     const timestamp = eventTimestamp ?? Date.now()

--- a/packages/extension-core/src/domains/analytics/store.ts
+++ b/packages/extension-core/src/domains/analytics/store.ts
@@ -66,7 +66,7 @@ class AnalyticsStore extends StorageProvider<AnalyticsData> {
     eventTimestamp?: number,
   ) {
     const enabled = await settingsStore.get("useAnalyticsTracking")
-    if (IS_FIREFOX ? !enabled : enabled === false) return
+    if (!IS_FIREFOX || enabled === false) return
 
     log.debug("AnalyticsStore.capture", { eventName, rawProperties, eventTimestamp })
     const timestamp = eventTimestamp ?? Date.now()

--- a/packages/extension-core/src/domains/analytics/store.ts
+++ b/packages/extension-core/src/domains/analytics/store.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/browser"
-import { DEBUG, log } from "extension-shared"
+import { DEBUG, IS_FIREFOX, log } from "extension-shared"
 import { v4 } from "uuid"
 
 import { StorageProvider } from "../../libs/Store"
@@ -66,7 +66,7 @@ class AnalyticsStore extends StorageProvider<AnalyticsData> {
     eventTimestamp?: number,
   ) {
     const enabled = await settingsStore.get("useAnalyticsTracking")
-    if (!enabled) return
+    if (IS_FIREFOX ? !enabled : enabled === false) return
 
     log.debug("AnalyticsStore.capture", { eventName, rawProperties, eventTimestamp })
     const timestamp = eventTimestamp ?? Date.now()

--- a/packages/extension-core/src/domains/app/store.settings.ts
+++ b/packages/extension-core/src/domains/app/store.settings.ts
@@ -1,4 +1,5 @@
 import { TokenRateCurrency } from "@talismn/token-rates"
+import { IS_FIREFOX } from "extension-shared"
 
 import { StorageProvider } from "../../libs/Store"
 import { IdenticonType } from "../accounts/types"
@@ -28,7 +29,7 @@ export interface SettingsStoreData {
 export class SettingsStore extends StorageProvider<SettingsStoreData> {}
 
 export const DEFAULT_SETTINGS: SettingsStoreData = {
-  useErrorTracking: false,
+  useErrorTracking: !IS_FIREFOX,
   useTestnets: false,
   identiconType: "talisman-orb",
   useAnalyticsTracking: undefined, // undefined for onboarding

--- a/packages/extension-core/src/libs/Analytics.ts
+++ b/packages/extension-core/src/libs/Analytics.ts
@@ -1,4 +1,4 @@
-import { DEBUG } from "extension-shared"
+import { DEBUG, IS_FIREFOX } from "extension-shared"
 
 import { analyticsStore } from "../domains/analytics/store"
 import { PostHogCaptureProperties } from "../domains/analytics/types"
@@ -15,7 +15,7 @@ class TalismanAnalytics {
       // have to put this manual check here because posthog is buggy and will not respect our settings
       // https://github.com/PostHog/posthog-js/issues/336
       const allowTracking = await settingsStore.get("useAnalyticsTracking")
-      if (!allowTracking) return
+      if (IS_FIREFOX ? !allowTracking : allowTracking === false) return
 
       const captureProperties = await withGeneralReport(properties)
       await analyticsStore.capture(eventName, captureProperties)

--- a/packages/extension-core/src/libs/Analytics.ts
+++ b/packages/extension-core/src/libs/Analytics.ts
@@ -6,7 +6,7 @@ import { settingsStore } from "../domains/app/store.settings"
 import { withGeneralReport } from "./GeneralReport"
 
 class TalismanAnalytics {
-  #enabled = Boolean(process.env.POSTHOG_AUTH_TOKEN)
+  #enabled = !IS_FIREFOX && Boolean(process.env.POSTHOG_AUTH_TOKEN)
 
   async capture(eventName: string, properties?: PostHogCaptureProperties) {
     if (!this.#enabled) return
@@ -15,7 +15,7 @@ class TalismanAnalytics {
       // have to put this manual check here because posthog is buggy and will not respect our settings
       // https://github.com/PostHog/posthog-js/issues/336
       const allowTracking = await settingsStore.get("useAnalyticsTracking")
-      if (IS_FIREFOX ? !allowTracking : allowTracking === false) return
+      if (allowTracking === false) return
 
       const captureProperties = await withGeneralReport(properties)
       await analyticsStore.capture(eventName, captureProperties)

--- a/packages/extension-core/src/libs/Analytics.ts
+++ b/packages/extension-core/src/libs/Analytics.ts
@@ -15,7 +15,7 @@ class TalismanAnalytics {
       // have to put this manual check here because posthog is buggy and will not respect our settings
       // https://github.com/PostHog/posthog-js/issues/336
       const allowTracking = await settingsStore.get("useAnalyticsTracking")
-      if (allowTracking === false) return
+      if (!allowTracking) return
 
       const captureProperties = await withGeneralReport(properties)
       await analyticsStore.capture(eventName, captureProperties)

--- a/packages/extension-core/src/libs/Analytics.ts
+++ b/packages/extension-core/src/libs/Analytics.ts
@@ -15,7 +15,7 @@ class TalismanAnalytics {
       // have to put this manual check here because posthog is buggy and will not respect our settings
       // https://github.com/PostHog/posthog-js/issues/336
       const allowTracking = await settingsStore.get("useAnalyticsTracking")
-      if (!allowTracking) return
+      if (allowTracking === false) return
 
       const captureProperties = await withGeneralReport(properties)
       await analyticsStore.capture(eventName, captureProperties)

--- a/packages/extension-core/src/libs/GeneralReport.ts
+++ b/packages/extension-core/src/libs/GeneralReport.ts
@@ -1,6 +1,6 @@
 import keyring from "@polkadot/ui-keyring"
 import { sleep } from "@talismn/util"
-import { DEBUG } from "extension-shared"
+import { DEBUG, IS_FIREFOX } from "extension-shared"
 import groupBy from "lodash/groupBy"
 
 import { db } from "../db"
@@ -84,7 +84,7 @@ async function getGeneralReport() {
     settingsStore.get("useAnalyticsTracking"),
     appStore.getIsOnboarded(),
   ])
-  if (!allowTracking || !onboarded) return
+  if (!allowTracking || !onboarded || IS_FIREFOX) return
 
   //
   // accounts


### PR DESCRIPTION
- Reverts changes to Chrome from #1692 
- Disables analytics and error reporting on FF
- Bonus: Hides Risk Analysis settings based on feature flag, as this was forgotten in #1677