### PR TITLE
fix: manually close alert (workaround breaking change in toastify)

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/layout/notifications/OnboardingToast.tsx
+++ b/apps/extension/src/ui/apps/dashboard/layout/notifications/OnboardingToast.tsx
@@ -48,6 +48,7 @@ export const OnboardingToast = () => {
 
       notifyCustom(OnboardNotification, {
         autoClose: false,
+        closeOnClick: true,
       })
     }
   }, [searchParams, setSearchParams, OnboardNotification])

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/QrMetadataPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/QrMetadataPage.tsx
@@ -52,7 +52,7 @@ const SetVerifierCertificateContentInner = () => {
           title: t("Error"),
           subtitle: t("Failed to set verifier certificate."),
         },
-        { autoClose: false },
+        { autoClose: false, closeOnClick: true },
       )
     }
   }, [generateMnemonic, mnemonicId, t])


### PR DESCRIPTION
since last package bump, the alerts with autoClose: false, such as the "Pin Talisman" one that we display after onboarding, couldn't be closed by clicking on them.