### PR TITLE
fix: chunk filenames

### DIFF
--- a/apps/extension/webpack/webpack.common.js
+++ b/apps/extension/webpack/webpack.common.js
@@ -41,7 +41,7 @@ const config = (env) => ({
   output: {
     path: distDir,
     filename: "[name].js",
-    chunkFilename: "[name].chunk.js",
+    chunkFilename: "chunk.[name].js",
     assetModuleFilename: "assets/[hash][ext]", // removes query string if there are any in our import strings (we use ?url for svgs)
     globalObject: "self",
   },


### PR DESCRIPTION
This pull request includes a change to the `chunkFilename` property in the Webpack configuration for the extension application. The change modifies the naming convention for chunk files to improve clarity and consistency, and ensuring chunk files never start with an underscore, which would prevent chrome from loading the folder package.

* [`apps/extension/webpack/webpack.common.js`](diffhunk://#diff-fbb11aeb541c893415e3da013f0124a193dcad1d0539c5da6392eacfb123f03eL44-R44): Changed the `chunkFilename` property from `"[name].chunk.js"` to `"chunk.[name].js"` to standardize the naming convention for chunk files.