### PR TITLE
fix: review builds via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,3 @@ RUN pnpm clean
 RUN pnpm install
 # NOTE: Only needed while we wait for https://github.com/polkadot-api/polkadot-api/pull/851 to be released
 RUN pnpm papi:dockerbuildcompat
-ENV USE_ONE_DIST_DIR=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ COPY . ./
 
 RUN pnpm clean
 RUN pnpm install
+# NOTE: Only needed while we wait for https://github.com/polkadot-api/polkadot-api/pull/851 to be released
+RUN pnpm papi:dockerbuildcompat
 ENV USE_ONE_DIST_DIR=true

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "license": "GPL-3.0-or-later",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "preconstruct:dev": "preconstruct dev",
     "preconstruct:fix": "preconstruct fix",
     "papi": "papi && pnpm papi:fixdep",
+    "papi:dockerbuildcompat": "cp pnpm-lock.yaml pnpm-lock.yaml.cp && ./node_modules/.bin/papi && mv pnpm-lock.yaml.cp pnpm-lock.yaml && pnpm remove --workspace-root @polkadot-api/descriptors && pnpm install",
     "papi:fixdep": "git checkout pnpm-lock.yaml && pnpm remove --workspace-root @polkadot-api/descriptors && pnpm install",
     "papi:generate": "papi generate && pnpm papi:fixdep",
     "papi:update": "papi update && pnpm papi:fixdep",

--- a/scripts/build-review-firefox.sh
+++ b/scripts/build-review-firefox.sh
@@ -10,7 +10,7 @@ docker run --rm --volume "$(pwd)/review":/review talisman-builder bash -c ' \
     rm -rf /talisman/apps/extension/dist && \
     find /talisman/ -depth -type d -name node_modules -exec rm -rf {} \; && \
     cp -r /talisman/ /review/sources && \
-    rm /review/sources/apps/extension/.env.local
+    rm -f /review/sources/apps/extension/.env.local
 '
 cd review
 zip -r source.zip ./sources/

--- a/scripts/build-review-firefox.sh
+++ b/scripts/build-review-firefox.sh
@@ -6,7 +6,7 @@ mkdir review
 docker build . --tag talisman-builder
 docker run --rm --volume "$(pwd)/review":/review talisman-builder bash -c ' \
     NODE_OPTIONS=--max_old_space_size=8192 pnpm build:extension:prod:firefox && \
-    cp /talisman/apps/extension/dist/firefox/*.zip /review/ && \
+    cp /talisman/apps/extension/dist/*.zip /review/ && \
     rm -rf /talisman/apps/extension/dist && \
     find /talisman/ -depth -type d -name node_modules -exec rm -rf {} \; && \
     cp -r /talisman/ /review/sources && \

--- a/scripts/build-review-firefox.sh
+++ b/scripts/build-review-firefox.sh
@@ -5,7 +5,7 @@ rm -rf review
 mkdir review
 docker build . --tag talisman-builder
 docker run --rm --volume "$(pwd)/review":/review talisman-builder bash -c ' \
-    NODE_OPTIONS=--max_old_space_size=8192 pnpm build:extension:prod:firefox && \
+    NODE_OPTIONS=--max_old_space_size=8192 USE_ONE_DIST_DIR=true pnpm build:extension:prod:firefox && \
     cp /talisman/apps/extension/dist/*.zip /review/ && \
     rm -rf /talisman/apps/extension/dist && \
     find /talisman/ -depth -type d -name node_modules -exec rm -rf {} \; && \

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,33 @@
 {
   "$schema": "https://turborepo.org/schema.json",
+  "globalEnv": [
+    "API_KEY_ONFINALITY",
+    "BLOWFISH_API_KEY",
+    "BLOWFISH_BASE_PATH",
+    "BLOWFISH_QA_API_KEY",
+    "COINGECKO_API_KEY_NAME",
+    "COINGECKO_API_KEY_VALUE",
+    "COINGECKO_API_URL",
+    "EVM_LOGPROXY",
+    "MEASURE_WEBPACK_SPEED",
+    "NFTS_API_BASE_PATH",
+    "NFTS_API_KEY",
+    "NFTS_QA_API_KEY",
+    "NODE_DEBUG",
+    "NODE_ENV",
+    "NODE_OPTIONS",
+    "PASSWORD",
+    "PORT_PREFIX",
+    "POSTHOG_AUTH_TOKEN",
+    "SENTRY_AUTH_TOKEN",
+    "SENTRY_DSN",
+    "SIMPLE_LOCALIZE_API_KEY",
+    "SIMPLE_LOCALIZE_PROJECT_TOKEN",
+    "SUPPORTED_LANGUAGES",
+    "TEST_MNEMONIC",
+    "USE_ONE_DIST_DIR",
+    "npm_package_version"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["//#build:packages", "^build"],
@@ -20,80 +48,26 @@
     },
     "build:extension:ci": {
       "dependsOn": ["//#build:packages"],
-      "env": [
-        "POSTHOG_AUTH_TOKEN",
-        "SIMPLE_LOCALIZE_API_KEY",
-        "SIMPLE_LOCALIZE_PROJECT_TOKEN",
-        "SENTRY_DSN",
-        "SENTRY_AUTH_TOKEN",
-        "BLOWFISH_BASE_PATH",
-        "BLOWFISH_API_KEY"
-      ],
       "outputs": ["dist/**"]
     },
     "build:extension:ci:firefox": {
       "dependsOn": ["//#build:packages"],
-      "env": [
-        "POSTHOG_AUTH_TOKEN",
-        "SIMPLE_LOCALIZE_API_KEY",
-        "SIMPLE_LOCALIZE_PROJECT_TOKEN",
-        "SENTRY_DSN",
-        "SENTRY_AUTH_TOKEN",
-        "BLOWFISH_BASE_PATH",
-        "BLOWFISH_API_KEY"
-      ],
       "outputs": ["dist/**"]
     },
     "build:extension:canary": {
       "dependsOn": ["//#build:packages"],
-      "env": [
-        "POSTHOG_AUTH_TOKEN",
-        "SIMPLE_LOCALIZE_API_KEY",
-        "SIMPLE_LOCALIZE_PROJECT_TOKEN",
-        "SENTRY_DSN",
-        "SENTRY_AUTH_TOKEN",
-        "BLOWFISH_BASE_PATH",
-        "BLOWFISH_API_KEY"
-      ],
       "outputs": ["dist/**"]
     },
     "build:extension:canary:firefox": {
       "dependsOn": ["//#build:packages"],
-      "env": [
-        "POSTHOG_AUTH_TOKEN",
-        "SIMPLE_LOCALIZE_API_KEY",
-        "SIMPLE_LOCALIZE_PROJECT_TOKEN",
-        "SENTRY_DSN",
-        "SENTRY_AUTH_TOKEN",
-        "BLOWFISH_BASE_PATH",
-        "BLOWFISH_API_KEY"
-      ],
       "outputs": ["dist/**"]
     },
     "build:extension:prod": {
       "dependsOn": ["//#build:packages"],
-      "env": [
-        "POSTHOG_AUTH_TOKEN",
-        "SIMPLE_LOCALIZE_API_KEY",
-        "SIMPLE_LOCALIZE_PROJECT_TOKEN",
-        "SENTRY_DSN",
-        "SENTRY_AUTH_TOKEN",
-        "BLOWFISH_BASE_PATH",
-        "BLOWFISH_API_KEY"
-      ],
       "outputs": ["dist/**"]
     },
     "build:extension:prod:firefox": {
       "dependsOn": ["//#build:packages"],
-      "env": [
-        "POSTHOG_AUTH_TOKEN",
-        "SIMPLE_LOCALIZE_API_KEY",
-        "SIMPLE_LOCALIZE_PROJECT_TOKEN",
-        "SENTRY_DSN",
-        "SENTRY_AUTH_TOKEN",
-        "BLOWFISH_BASE_PATH",
-        "BLOWFISH_API_KEY"
-      ],
       "outputs": ["dist/**"]
     }
   }


### PR DESCRIPTION
While we're waiting on https://github.com/polkadot-api/polkadot-api/pull/851 to make papi compatible with our monorepo *without* needing any hacks or workarounds, this PR fixes the existing workaround to also work in our docker-based review builds.

The existing workaround depends on `git` to revert the unwanted `pnpm-lock.yaml` changes which are made by `pnpm papi`.  
This PR introduces an alternative `pnpm papi:dockerbuildcompat` command which will instead make a copy of `pnpm-lock.yaml` before modification, then move the copy back over the modified file after papi has done its thing.