### PR TITLE
fix: ledger add account loading balance state

### DIFF
--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddLedger/AddLedgerSelectAccount.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddLedger/AddLedgerSelectAccount.tsx
@@ -10,7 +10,7 @@ import * as yup from "yup"
 import { LedgerEthDerivationPathType } from "@extension/core"
 import { notify, notifyUpdate } from "@talisman/components/Notifications"
 import { LedgerEthereumAccountPicker } from "@ui/domains/Account/LedgerEthereumAccountPicker"
-import { LedgerSubstrateAccountPicker } from "@ui/domains/Account/LedgerSubstrateLegacyAccountPicker"
+import { LedgerSubstrateLegacyAccountPicker } from "@ui/domains/Account/LedgerSubstrateLegacyAccountPicker"
 import { CHAIN_ID_TO_LEDGER_APP_NAME } from "@ui/hooks/ledger/common"
 import { useLedgerSubstrateAppByName } from "@ui/hooks/ledger/useLedgerSubstrateApp"
 
@@ -180,7 +180,7 @@ export const AddLedgerSelectAccount = () => {
         {data.type === "sr25519" && (
           <>
             {data.substrateAppType === AddSubstrateLedgerAppType.Legacy && (
-              <LedgerSubstrateAccountPicker
+              <LedgerSubstrateLegacyAccountPicker
                 chainId={data.chainId as string}
                 onChange={handleAccountsChange}
               />

--- a/apps/extension/src/ui/domains/Account/LedgerSubstrateGenericAccountPicker.tsx
+++ b/apps/extension/src/ui/domains/Account/LedgerSubstrateGenericAccountPicker.tsx
@@ -21,7 +21,7 @@ import { LedgerAccountDefSubstrateGeneric } from "@ui/domains/Account/AccountAdd
 import { getPolkadotLedgerDerivationPath } from "@ui/hooks/ledger/common"
 import { useLedgerSubstrateGeneric } from "@ui/hooks/ledger/useLedgerSubstrateGeneric"
 import { AccountImportDef, useAccountImportBalances } from "@ui/hooks/useAccountImportBalances"
-import { useAccounts } from "@ui/state"
+import { useAccounts, useChains } from "@ui/state"
 
 import { Fiat } from "../Asset/Fiat"
 import { AccountIcon } from "./AccountIcon"
@@ -44,6 +44,9 @@ const useLedgerSubstrateGenericAccounts = (
   >([...Array(itemsPerPage)])
   const [isBusy, setIsBusy] = useState(false)
   const [error, setError] = useState<string>()
+  const chains = useChains({ activeOnly: true, includeTestnets: false })
+
+  const withBalances = useMemo(() => chains.some((chain) => chain.hasCheckMetadataHash), [chains])
 
   const { isReady, ledger, getAddress, ...connectionStatus } = useLedgerSubstrateGeneric({ app })
 
@@ -89,16 +92,16 @@ const useLedgerSubstrateGenericAccounts = (
   }, [app, isReady, itemsPerPage, ledger, getAddress, pageIndex, t])
 
   // start fetching balances only once all accounts are loaded to prevent recreating subscription 5 times
-  const accountImportDefs = useMemo<AccountImportDef[]>(
+  const balanceDefs = useMemo<AccountImportDef[]>(
     () =>
-      ledgerAccounts.filter(Boolean).length === itemsPerPage
+      withBalances && ledgerAccounts.filter(Boolean).length === itemsPerPage
         ? ledgerAccounts
             .filter((acc): acc is LedgerSubstrateGenericAccount => !!acc)
             .map((acc) => ({ address: acc.address, type: "ed25519" }))
         : [],
-    [itemsPerPage, ledgerAccounts],
+    [itemsPerPage, ledgerAccounts, withBalances],
   )
-  const balances = useAccountImportBalances(accountImportDefs)
+  const balances = useAccountImportBalances(balanceDefs)
 
   const accounts: (LedgerSubstrateGenericAccount | null)[] = useMemo(
     () =>
@@ -120,10 +123,11 @@ const useLedgerSubstrateGenericAccounts = (
           connected: !!existingAccount,
           selected: selectedAccounts.some((sa) => sa.address === acc.address),
           balances: accountBalances,
-          isBalanceLoading: balances.status === "initialising" || balances.status === "cached",
+          isBalanceLoading:
+            withBalances && (balances.status === "initialising" || balances.status === "cached"),
         }
       }),
-    [ledgerAccounts, walletAccounts, balances, selectedAccounts],
+    [ledgerAccounts, walletAccounts, balances, selectedAccounts, withBalances],
   )
 
   useEffect(() => {
@@ -137,6 +141,7 @@ const useLedgerSubstrateGenericAccounts = (
     isBusy,
     error,
     connectionStatus,
+    withBalances,
   }
 }
 
@@ -155,12 +160,8 @@ const LedgerSubstrateGenericAccountPickerDefault: FC<LedgerSubstrateGenericAccou
   const itemsPerPage = 5
   const [pageIndex, setPageIndex] = useState(0)
   const [selectedAccounts, setSelectedAccounts] = useState<LedgerAccountDefSubstrateGeneric[]>([])
-  const { accounts, error, isBusy, connectionStatus } = useLedgerSubstrateGenericAccounts(
-    selectedAccounts,
-    pageIndex,
-    itemsPerPage,
-    app,
-  )
+  const { accounts, error, isBusy, connectionStatus, withBalances } =
+    useLedgerSubstrateGenericAccounts(selectedAccounts, pageIndex, itemsPerPage, app)
 
   // if ledger was busy when changing tabs, connection needs to be refreshed once on mount
   const refInitialized = useRef(false)
@@ -206,7 +207,7 @@ const LedgerSubstrateGenericAccountPickerDefault: FC<LedgerSubstrateGenericAccou
       </div>
       <DerivedAccountPickerBase
         accounts={accounts}
-        withBalances
+        withBalances={withBalances}
         disablePaging={isBusy}
         canPageBack={pageIndex > 0}
         onAccountClick={handleToggleAccount}

--- a/apps/extension/src/ui/domains/Account/LedgerSubstrateGenericAccountPicker.tsx
+++ b/apps/extension/src/ui/domains/Account/LedgerSubstrateGenericAccountPicker.tsx
@@ -45,7 +45,6 @@ const useLedgerSubstrateGenericAccounts = (
   const [isBusy, setIsBusy] = useState(false)
   const [error, setError] = useState<string>()
   const chains = useChains({ activeOnly: true, includeTestnets: false })
-
   const withBalances = useMemo(() => chains.some((chain) => chain.hasCheckMetadataHash), [chains])
 
   const { isReady, ledger, getAddress, ...connectionStatus } = useLedgerSubstrateGeneric({ app })


### PR DESCRIPTION
fixed inconsistant "flashing" balances in ledger add account flow
this will still happen though if mini metadatas update while the user is on that screen, as it restarts balance subs.