### PR TITLE
fix: tao staking release ceremony bugs

### DIFF
--- a/apps/extension/src/ui/domains/Staking/hooks/bittensor/useGetBittensorValidator.ts
+++ b/apps/extension/src/ui/domains/Staking/hooks/bittensor/useGetBittensorValidator.ts
@@ -5,10 +5,6 @@ const fetchBittensorValidator = async (
   hotkey: string | number | null | undefined,
 ): Promise<BittensorValidator> => {
   try {
-    if (!TAOSTATS_API_KEY) {
-      throw new Error("TAOSTATS_API_KEY is not set. Cannot make API request.")
-    }
-
     if (!hotkey) {
       throw new Error("No hotkey provided")
     }

--- a/apps/extension/src/ui/domains/Staking/hooks/nomPools/useDetaultNomPoolId.ts
+++ b/apps/extension/src/ui/domains/Staking/hooks/nomPools/useDetaultNomPoolId.ts
@@ -7,7 +7,7 @@ export const useDetaultNomPoolId = (chainId?: ChainId | null | undefined) => {
   const remoteConfig = useRemoteConfig()
 
   return useMemo(() => {
-    if (!chainId || chainId === "bittensor") return null
-    return remoteConfig.stakingPools?.[chainId]?.[0] ?? null
-  }, [chainId, remoteConfig.stakingPools])
+    if (!chainId) return null
+    return remoteConfig.nominationPools?.[chainId]?.[0] ?? null
+  }, [chainId, remoteConfig.nominationPools])
 }

--- a/apps/extension/src/ui/domains/Staking/hooks/nomPools/useDetaultNomPoolId.ts
+++ b/apps/extension/src/ui/domains/Staking/hooks/nomPools/useDetaultNomPoolId.ts
@@ -7,7 +7,7 @@ export const useDetaultNomPoolId = (chainId?: ChainId | null | undefined) => {
   const remoteConfig = useRemoteConfig()
 
   return useMemo(() => {
-    if (!chainId) return null
+    if (!chainId || chainId === "bittensor") return null
     return remoteConfig.stakingPools?.[chainId]?.[0] ?? null
   }, [chainId, remoteConfig.stakingPools])
 }

--- a/apps/extension/src/ui/domains/Staking/hooks/nomPools/useNomPoolStakingStatus.ts
+++ b/apps/extension/src/ui/domains/Staking/hooks/nomPools/useNomPoolStakingStatus.ts
@@ -95,7 +95,7 @@ export const useNomPoolStakingStatus = (tokenId: TokenId) => {
 
       return { accounts, poolId }
     },
-    enabled: !!sapi,
+    enabled: !!sapi && token?.chain?.id !== "bittensor",
   })
 }
 

--- a/apps/extension/src/ui/domains/Staking/hooks/nomPools/useNomPoolStakingStatus.ts
+++ b/apps/extension/src/ui/domains/Staking/hooks/nomPools/useNomPoolStakingStatus.ts
@@ -95,7 +95,7 @@ export const useNomPoolStakingStatus = (tokenId: TokenId) => {
 
       return { accounts, poolId }
     },
-    enabled: !!sapi && token?.chain?.id !== "bittensor",
+    enabled: !!sapi,
   })
 }
 


### PR DESCRIPTION
# Description

- Disable useNomPoolStatus query if chain id is bittensor
- Do no throw if `TAOSTATS_API_KEY` is missing. This key should be used in dev mode only and not affect prod