### PR TITLE
Disable selecting incorrect address in send funds recipient

### DIFF
--- a/apps/extension/src/ui/domains/SendFunds/SendFundsAccountsList.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsAccountsList.tsx
@@ -99,7 +99,7 @@ const AccountRow: FC<AccountRowProps> = ({
         genesisHash={account.genesisHash}
         className="!text-lg"
       />
-      <div className="flex grow items-center overflow-hidden">
+      <div className="flex grow items-center justify-between overflow-hidden">
         <div className="flex flex-col space-y-2">
           <div className="flex items-center gap-2">
             <div className="truncate">

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsRecipientPicker.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsRecipientPicker.tsx
@@ -290,8 +290,8 @@ export const SendFundsRecipientPicker = () => {
   )
 
   const handleSubmitSearch = useCallback(() => {
-    if (isValidAddressInput) set("to", search, true)
-  }, [isValidAddressInput, search, set])
+    if (isValidAddressInput && isValidSubstrateNetworkAddressInput) set("to", search, true)
+  }, [isValidAddressInput, isValidSubstrateNetworkAddressInput, search, set])
 
   return (
     <div className="flex h-full min-h-full w-full flex-col overflow-hidden">


### PR DESCRIPTION
- Prevents enter key selecting incorrectly formatted address in send funds recipient
- Fixes spacing issue on selected account display

Before:
<img width="411" alt="Screenshot 2024-12-06 at 11 48 51 AM" src="https://github.com/user-attachments/assets/5759e82c-d277-4f19-9282-8b59aa0484d6">

After:
<img width="403" alt="Screenshot 2024-12-06 at 11 48 34 AM" src="https://github.com/user-attachments/assets/d959b62c-cb4c-4bb1-874f-0f46dd979e6f">
