### PR TITLE
fix: quick fixes

### DIFF
--- a/apps/extension/src/ui/domains/Asset/Tokens.tsx
+++ b/apps/extension/src/ui/domains/Asset/Tokens.tsx
@@ -67,15 +67,14 @@ export const Tokens: FC<TokensProps> = ({
   const { refReveal, isRevealable, isRevealed, isHidden, effectiveNoCountUp } =
     useRevealableBalance(isBalance, noCountUp)
 
-  const tooltip = useMemo(
+  const tooltipAmount = useMemo(
     () =>
-      noTooltip
-        ? null
-        : `${formatDecimals(amount, decimals ?? MAX_DECIMALS_FORMAT, { notation: "standard" })} ${
-            symbol ?? ""
-          }`.trim(),
-    [amount, decimals, noTooltip, symbol],
+      `${formatDecimals(amount, decimals ?? MAX_DECIMALS_FORMAT, { notation: "standard" })} ${
+        symbol ?? ""
+      }`.trim(),
+    [amount, decimals, symbol],
   )
+  const tooltip = useMemo(() => (noTooltip ? null : tooltipAmount), [noTooltip, tooltipAmount])
 
   const render = amount !== null && amount !== undefined
 
@@ -92,7 +91,7 @@ export const Tokens: FC<TokensProps> = ({
       {render && (
         <Tooltip placement="bottom-end">
           <TooltipTrigger asChild>
-            <span>
+            <span data-amount={tooltipAmount}>
               <DisplayValue
                 amount={isHidden ? 0 : amount}
                 symbol={symbol}

--- a/apps/extension/src/ui/hooks/useNetworkInfo.ts
+++ b/apps/extension/src/ui/hooks/useNetworkInfo.ts
@@ -11,25 +11,23 @@ export type NetworkInfoProps = {
 }
 
 export const getNetworkInfo = (t: TFunction, { chain, evmNetwork, relay }: NetworkInfoProps) => {
-  if (evmNetwork)
-    return {
-      label: evmNetwork.name,
-      type: evmNetwork.isTestnet ? t("EVM Testnet") : t("EVM Blockchain"),
-    }
+  if (evmNetwork) {
+    const label = evmNetwork.name
+    return { label, type: evmNetwork.isTestnet ? t("EVM Testnet") : t("EVM Blockchain") }
+  }
 
   if (chain) {
-    if (chain.isTestnet) return { label: chain.name, type: t("Testnet") }
-    if (chain.paraId)
-      return {
-        label: chain.name,
-        type: relay?.chainName
-          ? t("{{name}} Parachain", { name: relay?.chainName })
-          : t("Parachain"),
+    const label = chain.name
+    const type = (() => {
+      if (chain.isTestnet) return t("Testnet")
+      if (chain.paraId) {
+        if (relay?.name) return t("{{name}} Parachain", { name: relay?.name })
+        return t("Parachain")
       }
-    return {
-      label: chain.name,
-      type: (chain.parathreads || []).length > 0 ? t("Relay Chain") : t("Blockchain"),
-    }
+      return (chain.parathreads || []).length > 0 ? t("Relay Chain") : t("Blockchain")
+    })()
+
+    return { label, type }
   }
 
   return { label: "", type: "" }


### PR DESCRIPTION
1. Adds a `data-amount` attribute for easier dev access to the exact token balance

<div align="center">

<img width="222" alt="Screenshot 2024-12-09 at 13 38 16" src="https://github.com/user-attachments/assets/cd075a23-6f89-4ef9-b168-d6c8658b062e">

</div>

---

2. Fixes the network infos rows to use the relay chain name (which we set) instead of the chainName (which is queried from the chain, and can be undesirable)

<div align="center">

| before | after |
| - | - |
| <img width="308" src="https://github.com/user-attachments/assets/648ac407-e36e-480e-8afd-78270901c488"> | <img width="278" src="https://github.com/user-attachments/assets/6ce8d048-2c1d-4001-82b1-cf84c3d80eeb"> |

</div>