### PR TITLE
feat: portfolio header adjustments

### DIFF
--- a/apps/extension/src/ui/apps/popup/components/TotalFiatBalance.tsx
+++ b/apps/extension/src/ui/apps/popup/components/TotalFiatBalance.tsx
@@ -204,6 +204,8 @@ const TopActions = ({ disabled }: { disabled?: boolean }) => {
           label: t("Swap"),
           icon: RepeatIcon,
           onClick: () => handleSwapClick(),
+          disabled: disableActions,
+          disabledReason,
         },
         canBuy
           ? {

--- a/apps/extension/src/ui/domains/Portfolio/DashboardPortfolioHeader.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/DashboardPortfolioHeader.tsx
@@ -285,6 +285,8 @@ const TopActions: FC = () => {
           label: t("Swap"),
           icon: RepeatIcon,
           onClick: () => window.open(TALISMAN_WEB_APP_SWAP_URL, "_blank"),
+          disabled: disableActions,
+          disabledReason,
         },
         canBuy
           ? {

--- a/apps/extension/src/ui/domains/Portfolio/DashboardPortfolioHeader.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/DashboardPortfolioHeader.tsx
@@ -271,14 +271,13 @@ const TopActions: FC = () => {
         {
           analyticsName: "Goto",
           analyticsAction: "open receive",
-          label: t("Receive"),
+          label: !!selectedAccount && !isOwnedAccount(selectedAccount) ? t("Copy") : t("Receive"),
           icon: ArrowDownIcon,
           onClick: () =>
             openCopyAddressModal({
               address: selectedAddress,
             }),
-          disabled: disableActions,
-          disabledReason,
+          disabled: !selectedAccounts.length, // always allow, as long as there is at least one account
         },
         {
           analyticsName: "Goto",
@@ -299,7 +298,17 @@ const TopActions: FC = () => {
             }
           : null,
       ].filter(Boolean) as Array<ActionProps>,
-    [canBuy, disableActions, disabledReason, selectedAddress, openCopyAddressModal, symbol, t],
+    [
+      t,
+      disableActions,
+      disabledReason,
+      selectedAccount,
+      selectedAccounts.length,
+      canBuy,
+      selectedAddress,
+      symbol,
+      openCopyAddressModal,
+    ],
   )
 
   return (


### PR DESCRIPTION
- Disable swap button for watched accounts
- Receive button labelled as “Copy” if current account is a watched account + enable it