### PR TITLE
fix: tx decoding - display non-ascii values as hex

### DIFF
--- a/apps/extension/src/ui/domains/Sign/Substrate/decode/SubSignDecodedCallContent.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/decode/SubSignDecodedCallContent.tsx
@@ -1,5 +1,5 @@
 import { LoaderIcon } from "@talismn/icons"
-import { classNames, encodeAnyAddress } from "@talismn/util"
+import { classNames, encodeAnyAddress, isAscii } from "@talismn/util"
 import DOMPurify from "dompurify"
 import { SignerPayloadJSON } from "extension-core"
 import { log } from "extension-shared"
@@ -129,8 +129,10 @@ const formatArgs = (args: unknown): unknown => {
   if (typeof args === "bigint") return args.toString() + "n"
   if (Array.isArray(args)) return args.map(formatArgs)
 
-  // TODO fallback to asHex if any weird characters are present
-  if (args instanceof Binary) return args.asText()
+  if (args instanceof Binary) {
+    const text = args.asText()
+    return isAscii(text) ? text : args.asHex()
+  }
 
   if (typeof args === "object") {
     // workaround for AccountId32 - asText() returns glyphs so we need to decode it manually


### PR DESCRIPTION
fixes a TODO that i forgot to process when implementing advanced tx decoding : 
when displaying the payload as json/yaml, we dont know what binary objects contain.
if the binary.toText() doesnt return ascii text, it will now display the hex output instead.

before : 
![Screenshot 2024-12-17 at 2 14 21 PM](https://github.com/user-attachments/assets/79a9a0c0-d2bb-42a6-946c-a391c3ccc035)

after : 
![Screenshot 2024-12-17 at 2 13 53 PM](https://github.com/user-attachments/assets/713ea831-5b81-4791-a51d-1cf0a36f99d6)
