### PR TITLE
fix: use tokenId instead of symbol for send funds lookup where possible

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardAssetDetails.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardAssetDetails.tsx
@@ -24,7 +24,7 @@ import { StaleBalancesIcon } from "../StaleBalancesIcon"
 import { usePortfolioNavigation } from "../usePortfolioNavigation"
 import { CopyAddressButton } from "./CopyAddressIconButton"
 import { PortfolioAccount } from "./PortfolioAccount"
-import { SendFundsButton } from "./SendFundsIconButton"
+import { SendFundsTokenButton } from "./SendFundsTokenIconButton"
 import { TokenContextMenu } from "./TokenContextMenu"
 import { useAssetDetails } from "./useAssetDetails"
 import { BalanceDetailRow, useTokenBalances } from "./useTokenBalances"
@@ -102,7 +102,7 @@ const TokenBalances: FC<{ tokenId: TokenId; balances: Balances }> = ({ tokenId, 
               <span className="mr-2">{chainOrNetwork.name}</span>
               <CopyAddressButton networkId={chainOrNetwork.id} />
               <Suspense fallback={<SuspenseTracker name="ChainTokenBalances.Buttons" />}>
-                <SendFundsButton tokenId={token.id} />
+                <SendFundsTokenButton tokenId={token.id} />
                 {tokenId && (
                   <TokenContextMenu
                     tokenId={tokenId}

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardAssetDetails.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardAssetDetails.tsx
@@ -102,7 +102,7 @@ const TokenBalances: FC<{ tokenId: TokenId; balances: Balances }> = ({ tokenId, 
               <span className="mr-2">{chainOrNetwork.name}</span>
               <CopyAddressButton networkId={chainOrNetwork.id} />
               <Suspense fallback={<SuspenseTracker name="ChainTokenBalances.Buttons" />}>
-                <SendFundsButton symbol={token.symbol} networkId={chainOrNetwork.id} />
+                <SendFundsButton tokenId={token.id} networkId={chainOrNetwork.id} />
                 {tokenId && (
                   <TokenContextMenu
                     tokenId={tokenId}

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardAssetDetails.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardAssetDetails.tsx
@@ -102,7 +102,7 @@ const TokenBalances: FC<{ tokenId: TokenId; balances: Balances }> = ({ tokenId, 
               <span className="mr-2">{chainOrNetwork.name}</span>
               <CopyAddressButton networkId={chainOrNetwork.id} />
               <Suspense fallback={<SuspenseTracker name="ChainTokenBalances.Buttons" />}>
-                <SendFundsButton tokenId={token.id} networkId={chainOrNetwork.id} />
+                <SendFundsButton tokenId={token.id} />
                 {tokenId && (
                   <TokenContextMenu
                     tokenId={tokenId}

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupAssetDetails.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupAssetDetails.tsx
@@ -27,7 +27,7 @@ import { useFeatureFlag, useSelectedCurrency } from "@ui/state"
 import { StaleBalancesIcon } from "../StaleBalancesIcon"
 import { CopyAddressButton } from "./CopyAddressIconButton"
 import { PortfolioAccount } from "./PortfolioAccount"
-import { SendFundsButton } from "./SendFundsIconButton"
+import { SendFundsTokenButton } from "./SendFundsTokenIconButton"
 import { TokenContextMenu } from "./TokenContextMenu"
 import { useAssetDetails } from "./useAssetDetails"
 import { BalanceDetailRow, useTokenBalances } from "./useTokenBalances"
@@ -62,7 +62,7 @@ const TokenBalances: FC<{ tokenId: TokenId; balances: Balances }> = ({ tokenId, 
               <span className="mr-2 truncate">{chainOrNetwork.name}</span>
               <CopyAddressButton networkId={chainOrNetwork.id} />
               <Suspense fallback={<SuspenseTracker name="ChainTokenBalances.Buttons" />}>
-                <SendFundsButton tokenId={token.id} shouldClose />
+                <SendFundsTokenButton tokenId={token.id} shouldClose />
               </Suspense>
             </div>
           </div>

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupAssetDetails.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupAssetDetails.tsx
@@ -62,7 +62,7 @@ const TokenBalances: FC<{ tokenId: TokenId; balances: Balances }> = ({ tokenId, 
               <span className="mr-2 truncate">{chainOrNetwork.name}</span>
               <CopyAddressButton networkId={chainOrNetwork.id} />
               <Suspense fallback={<SuspenseTracker name="ChainTokenBalances.Buttons" />}>
-                <SendFundsButton tokenId={token.id} networkId={chainOrNetwork.id} shouldClose />
+                <SendFundsButton tokenId={token.id} shouldClose />
               </Suspense>
             </div>
           </div>

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupAssetDetails.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupAssetDetails.tsx
@@ -62,7 +62,7 @@ const TokenBalances: FC<{ tokenId: TokenId; balances: Balances }> = ({ tokenId, 
               <span className="mr-2 truncate">{chainOrNetwork.name}</span>
               <CopyAddressButton networkId={chainOrNetwork.id} />
               <Suspense fallback={<SuspenseTracker name="ChainTokenBalances.Buttons" />}>
-                <SendFundsButton symbol={token.symbol} networkId={chainOrNetwork.id} shouldClose />
+                <SendFundsButton tokenId={token.id} networkId={chainOrNetwork.id} shouldClose />
               </Suspense>
             </div>
           </div>

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/SendFundsIconButton.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/SendFundsIconButton.tsx
@@ -1,42 +1,25 @@
-import { ChainId, EvmNetworkId } from "@talismn/chaindata-provider"
+import { TokenId } from "@talismn/chaindata-provider"
 import { SendIcon } from "@talismn/icons"
 import { useCallback } from "react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
 
 import { useSendFundsPopup } from "@ui/hooks/useSendFundsPopup"
-import { useSetting, useTokens } from "@ui/state"
+import { useSetting, useTokensMap } from "@ui/state"
 import { isTransferableToken } from "@ui/util/isTransferableToken"
 
 import { usePortfolioNavigation } from "../usePortfolioNavigation"
 
 export const SendFundsButton = ({
-  networkId,
+  tokenId,
   shouldClose,
-  ...tokenLookup
 }: {
-  networkId: ChainId | EvmNetworkId
+  tokenId: TokenId
   shouldClose?: boolean
-} & ({ tokenId: string } | { symbol: string })) => {
-  const tokenId = "tokenId" in tokenLookup ? tokenLookup.tokenId : undefined
-  const symbol = "symbol" in tokenLookup ? tokenLookup.symbol : undefined
-
+}) => {
   const { selectedAccount } = usePortfolioNavigation()
   const [includeTestnets] = useSetting("useTestnets")
-  const tokens = useTokens({ activeOnly: true, includeTestnets })
-
-  const token = tokens?.find(
-    typeof tokenId === "string"
-      ? // search by tokenId
-        (t) =>
-          t.id === tokenId &&
-          isTransferableToken(t) &&
-          (("evmNetwork" in t && t.evmNetwork?.id === networkId) || t.chain?.id === networkId)
-      : // search by token symbol
-        (t) =>
-          t.symbol === symbol &&
-          isTransferableToken(t) &&
-          (("evmNetwork" in t && t.evmNetwork?.id === networkId) || t.chain?.id === networkId),
-  )
+  const tokensMap = useTokensMap({ activeOnly: true, includeTestnets })
+  const token = isTransferableToken(tokensMap[tokenId]) ? tokensMap[tokenId] : undefined
 
   const { canSendFunds, cannotSendFundsReason, openSendFundsPopup } = useSendFundsPopup(
     selectedAccount,

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/SendFundsIconButton.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/SendFundsIconButton.tsx
@@ -10,23 +10,32 @@ import { isTransferableToken } from "@ui/util/isTransferableToken"
 import { usePortfolioNavigation } from "../usePortfolioNavigation"
 
 export const SendFundsButton = ({
-  symbol,
   networkId,
   shouldClose,
+  ...tokenLookup
 }: {
-  symbol: string
   networkId: ChainId | EvmNetworkId
   shouldClose?: boolean
-}) => {
+} & ({ tokenId: string } | { symbol: string })) => {
+  const tokenId = "tokenId" in tokenLookup ? tokenLookup.tokenId : undefined
+  const symbol = "symbol" in tokenLookup ? tokenLookup.symbol : undefined
+
   const { selectedAccount } = usePortfolioNavigation()
   const [includeTestnets] = useSetting("useTestnets")
   const tokens = useTokens({ activeOnly: true, includeTestnets })
 
   const token = tokens?.find(
-    (t) =>
-      t.symbol === symbol &&
-      isTransferableToken(t) &&
-      (("evmNetwork" in t && t.evmNetwork?.id === networkId) || t.chain?.id === networkId),
+    typeof tokenId === "string"
+      ? // search by tokenId
+        (t) =>
+          t.id === tokenId &&
+          isTransferableToken(t) &&
+          (("evmNetwork" in t && t.evmNetwork?.id === networkId) || t.chain?.id === networkId)
+      : // search by token symbol
+        (t) =>
+          t.symbol === symbol &&
+          isTransferableToken(t) &&
+          (("evmNetwork" in t && t.evmNetwork?.id === networkId) || t.chain?.id === networkId),
   )
 
   const { canSendFunds, cannotSendFundsReason, openSendFundsPopup } = useSendFundsPopup(

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/SendFundsTokenIconButton.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/SendFundsTokenIconButton.tsx
@@ -9,7 +9,7 @@ import { isTransferableToken } from "@ui/util/isTransferableToken"
 
 import { usePortfolioNavigation } from "../usePortfolioNavigation"
 
-export const SendFundsButton = ({
+export const SendFundsTokenButton = ({
   tokenId,
   shouldClose,
 }: {


### PR DESCRIPTION
Prevents a bug when the same symbol is used by multiple tokens on one network.

e.g. `USDC` vs `USDC.e` vs `whUSDC` (which is also just `USDC` in the contract) on Polygon.