### PR TITLE
fix: yeet redundant error boundaries

### DIFF
--- a/apps/extension/src/ui/apps/popup/Layout/PopupLayout.tsx
+++ b/apps/extension/src/ui/apps/popup/Layout/PopupLayout.tsx
@@ -11,7 +11,6 @@ import {
 import { useLocation } from "react-router-dom"
 
 import { ScrollContainer } from "@talisman/components/ScrollContainer"
-import { TalismanErrorBoundary } from "@talisman/components/TalismanErrorBoundary"
 import { HandMonoLogo } from "@talisman/theme/logos"
 import { api } from "@ui/api"
 
@@ -89,7 +88,7 @@ export const PopupLayout: FC<ContainerProps> = ({ className, children, ...props 
       {...props}
       className={classNames("relative flex h-full w-full flex-col overflow-hidden", className)}
     >
-      <TalismanErrorBoundary>{children}</TalismanErrorBoundary>
+      {children}
     </main>
   )
 }

--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/index.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/index.tsx
@@ -4,7 +4,6 @@ import { Route, Routes, useLocation } from "react-router-dom"
 
 import { ScrollContainer } from "@talisman/components/ScrollContainer"
 import { SuspenseTracker } from "@talisman/components/SuspenseTracker"
-import { TalismanErrorBoundary } from "@talisman/components/TalismanErrorBoundary"
 import { PortfolioContainer } from "@ui/domains/Portfolio/PortfolioContainer"
 import BraveWarningPopupBanner from "@ui/domains/Settings/BraveWarning/BraveWarningPopupBanner"
 import MigratePasswordAlert from "@ui/domains/Settings/MigratePasswordAlert"
@@ -51,15 +50,13 @@ const Content: FC<PropsWithChildren> = ({ children }) => {
 export const Portfolio = () => (
   <PortfolioContainer renderWhileLoading>
     <div id="main" className="relative size-full overflow-hidden">
-      <TalismanErrorBoundary>
-        <Content>
-          <div className="flex size-full flex-col gap-4 py-8">
-            <PortfolioRoutes />
-            <BottomNav />
-          </div>
-        </Content>
-        <NavigationDrawer />
-      </TalismanErrorBoundary>
+      <Content>
+        <div className="flex size-full flex-col gap-4 py-8">
+          <PortfolioRoutes />
+          <BottomNav />
+        </div>
+      </Content>
+      <NavigationDrawer />
     </div>
   </PortfolioContainer>
 )


### PR DESCRIPTION
Following on from https://github.com/TalismanSociety/talisman/pull/1774, this PR yeets the two extra uses of `<TalismanErrorBoundary>`, which we don't think we need anymore.