### PR TITLE
fix: errors in balance pool

### DIFF
--- a/.changeset/fuzzy-penguins-promise.md
+++ b/.changeset/fuzzy-penguins-promise.md
@@ -1,0 +1,5 @@
+---
+"@talismn/chaindata-provider": patch
+---
+
+fix: unawaited promise

--- a/packages/chaindata-provider/src/util.ts
+++ b/packages/chaindata-provider/src/util.ts
@@ -106,16 +106,19 @@ export const customTokensFilter = (tokens: Token[]) =>
 type ObservableReturnType<O> = O extends Observable<infer T> ? T : O
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const wrapObservableWithGetter = async <O extends Observable<any>>(
+export const wrapObservableWithGetter = <O extends Observable<any>>(
   errorReason: string,
   observable: O,
 ): Promise<ObservableReturnType<O>> => {
-  return await withErrorReason(errorReason, () => firstValueFrom(observable))
+  return withErrorReason(errorReason, () => firstValueFrom(observable))
 }
 
-export const withErrorReason = <T>(reason: string, task: () => T): T => {
+export const withErrorReason = async <T>(
+  reason: string,
+  task: () => Promise<T> | T,
+): Promise<T> => {
   try {
-    return task()
+    return await task()
   } catch (cause) {
     throw new Error(reason, { cause })
   }

--- a/packages/chaindata-provider/src/util.ts
+++ b/packages/chaindata-provider/src/util.ts
@@ -106,11 +106,11 @@ export const customTokensFilter = (tokens: Token[]) =>
 type ObservableReturnType<O> = O extends Observable<infer T> ? T : O
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const wrapObservableWithGetter = <O extends Observable<any>>(
+export const wrapObservableWithGetter = async <O extends Observable<any>>(
   errorReason: string,
   observable: O,
 ): Promise<ObservableReturnType<O>> => {
-  return withErrorReason(errorReason, () => firstValueFrom(observable))
+  return await withErrorReason(errorReason, () => firstValueFrom(observable))
 }
 
 export const withErrorReason = async <T>(

--- a/packages/extension-core/src/domains/balances/pool.ts
+++ b/packages/extension-core/src/domains/balances/pool.ts
@@ -76,7 +76,7 @@ const getActiveStuff = <T extends { isTestnet?: boolean }, A extends Record<stri
   return combineLatest([dataObservable, activeStoreObservable, settingsStore.observable]).pipe(
     map(([data, active, { useTestnets }]) => {
       return data
-        .filter((item) => isActiveFn(item, active))
+        .filter((item) => !!item && isActiveFn(item, active))
         .filter((item) => (useTestnets ? true : !item.isTestnet))
     }),
   )


### PR DESCRIPTION
Fixes a bunch of sentry errors about isActiveToken/isActiveEvmNetwork/isActiveChain being sometimes called from pool.ts with a null argument, that i can't reproduce on my computer. 

Also includes a fix to an unawaited promise in chaindata providers, that could be tied to the above problem