### PR TITLE
fix: normalize failed to update metadata error message

### DIFF
--- a/packages/extension-core/src/util/getMetadataDef.ts
+++ b/packages/extension-core/src/util/getMetadataDef.ts
@@ -132,11 +132,9 @@ const getMetadataDefInner = async (
     return CACHE_RESULTS.get(cacheKey)
   } catch (cause) {
     if ((cause as Error).message !== "RPC connect timeout reached") {
-      // not a useful error, do not log to sentry
-      const message = `Failed to update metadata for chain ${genesisHash}`
-      const error = new Error(message, { cause })
+      const error = new Error("Failed to update metadata", { cause })
       log.error(error)
-      sentry.captureException(error, { extra: { genesisHash } })
+      sentry.captureException(error, { extra: { genesisHash, chainId: chain?.id ?? "UNKNOWN" } })
     }
     metadataUpdatesStore.set(genesisHash, false)
   }


### PR DESCRIPTION
simplifies the error message for when backend can't update metadata, so that:
- all errors have the same message and will be grouped together in sentry
- the chainId of target chain, if known, is added as extra property in the sentry payload