### PR TITLE
chore: add rootnet uid to add/remove stake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           # SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           # SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: ./apps/extension/dist/chrome/talisman_extension_ci_${{ steps.vars.outputs.sha_short }}_chrome.zip
@@ -215,7 +215,7 @@ jobs:
             ${{ steps.without-changesets.outputs.WITHOUT_CHANGESETS }}
             ```
 
-            Please add a changeset for these packages.  
+            Please add a changeset for these packages.
             You can do so by running `pnpm changeset` in your local development environment.
 
             Not sure what this means? [Click here to learn what changesets are](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).

--- a/apps/extension/src/ui/domains/Staking/Bittensor/constants.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/constants.ts
@@ -1,0 +1,1 @@
+export const ROOT_NETUID = 0

--- a/apps/extension/src/ui/domains/Staking/helpers.ts
+++ b/apps/extension/src/ui/domains/Staking/helpers.ts
@@ -3,6 +3,8 @@ import { range } from "lodash"
 import { Binary } from "polkadot-api"
 import { ScaleApi } from "sapi"
 
+import { ROOT_NETUID } from "./Bittensor/constants"
+
 export const getStakingErasPerYear = (sapi: ScaleApi) => {
   const MS_PER_YEAR = 1000n * 60n * 60n * 24n * 365n
   const eraDuration = getStakingEraDurationMs(sapi)
@@ -83,6 +85,7 @@ export const getBittensorStakingPayload = async ({
       calls: [
         sapi.getDecodedCall("SubtensorModule", "add_stake", {
           hotkey: poolId,
+          netuid: ROOT_NETUID,
           amount_staked: amount,
         }),
         sapi.getDecodedCall("System", "remark_with_event", {

--- a/apps/extension/src/ui/domains/Staking/hooks/bittensor/useGetBittensorUnbondPayload.ts
+++ b/apps/extension/src/ui/domains/Staking/hooks/bittensor/useGetBittensorUnbondPayload.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query"
 import { ScaleApi } from "sapi"
 
+import { ROOT_NETUID } from "../../Bittensor/constants"
+
 type GetBittensorUnbondPayload = {
   sapi: ScaleApi | undefined | null
   isEnabled: boolean
@@ -25,6 +27,7 @@ export const useGetBittensorUnbondPayload = ({
         "remove_stake",
         {
           hotkey: hotkey,
+          netuid: ROOT_NETUID,
           amount_unstaked: plancks,
         },
         { address },


### PR DESCRIPTION
## Description

Added rootnet uid to Bittensor add/remove stake, this change is required to comply with upcoming subnet staking.

Passing a netuid does not throw when using papi and is ignored by their network.

The following tx was submited with netuid, though it is not included in the params: 
https://taostats.io/extrinsic/4865692-0010?network=finney