### PR TITLE
fix: don't throw error when currentEra is greater than 0, less than `maxErasToCheck`

### DIFF
--- a/apps/extension/src/ui/domains/Staking/helpers.ts
+++ b/apps/extension/src/ui/domains/Staking/helpers.ts
@@ -49,7 +49,7 @@ export const getStakingAPR = async (sapi: ScaleApi) => {
   if (!currentEra) throw new Error("Current era unavailable")
 
   const maxErasToCheck = Math.min(15, historyDepth)
-  const eras = range(currentEra - maxErasToCheck, currentEra - 1)
+  const eras = range(currentEra - maxErasToCheck, currentEra - 1).filter((era) => era >= 0)
 
   const [eraRewards, eraTotalStakes] = await Promise.all([
     Promise.all(


### PR DESCRIPTION
The code here would check e.g. eras `[-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5]` if `currentEra` is 6.

Attempting to make calls to the chain with an `era` parameter less than `0` will throw errors.

Now, we'll filter for negative values, making the list of eras to check just `[0, 1, 2, 3, 4, 5]` if `currentEra` is 6.