### PR TITLE
fix: add account type to `Unsupported account type` error

### DIFF
--- a/apps/extension/src/ui/domains/Transactions/SapiSendButton.tsx
+++ b/apps/extension/src/ui/domains/Transactions/SapiSendButton.tsx
@@ -163,7 +163,7 @@ export const SapiSendButton: FC<SapiSendButtonProps> = (props) => {
       case AccountType.Talisman:
         return "local"
       default:
-        throw new Error("Unsupported account type")
+        throw new Error(`Unsupported account type '${account?.origin}'`)
     }
   }, [account])
 


### PR DESCRIPTION
Some users are seeing our `Oops!` error screen when they attempt to stake on Analog.

The account type they're using to stake is raising the [`Unsupported account type`](<https://talisman.sentry.io/issues/6290021080/events/45c76602042e4aea8b49ca5d99c5f0e3/?project=4506748422389760&referrer=issue-list&statsPeriod=14d>) error.

This PR aims to tell us what the incorrect account type is, so that we can better understand the problem!