### PR TITLE
feat: reserved nompool staking balances

### DIFF
--- a/.changeset/smart-rivers-yell.md
+++ b/.changeset/smart-rivers-yell.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": minor
+---
+
+reserved nompool staking

--- a/apps/extension/src/ui/state/balances.ts
+++ b/apps/extension/src/ui/state/balances.ts
@@ -80,7 +80,8 @@ const allBalances$ = combineLatest([
       return false
     })
     return new Balances(validBalances, hydrate)
-  }, shareReplay(1)),
+  }),
+  shareReplay(1),
 )
 
 type BalanceQueryParams = {

--- a/packages/balances/src/modules/SubstrateNativeModule/util/buildQueries.ts
+++ b/packages/balances/src/modules/SubstrateNativeModule/util/buildQueries.ts
@@ -1,6 +1,7 @@
 import { Chain, Token } from "@talismn/chaindata-provider"
 import { Binary, decodeScale, encodeStateKey } from "@talismn/scale"
 import { BigMath, blake2Concat, decodeAnyAddress } from "@talismn/util"
+import { Enum } from "polkadot-api"
 import { Struct, u32, u128 } from "scale-ts"
 
 import log from "../../../log"
@@ -102,6 +103,7 @@ export async function buildQueries(
       let locksQueryLocks: Array<AmountWithLabel<string>> = []
       let freezesQueryLocks: Array<AmountWithLabel<string>> = []
       let unbondingQueryLocks: Array<AmountWithLabel<string>> = []
+      let holdsQueryLocks: Array<AmountWithLabel<string>> = []
 
       const baseQuery: RpcStateQuery<SubNativeBalance> | undefined = (() => {
         // For chains which are using metadata < v14
@@ -250,6 +252,53 @@ export async function buildQueries(
         return { chainId, stateKey, decodeResult }
       })()
 
+      const holdsQuery: RpcStateQuery<SubNativeBalance> | undefined = (() => {
+        const scaleCoder = chainStorageCoders.get(chainId)?.holds
+        const stateKey = encodeStateKey(
+          scaleCoder,
+          `Invalid address in ${chainId} holds query ${address}`,
+          address,
+        )
+        if (!stateKey) return
+
+        const decodeResult = (change: string | null) => {
+          /** NOTE: This type is only a hint for typescript, the chain can actually return whatever it wants to */
+          type DecodedType = Array<{
+            id?: Enum<{ DelegatedStaking: Enum<{ StakingDelegation: undefined }> }>
+            amount?: bigint
+          }>
+
+          const decoded = decodeScale<DecodedType>(
+            scaleCoder,
+            change,
+            `Failed to decode holds on chain ${chainId}`,
+          )
+
+          // at this time we re only interested in DelegatedStaking holds, to determine if nom pool staked amount is included in reserved or not
+          holdsQueryLocks =
+            decoded
+              ?.filter((hold) => hold.id?.type)
+              .map((hold) => ({
+                type: "locked",
+                source: "substrate-native-holds",
+                label: hold.id!.type,
+                // anount needs to be 0 or a row could appear in the UI, this entry is just for information
+                amount: "0",
+                meta: { amount: (hold?.amount ?? 0n).toString() },
+              })) ?? []
+
+          // values should be replaced entirely, not merged or appended
+          const nonHoldsValues = balanceJson.values.filter(
+            (v) => v.source !== "substrate-native-holds",
+          )
+          balanceJson.values = nonHoldsValues.concat(holdsQueryLocks)
+
+          return balanceJson
+        }
+
+        return { chainId, stateKey, decodeResult }
+      })()
+
       const freezesQuery: RpcStateQuery<SubNativeBalance> | undefined = (() => {
         const scaleCoder = chainStorageCoders.get(chainId)?.freezes
         const stateKey = encodeStateKey(
@@ -350,7 +399,7 @@ export async function buildQueries(
         return { chainId, stateKey, decodeResult }
       })()
 
-      const queries = [baseQuery, locksQuery, freezesQuery, unbondingQuery].filter(
+      const queries = [baseQuery, locksQuery, freezesQuery, holdsQuery, unbondingQuery].filter(
         (query): query is RpcStateQuery<SubNativeBalance> => Boolean(query),
       )
 

--- a/packages/balances/src/types/balances.ts
+++ b/packages/balances/src/types/balances.ts
@@ -516,10 +516,18 @@ export class Balance {
   get total() {
     const extra = this.getValue("extra") as FormattedAmount<ExtraAmount<string>, string>[]
 
+    // if there is a DelegatedStaking hold (new model: polkadot, kusama), nom pool staked amount is included in reserved
+    // if not (old model: vara, avail, cere), staked amount is not in the account and it needs to be added to the total
+    const nomPoolStakedPlancks = this.locks.some(
+      (lock) => lock.source === "substrate-native-holds" && lock.label === "DelegatedStaking",
+    )
+      ? 0n
+      : this.nompools.map(({ amount }) => amount.planck).reduce((a, b) => a + b, 0n)
+
     return this.#format(
       this.free.planck +
         this.reserved.planck +
-        this.nompools.map(({ amount }) => amount.planck).reduce((a, b) => a + b, 0n) +
+        nomPoolStakedPlancks +
         this.crowdloans.map(({ amount }) => amount.planck).reduce((a, b) => a + b, 0n) +
         this.subtensor.map(({ amount }) => amount.planck).reduce((a, b) => a + b, 0n) +
         includeInTotalExtraAmount(extra),
@@ -641,9 +649,18 @@ export class Balance {
     const baseUnavailable = this.#storage.useLegacyTransferableCalculation
       ? oldCalculation()
       : newCalculation()
+
+    // if there is a DelegatedStaking hold (new model: polkadot, kusama), nom pool staked amount is included in reserved
+    // if not (old model: vara, avail, cere), staked amount is not in the account and it needs to be added to the total
+    const nomPoolStakedPlancks = this.locks.some(
+      (lock) => lock.source === "substrate-native-holds" && lock.label === "DelegatedStaking",
+    )
+      ? 0n
+      : this.nompools.map(({ amount }) => amount.planck).reduce((a, b) => a + b, 0n)
+
     const otherUnavailable =
+      nomPoolStakedPlancks +
       this.crowdloans.reduce((total, each) => total + each.amount.planck, 0n) +
-      this.nompools.reduce((total, each) => total + each.amount.planck, 0n) +
       this.subtensor.reduce((total, each) => total + each.amount.planck, 0n)
     return this.#format(baseUnavailable + otherUnavailable)
   }


### PR DESCRIPTION
Fixes locked balances display after the polkadot-sdk runtime upgrade that keeps custody of tokens (as reserve) when staking via nomination pools