### PR TITLE
fix: incorrect `@talismn/util` readme

### DIFF
--- a/.changeset/modern-months-doubt.md
+++ b/.changeset/modern-months-doubt.md
@@ -1,0 +1,5 @@
+---
+"@talismn/util": patch
+---
+
+chore: updated readme

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -1,5 +1,3 @@
 # @talismn/util
 
 This library hosts non-UI code meant to be shared between Talisman projects
-
-It doesn't need to be published as npm package, therefore it is simply transpiled with tsc.


### PR DESCRIPTION
We actually do publish this one to npm, and we don't transpile it with tsc (we use preconstruct)