### PR TITLE
Fix/bittensor managed stake

### DIFF
--- a/.changeset/red-zebras-heal.md
+++ b/.changeset/red-zebras-heal.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": minor
+---
+
+fix getValueId coercing 0 to falsy when evaluating subtensor balance

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorTokenBalanceList.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorTokenBalanceList.tsx
@@ -50,7 +50,7 @@ export const BittensorTokenBalanceList = ({
   const {
     meta: {
       alphaToTaoRate,
-      dynamicInfo: { subnetIdentity: { subnetName } = {}, tokenSymbol } = {},
+      dynamicInfo: { subnetIdentity: { subnetName = subnet_name } = {}, tokenSymbol } = {},
     } = {},
   } = fistGroupStake
 
@@ -74,7 +74,7 @@ export const BittensorTokenBalanceList = ({
       }
     }, defaultSummary) ?? defaultSummary
 
-  const subnetListName = `${listKey} | ${subnetName || subnet_name} ${tokenSymbol || ""}`.trim()
+  const subnetListName = `${listKey} | ${subnetName} ${tokenSymbol || ""}`.trim()
   const chainName = isRootStake || isChainIfo ? chainOrNetwork.name || "" : subnetListName
 
   const rowSummary = isChainIfo ? summary : groupSummary

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorTokenBalanceList.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorTokenBalanceList.tsx
@@ -41,7 +41,11 @@ export const BittensorTokenBalanceList = ({
   const [fistGroupStake] = groupedStakesByNetuid ?? []
   const { chainOrNetwork, summary, token, detailRows, status, networkType } = tokenBalances
   const { subnetData, isError, isLoading, isFetchingNextPage } = combinedSubnetData
-  const { price_change_1_day, subnet_name } = subnetData[Number(listKey)] ?? {}
+  const {
+    price_change_1_day,
+    subnet_name,
+    symbol: subnetTokenSymbol,
+  } = subnetData[Number(listKey)] ?? {}
 
   // wait for data to load
   if (!chainOrNetwork || !summary || !token || balances.count === 0) return null
@@ -50,7 +54,10 @@ export const BittensorTokenBalanceList = ({
   const {
     meta: {
       alphaToTaoRate,
-      dynamicInfo: { subnetIdentity: { subnetName = subnet_name } = {}, tokenSymbol } = {},
+      dynamicInfo: {
+        subnetIdentity: { subnetName = subnet_name } = {},
+        tokenSymbol = subnetTokenSymbol,
+      } = {},
     } = {},
   } = fistGroupStake
 

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupTokenBalances/BittensorTokenBalanceList.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupTokenBalances/BittensorTokenBalanceList.tsx
@@ -38,7 +38,11 @@ export const BittensorTokenBalanceList = ({
   const [fistGroupStake] = groupedStakesByNetuid ?? []
   const { chainOrNetwork, token, detailRows, status, networkType } = tokenBalances
   const { subnetData, isError, isLoading, isFetchingNextPage } = combinedSubnetData
-  const { price_change_1_day, subnet_name } = subnetData[Number(listKey)] ?? {}
+  const {
+    price_change_1_day,
+    subnet_name,
+    symbol: subnetTokenSymbol,
+  } = subnetData[Number(listKey)] ?? {}
 
   // wait for data to load
   if (!chainOrNetwork || !token || balances.count === 0) return null
@@ -47,7 +51,10 @@ export const BittensorTokenBalanceList = ({
   const {
     meta: {
       alphaToTaoRate,
-      dynamicInfo: { subnetIdentity: { subnetName = subnet_name } = {}, tokenSymbol } = {},
+      dynamicInfo: {
+        subnetIdentity: { subnetName = subnet_name } = {},
+        tokenSymbol = subnetTokenSymbol,
+      } = {},
     } = {},
   } = fistGroupStake
 

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupTokenBalances/BittensorTokenBalanceList.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupTokenBalances/BittensorTokenBalanceList.tsx
@@ -38,7 +38,7 @@ export const BittensorTokenBalanceList = ({
   const [fistGroupStake] = groupedStakesByNetuid ?? []
   const { chainOrNetwork, token, detailRows, status, networkType } = tokenBalances
   const { subnetData, isError, isLoading, isFetchingNextPage } = combinedSubnetData
-  const { price_change_1_day } = subnetData[Number(listKey)] ?? {}
+  const { price_change_1_day, subnet_name } = subnetData[Number(listKey)] ?? {}
 
   // wait for data to load
   if (!chainOrNetwork || !token || balances.count === 0) return null
@@ -47,11 +47,11 @@ export const BittensorTokenBalanceList = ({
   const {
     meta: {
       alphaToTaoRate,
-      dynamicInfo: { subnetIdentity: { subnetName } = {}, tokenSymbol } = {},
+      dynamicInfo: { subnetIdentity: { subnetName = subnet_name } = {}, tokenSymbol } = {},
     } = {},
   } = fistGroupStake
 
-  const subnetListName = `${listKey} | ${subnetName || ""} ${tokenSymbol || ""}`.trim()
+  const subnetListName = `${listKey} | ${subnetName} ${tokenSymbol || ""}`.trim()
   const chainName = isRootStake || isChainIfo ? chainOrNetwork.name || "" : subnetListName
 
   const symbol = isRootStake ? token.symbol : tokenSymbol

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/useTokenBalances.ts
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/useTokenBalances.ts
@@ -188,7 +188,9 @@ const useEnhanceDetailRows = (detailRows: BalanceDetailRow[]) => {
         if (row.meta?.type === "subtensor-staking")
           return {
             ...row,
-            description: combinedValidatorsData?.find((v) => v?.poolId === row.meta.hotkey)?.name,
+            description:
+              combinedValidatorsData?.find((v) => v?.poolId === row.meta.hotkey)?.name ??
+              "Managed delegation",
             isLoading: isLoadingCombinedValidators,
           } as BalanceDetailRow
 

--- a/packages/balances/src/modules/SubstrateNativeModule/subscribeSubtensorStaking.ts
+++ b/packages/balances/src/modules/SubstrateNativeModule/subscribeSubtensorStaking.ts
@@ -12,6 +12,7 @@ import { AddressesByToken, SubscriptionCallback } from "../../types"
 import { findChainMeta, getUniqueChainIds } from "../util"
 import { SubNativeBalance, SubNativeToken } from "./types"
 import {
+  BITTENSOR_TESTNET_CHAIN_ID,
   calculateTaoFromDynamicInfo,
   DecodeResult_GetDynamicInfo,
   DecodeResult_GetStakeInfoForColdkey,
@@ -158,6 +159,7 @@ export async function subscribeSubtensorStaking(
         >
         const queryMethods: Array<QueryMethod> = [
           async () => {
+            if (chainId === BITTENSOR_TESTNET_CHAIN_ID) return []
             const method = "StakeInfoRuntimeApi_get_stake_info_for_coldkey"
             const params = EncodeParams_GetStakeInfoForColdkey(address)
             const response = await chainConnector.send(

--- a/packages/balances/src/modules/SubstrateNativeModule/util/subtensor.ts
+++ b/packages/balances/src/modules/SubstrateNativeModule/util/subtensor.ts
@@ -7,6 +7,7 @@ export const SUBTENSOR_MIN_STAKE_AMOUNT_PLANK = 1000000n
 const TAO_DECIMALS = 9n
 export const SCALE_FACTOR = 10n ** TAO_DECIMALS // Equivalent to 10e9 for precision
 export const ONE_ALPHA_TOKEN = SCALE_FACTOR
+export const BITTENSOR_TESTNET_CHAIN_ID = "bittensor-testnet"
 
 const BittensorAccountPrefix = 42
 const BittensorAccountId = AccountId(BittensorAccountPrefix)

--- a/packages/balances/src/types/balancetypes.ts
+++ b/packages/balances/src/types/balancetypes.ts
@@ -133,9 +133,9 @@ export const getValueId = (amount: AmountWithLabel<string>) => {
     if (amount.type === "nompool") return meta.poolId?.toString() ?? ""
     if (amount.type === "subtensor") {
       const { hotkey, netuid } = meta
-      if (hotkey && netuid) return `${hotkey.toString()}${netuid.toString()}`
-      return ""
+      if (hotkey && netuid !== undefined) return `${hotkey.toString()}${netuid.toString()}`
     }
+
     return ""
   }
 


### PR DESCRIPTION
# Description

Fix:

1. Fix displaying more than one rootnet staked position, `getValueId` mistakenly coercing rootnet netuid to 0 and not evaluating if statement correctly
2. Do not fetch staked positions for testnets
3. Defaults to "Managed delegation" label when not staked with any known subnets known to taostats api
4. Fix empty subnet name on popup, when decoding dynamic data default subnetName to taoStats data on popup
5. Fix default to taostats token symbol when failed to decode dynamic data

### 🧪 **How to test:**

1. Stake more than one position on rootnet, both should be displayed and their values added towards TAO total balance
2. Add the following watched account, it should not fetch its testnet staked balances: 5HiveMEoWPmQmBAb8v63bKPcFhgTGCmST1TVZNvPHSTKFLCv
3. Add the following watched account, it should display  "Managed delegation" for their Mentat minds staked positions: 5Co21odW75rPN1btp9FEPEnPd4t7WJoSCUcsyvTbHVVnLAHp
4. Connect Guardians account or stake with subnet 64, it's name & symbol should be visible on pop and dashboard view
5. Same as above