### PR TITLE
chore: bump version v2.7.2

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "private": true,
   "license": "GPL-3.0-or-later",
   "dependencies": {


### PR DESCRIPTION
i ran chore:generate-init-data but no there have been no chaindata changes!