### PR TITLE
fix: displays ledger error when checking address with a ledger legacy app

### DIFF
--- a/apps/extension/src/ui/hooks/ledger/useLedgerSubstrateLegacy.ts
+++ b/apps/extension/src/ui/hooks/ledger/useLedgerSubstrateLegacy.ts
@@ -198,7 +198,15 @@ const checkAppAndDevice = async (account: AccountLedgerPolkadot, ledger: Substra
   if (ledger.cla !== app.cla) throw getOpenLedgerAppError(app.name)
 
   const { accountIndex, change, addressOffset } = getAccountSpecs(account)
-  const { address } = await ledger.getAddress(accountIndex, change, addressOffset)
+  const { address, error_message, return_code } = await ledger.getAddress(
+    accountIndex,
+    change,
+    addressOffset,
+  )
+
+  if (return_code !== LEDGER_SUCCESS_CODE)
+    throw getCustomNativeLedgerError(error_message, return_code)
+
   if (!isAddressEqual(address, account.address))
     throw getTalismanLedgerError(
       t(


### PR DESCRIPTION
When signing with a legacy app, at the check address step, if an error is raised it will be displayed properly instead of considering the address is missing.
For example if the ledger is locked, it will now display "Please unlock your ledger" instead of "Unable to normalize address: undefined"