### PR TITLE
fix: genesisHash checks preventing balances to be fetched on PV root accounts

### DIFF
--- a/.changeset/brave-jobs-lay.md
+++ b/.changeset/brave-jobs-lay.md
@@ -1,0 +1,5 @@
+---
+"@talismn/keyring": patch
+---
+
+fix: genesisHash checks

--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddLedger/context.ts
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddLedger/context.ts
@@ -52,7 +52,10 @@ const useAddLedgerAccountProvider = ({ onSuccess }: { onSuccess: (address: strin
 
       if (data.substrateAppType === AddSubstrateLedgerAppType.Legacy)
         assert(
-          accounts.every((acc) => "genesisHash" in acc && acc.genesisHash === chain?.genesisHash),
+          accounts.every((acc) => {
+            const genesisHash = "genesisHash" in acc ? acc.genesisHash || undefined : undefined
+            return genesisHash && genesisHash === chain?.genesisHash
+          }),
           "Chain mismatch",
         )
 

--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddLedger/context.ts
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddLedger/context.ts
@@ -54,7 +54,7 @@ const useAddLedgerAccountProvider = ({ onSuccess }: { onSuccess: (address: strin
         assert(
           accounts.every((acc) => {
             const genesisHash = "genesisHash" in acc ? acc.genesisHash || undefined : undefined
-            return genesisHash && genesisHash === chain?.genesisHash
+            return !!genesisHash && genesisHash === chain?.genesisHash
           }),
           "Chain mismatch",
         )

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryNetworkPicker.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryNetworkPicker.tsx
@@ -21,7 +21,8 @@ import { IS_POPUP } from "@ui/util/constants"
 type Network = Chain | EvmNetwork
 
 const getNetworkId = (network: Network): string => {
-  return "genesisHash" in network && network.genesisHash ? network.genesisHash : network.id
+  const genesisHash = "genesisHash" in network ? network.genesisHash : undefined
+  return genesisHash || network.id
 }
 
 export const TxHistoryNetworkPicker: FC<{

--- a/apps/extension/src/ui/state/balances.ts
+++ b/apps/extension/src/ui/state/balances.ts
@@ -51,7 +51,7 @@ const rawBalances$ = new Observable<BalanceSubscriptionResponse>((subscriber) =>
   return () => unsubscribe()
 }).pipe(
   throttleTime(200, undefined, { leading: true, trailing: true }),
-  debugObservable("rawBalances$"),
+  debugObservable("rawBalances$", true),
   shareReplay(1),
 )
 

--- a/apps/extension/src/ui/state/balances.ts
+++ b/apps/extension/src/ui/state/balances.ts
@@ -51,7 +51,7 @@ const rawBalances$ = new Observable<BalanceSubscriptionResponse>((subscriber) =>
   return () => unsubscribe()
 }).pipe(
   throttleTime(200, undefined, { leading: true, trailing: true }),
-  debugObservable("rawBalances$", true),
+  debugObservable("rawBalances$"),
   shareReplay(1),
 )
 

--- a/packages/extension-core/src/domains/accounts/helpers.ts
+++ b/packages/extension-core/src/domains/accounts/helpers.ts
@@ -56,18 +56,21 @@ const getInjectedAccountType = (account: Account): InjectedAccount["type"] => {
 export const getPjsInjectedAccount = (
   account: Account,
   options = { includePortalOnlyInfo: false },
-): InjectedAccount | (InjectedAccount & { readonly: boolean; partOfPortfolio: boolean }) => ({
-  address: account.address,
-  name: account.name,
-  type: getInjectedAccountType(account),
-  ...("genesisHash" in account && account.genesisHash ? { genesisHash: account.genesisHash } : {}),
-  ...(options.includePortalOnlyInfo
-    ? {
-        readonly: account.type === "watch-only",
-        partOfPortfolio: account.type === "watch-only" && account.isPortfolio,
-      }
-    : {}),
-})
+): InjectedAccount | (InjectedAccount & { readonly: boolean; partOfPortfolio: boolean }) => {
+  const genesisHash = getAccountGenesisHash(account)
+  return {
+    address: account.address,
+    name: account.name,
+    type: getInjectedAccountType(account),
+    ...(genesisHash ? { genesisHash } : {}),
+    ...(options.includePortalOnlyInfo
+      ? {
+          readonly: account.type === "watch-only",
+          partOfPortfolio: account.type === "watch-only" && account.isPortfolio,
+        }
+      : {}),
+  }
+}
 
 export const filterAccountsByAddresses =
   (addresses: string[] = [], anyType = false) =>

--- a/packages/extension-core/src/domains/balances/pool.ts
+++ b/packages/extension-core/src/domains/balances/pool.ts
@@ -7,7 +7,7 @@ import {
   StoredBalanceJson,
 } from "@talismn/balances"
 import { Token } from "@talismn/chaindata-provider"
-import { Account, isAccountNotContact } from "@talismn/keyring"
+import { Account, getAccountGenesisHash, isAccountNotContact } from "@talismn/keyring"
 import { Deferred, encodeAnyAddress, isEthereumAddress } from "@talismn/util"
 import { firstThenDebounce } from "@talismn/util/src/firstThenDebounce"
 import { Dexie, liveQuery } from "dexie"
@@ -509,7 +509,8 @@ abstract class BalancePool {
   protected async setAccounts(accounts: Account[]) {
     const addresses = Object.fromEntries(
       accounts.map((account) => {
-        return [account.address, "genesisHash" in account ? [account.genesisHash!] : null]
+        const genesisHash = getAccountGenesisHash(account)
+        return [account.address, genesisHash ? [genesisHash!] : null]
       }),
     )
     this.addresses.next(addresses)

--- a/packages/keyring/src/types/account.ts
+++ b/packages/keyring/src/types/account.ts
@@ -48,7 +48,7 @@ export type AccountPolkadotVault = AccountBase & {
 
 export type AccountSignet = AccountBase & {
   type: "signet"
-  genesisHash: `0x${string}` // TODO check if this field is required
+  genesisHash: `0x${string}`
   url: string // usually https://signet.talisman.xyz or https://polkadotmultisig.com/
 }
 

--- a/packages/keyring/src/types/utils.ts
+++ b/packages/keyring/src/types/utils.ts
@@ -102,7 +102,7 @@ export const isAccountLedgerPolkadotLegacy = (
 
 export const getAccountGenesisHash = (account: Account | null | undefined) => {
   if (!account) return undefined
-  return "genesisHash" in account ? account.genesisHash : undefined
+  return "genesisHash" in account ? account.genesisHash || undefined : undefined
 }
 
 export const getAccountSignetUrl = (account: Account | null | undefined) => {


### PR DESCRIPTION
Solves several issues caused by inaccurate genesisHash checks:
The code assumed that if `"genesisHash" in account` then there was always a valid genesisHash in the property, althought it could be null.

Main issue was balances not being fetched on Polkadot Vault root accounts, as they have a null genesisHash.