### PR TITLE
chore: updated APY label for bittensor staking

### DIFF
--- a/apps/extension/src/ui/domains/Staking/Bond/BondForm.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bond/BondForm.tsx
@@ -421,7 +421,10 @@ export const BondForm = () => {
   const { t } = useTranslation()
   const { account, accountPicker, token, payload, setStep, poolId, bondType } = useBondWizard()
 
-  const bondRowLabel = bondType === "bittensor" ? t("Validator") : t("Pool")
+  const isBittensor = bondType === "bittensor"
+
+  const bondRowLabel = useMemo(() => (isBittensor ? t("Validator") : t("Pool")), [isBittensor, t])
+  const yeldRowLabel = useMemo(() => (isBittensor ? t("APY") : t("APR")), [isBittensor, t])
 
   return (
     <div className="text-body-secondary flex size-full flex-col gap-4">
@@ -460,11 +463,15 @@ export const BondForm = () => {
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="flex items-center gap-1 whitespace-nowrap leading-none">
-                  {t("APR")}
+                  {yeldRowLabel}
                   <InfoIcon />
                 </div>
               </TooltipTrigger>
-              <TooltipContent>{t("Estimated Annual Percentage Rate (APR)")}</TooltipContent>
+              <TooltipContent>
+                {isBittensor
+                  ? t("Estimated Annual Percentage Yield (APY)")
+                  : t("Estimated Annual Percentage Rate (APR)")}
+              </TooltipContent>
             </Tooltip>
           </div>
           <div className={"overflow-hidden font-bold"}>


### PR DESCRIPTION
# Description

Updated stake return label for Bittensor staking to APY

### 🖼️ **Screenshots:**

![Screenshot 2025-04-16 at 14 56 28](https://github.com/user-attachments/assets/bcd1d670-137e-4726-9c74-7a95e5911d87)
