### PR TITLE
chore: Bittensor remove recommended delegator

### DIFF
--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondDelegateSelect.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondDelegateSelect.tsx
@@ -52,7 +52,7 @@ export const BittensorBondDelegateSelect = () => {
       !combinedValidatorsDataLoading &&
       !sortedDelegators.length
     ) {
-      setSortedDelegators(sortBondOptions(combinedValidatorsData, "name"))
+      setSortedDelegators(sortBondOptions(combinedValidatorsData, "totalStaked"))
     }
   }, [
     combinedValidatorsData,

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorDelegatorNameButton.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorDelegatorNameButton.tsx
@@ -1,5 +1,6 @@
 import { SettingsIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
+import { useTranslation } from "react-i18next"
 
 import { useBondWizard } from "../Bond/useBondWizard"
 import { useCombinedBittensorValidatorsData } from "../hooks/bittensor/useCombinedBittensorValidatorsData"
@@ -9,13 +10,14 @@ type BittensorDelegatorNameButtonProps = {
 }
 
 export const BittensorDelegatorNameButton = ({ poolId }: BittensorDelegatorNameButtonProps) => {
+  const { t } = useTranslation()
   const { combinedValidatorsData, isLoading, isError } = useCombinedBittensorValidatorsData()
 
   const selectedPool = combinedValidatorsData.find((data) => data.poolId === poolId)
 
   const { setStep, step } = useBondWizard()
 
-  const defaultPoolName = "Bittensor Pool"
+  const defaultPoolName = t("Select validator")
 
   const poolName = selectedPool?.name
 

--- a/apps/extension/src/ui/domains/Staking/Bond/useBondButton.ts
+++ b/apps/extension/src/ui/domains/Staking/Bond/useBondButton.ts
@@ -57,7 +57,9 @@ export const useBondButton = ({
         remoteConfig.stakingPools[token.chain.id]?.[0] ||
         remoteConfig.nominationPools[token.chain.id]?.[0]
 
-      if (!poolId) return [null, false]
+      const isStakingEnabled = !!remoteConfig.stakingPools[token.chain.id]
+
+      if (!poolId && !isStakingEnabled) return [null, false]
 
       // if a watch-only or solo-staking account is selected, array will be empty
       if (!sorted.length) return [null, false]

--- a/apps/extension/src/ui/domains/Staking/shared/BondDelegateSelect.tsx
+++ b/apps/extension/src/ui/domains/Staking/shared/BondDelegateSelect.tsx
@@ -72,16 +72,15 @@ export const BondDelegateSelect = <T,>({
                 .fill(null)
                 .map((_, i) => {
                   return (
-                    <>
-                      <BondOptionSkeleton key={i} isRecommended={i === 0} />
+                    <div key={i}>
+                      <BondOptionSkeleton isRecommended={i === 0} />
                       {i === 0 && <div className="bg-grey-800 h-[1px]" />}
-                    </>
+                    </div>
                   )
                 })
             : bondOptions.map((option, i) => (
-                <>
+                <div key={option.poolId}>
                   <BondOption
-                    key={option.poolId}
                     option={option}
                     selectedPoolId={poolId}
                     handleSelectPoolId={handleSelectPoolId}
@@ -89,7 +88,7 @@ export const BondDelegateSelect = <T,>({
                   />
                   {/* add a separator after the recommended it, which should be first */}
                   {i === 0 && <div className="bg-grey-800 h-[1px]" />}
-                </>
+                </div>
               ))}
           {isError && (
             <div className="text-alert-error flex h-full items-center justify-center">

--- a/packages/extension-core/src/domains/app/store.remoteConfig.ts
+++ b/packages/extension-core/src/domains/app/store.remoteConfig.ts
@@ -59,6 +59,12 @@ export class RemoteConfigStore extends StorageProvider<RemoteConfigStoreData> {
             config.coingecko.apiKeyValue = process.env.COINGECKO_API_KEY_VALUE
         }
 
+        // as per 2.8.0 we dont want this address to be the default validator anymore.
+        // versions prior to 2.8.0 expect a value there so GH config file cant be altered, we need to remove it at runtime
+        config.stakingPools["bittensor"] = config.stakingPools["bittensor"]?.filter(
+          (address) => address !== "5ELREhApbCahM7FyGLM1V9WDsnnjCRmMCJTmtQD51oAEqwVh",
+        )
+
         // first arg is an empty object so that DEFAULT_REMOTE_CONFIG is not mutated
         await this.mutate(() => merge({}, DEFAULT_REMOTE_CONFIG, config))
       } catch (err) {


### PR DESCRIPTION
# Description

- Remove Bittensor preselected recommended delegator when there is no active staked position
- Fix Delegator select modal default sort method matches label
- Fix key warning messages on console

### 🗒️ **Notes:**

Merge https://github.com/TalismanSociety/talisman-config/pull/12 *after* releasing this PR


### 🧪 **How to test:**

- Run this branch locally
- Pull mocked remote config branch https://github.com/TalismanSociety/talisman/pull/1806
- Open browser inspector, go on Applications tab, select Storage and then click on "Clear site data"
- Go on browser extension manager, reload Talisman dev wallet
- Open the wallet, select an account with no active Tao staking position, select stake tao.

Expected result:

Validator row should display "Select Validator"

- Click on Select Validator

Expected result: 

Validators should be sorted by Total staked (check validators card, not only the selected filter button)


### 🖼️ **Screenshots:**

![Screenshot 2025-04-17 at 11 16 17](https://github.com/user-attachments/assets/7b106bf6-907f-4c25-9d5c-a1c2031ea434)
