### PR TITLE
feat: no maxFee security margin if baseFee is idle

### DIFF
--- a/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
+++ b/apps/extension/src/ui/domains/Ethereum/useEthTransaction.ts
@@ -371,22 +371,31 @@ const useGasSettings = ({
         if (mapMaxPriority.high === 0n) mapMaxPriority.high = 1n
       }
 
-      const low = getGasSettingsEip1559(baseFeePerGas, mapMaxPriority.low, gas)
-      const medium = getGasSettingsEip1559(baseFeePerGas, mapMaxPriority.medium, gas)
-      const high = getGasSettingsEip1559(baseFeePerGas, mapMaxPriority.high, gas)
+      const low = getGasSettingsEip1559(
+        baseFeePerGas,
+        mapMaxPriority.low,
+        gas,
+        feeHistoryAnalysis.isBaseFeeIdle,
+      )
+      const medium = getGasSettingsEip1559(
+        baseFeePerGas,
+        mapMaxPriority.medium,
+        gas,
+        feeHistoryAnalysis.isBaseFeeIdle,
+      )
+      const high = getGasSettingsEip1559(
+        baseFeePerGas,
+        mapMaxPriority.high,
+        gas,
+        feeHistoryAnalysis.isBaseFeeIdle,
+      )
 
       const custom: EthGasSettingsEip1559 =
         customSettings?.type === "eip1559"
           ? customSettings
           : suggestedSettings?.type === "eip1559"
             ? suggestedSettings
-            : {
-                ...low,
-                // if network is idle, it makes sense to use baseFee as max base fee
-                maxFeePerGas: feeHistoryAnalysis.isBaseFeeIdle
-                  ? baseFeePerGas + low.maxPriorityFeePerGas
-                  : low.maxFeePerGas,
-              }
+            : low
 
       return {
         type: "eip1559",

--- a/packages/extension-core/src/domains/ethereum/helpers.ts
+++ b/packages/extension-core/src/domains/ethereum/helpers.ts
@@ -285,12 +285,15 @@ export const getMaxFeePerGas = (
   maxPriorityFeePerGas: bigint,
   maxBlocksWait = 8,
   increase = true,
+  isBaseFeeIdle = false,
 ) => {
   let base = baseFeePerGas
 
   //baseFeePerGas can augment 12.5% per block
-  for (let i = 0; i < maxBlocksWait; i++)
-    base = (base * BigInt((1 + (increase ? 1 : -1) * FEE_MAX_RAISE_RATIO_PER_BLOCK) * 1000)) / 1000n
+  if (!isBaseFeeIdle)
+    for (let i = 0; i < maxBlocksWait; i++)
+      base =
+        (base * BigInt((1 + (increase ? 1 : -1) * FEE_MAX_RAISE_RATIO_PER_BLOCK) * 1000)) / 1000n
 
   return base + maxPriorityFeePerGas
 }
@@ -299,11 +302,11 @@ export const getGasSettingsEip1559 = (
   baseFee: bigint,
   maxPriorityFeePerGas: bigint,
   gas: bigint,
-  maxBlocksWait?: number,
+  isBaseFeeIdle?: boolean,
 ): EthGasSettingsEip1559 => ({
   type: "eip1559",
   maxPriorityFeePerGas,
-  maxFeePerGas: getMaxFeePerGas(baseFee, maxPriorityFeePerGas, maxBlocksWait),
+  maxFeePerGas: getMaxFeePerGas(baseFee, maxPriorityFeePerGas, 8, true, isBaseFeeIdle),
   gas,
 })
 


### PR DESCRIPTION
results in much cheaper fees on Monad, where the maxFee is always paid for.