### PR TITLE
fix: incorrect typecasts to `EvmNetwork` in `src/ui`

### DIFF
--- a/.changeset/light-panthers-know.md
+++ b/.changeset/light-panthers-know.md
@@ -1,0 +1,6 @@
+---
+"@talismn/chaindata-provider": patch
+"@talismn/balances": patch
+---
+
+chore: add SimpleEvmNetworkList

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
@@ -1,6 +1,6 @@
 import { bind } from "@react-rxjs/core"
 import { Address, BalanceFormatter } from "@talismn/balances"
-import { Chain, EvmNetwork, EvmNetworkId, Token, TokenId } from "@talismn/chaindata-provider"
+import { Chain, EvmNetworkId, SimpleEvmNetwork, Token, TokenId } from "@talismn/chaindata-provider"
 import {
   ChevronDownIcon,
   DiamondIcon,
@@ -119,7 +119,7 @@ const AccountsTooltip: FC<{ addresses: Address[] }> = ({ addresses }) => {
   )
 }
 
-const NetworksTooltip: FC<{ networks: (EvmNetwork | Chain)[] }> = ({ networks }) => {
+const NetworksTooltip: FC<{ networks: (Chain | SimpleEvmNetwork)[] }> = ({ networks }) => {
   const { t } = useTranslation()
 
   const tokens = useTokens()
@@ -521,7 +521,7 @@ const AccountsWrapper: FC<{
 
 const NetworksWrapper: FC<{
   children?: ReactNode
-  networks: (EvmNetwork | Chain)[]
+  networks: (Chain | SimpleEvmNetwork)[]
   className?: string
 }> = ({ children, networks, className }) => {
   return (
@@ -583,7 +583,7 @@ const ScanInfo: FC = () => {
     () => accounts.filter((a) => lastScanAccounts.includes(a.address)),
     [accounts, lastScanAccounts],
   )
-  const lastNetworks = useMemo<(EvmNetwork | Chain)[]>(
+  const lastNetworks = useMemo<(Chain | SimpleEvmNetwork)[]>(
     () => lastScanNetworks.map((id) => evmNetworksMap[id] ?? chainsMap[id]).filter(isNotNil),
     [chainsMap, evmNetworksMap, lastScanNetworks],
   )

--- a/apps/extension/src/ui/apps/popup/pages/AddEthereumNetwork.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/AddEthereumNetwork.tsx
@@ -1,4 +1,4 @@
-import { EvmNetwork } from "@talismn/chaindata-provider"
+import { SimpleEvmNetwork } from "@talismn/chaindata-provider"
 import { GlobeIcon, InfoIcon } from "@talismn/icons"
 import { KnownRequestIdOnly } from "extension-core"
 import { log } from "extension-shared"
@@ -23,7 +23,7 @@ const SettingsSourceSelector: FC<{
   source: SettingsSource
   onChange: (src: SettingsSource) => void
   network: AddEthereumChainParameter
-  knownNetwork: EvmNetwork
+  knownNetwork: SimpleEvmNetwork
 }> = ({ source, onChange, network, knownNetwork }) => {
   const { t } = useTranslation("request")
   const knownNativeToken = useToken(knownNetwork.nativeToken?.id)

--- a/apps/extension/src/ui/apps/popup/pages/Sign/SignNetworkLogo.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Sign/SignNetworkLogo.tsx
@@ -1,10 +1,10 @@
-import { Chain, EvmNetwork } from "extension-core"
+import { Chain, SimpleEvmNetwork } from "extension-core"
 import { FC } from "react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
 
 import { ChainLogo } from "@ui/domains/Asset/ChainLogo"
 
-export const SignNetworkLogo: FC<{ network: Chain | EvmNetwork | null | undefined }> = ({
+export const SignNetworkLogo: FC<{ network: Chain | SimpleEvmNetwork | null | undefined }> = ({
   network,
 }) => {
   if (!network) return null

--- a/apps/extension/src/ui/domains/Erc20Tokens/CustomErc20TokenViewDetails.tsx
+++ b/apps/extension/src/ui/domains/Erc20Tokens/CustomErc20TokenViewDetails.tsx
@@ -1,5 +1,5 @@
 import { CustomEvmErc20Token } from "@talismn/balances"
-import { CustomEvmNetwork, EvmNetwork } from "extension-core"
+import { SimpleEvmNetwork } from "@talismn/chaindata-provider"
 import { useTranslation } from "react-i18next"
 import { Button, Drawer, PillButton } from "talisman-ui"
 
@@ -10,7 +10,7 @@ import { ViewDetailsField } from "../Sign/ViewDetails/ViewDetailsField"
 
 type CustomErc20TokenViewDetailsProps = {
   token: CustomEvmErc20Token
-  network: EvmNetwork | CustomEvmNetwork
+  network: SimpleEvmNetwork
 }
 
 export const CustomErc20TokenViewDetails = ({

--- a/apps/extension/src/ui/domains/Ethereum/usePublicClient.ts
+++ b/apps/extension/src/ui/domains/Ethereum/usePublicClient.ts
@@ -1,5 +1,5 @@
 import { EvmNativeToken } from "@talismn/balances"
-import { EvmNetwork, EvmNetworkId } from "@talismn/chaindata-provider"
+import { EvmNetworkId, SimpleEvmNetwork } from "@talismn/chaindata-provider"
 import { log } from "extension-shared"
 import { useMemo } from "react"
 import { createPublicClient, custom, PublicClient } from "viem"
@@ -21,7 +21,7 @@ const viemRequest =
   }
 
 export const getExtensionPublicClient = (
-  evmNetwork: EvmNetwork,
+  evmNetwork: SimpleEvmNetwork,
   nativeToken: EvmNativeToken,
 ): PublicClient => {
   const name = evmNetwork.name ?? `EVM Chain ${evmNetwork.id}`

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/usePortfolioNetworks.ts
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/usePortfolioNetworks.ts
@@ -1,4 +1,4 @@
-import { Chain, ChainId, EvmNetwork, EvmNetworkId } from "extension-core"
+import { Chain, ChainId, EvmNetworkId, SimpleEvmNetwork } from "extension-core"
 import { TFunction } from "i18next"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
@@ -16,7 +16,7 @@ const getPortfolioNetwork = (
   t: TFunction,
   id: ChainId | EvmNetworkId,
   chains?: Chain[],
-  evmNetworks?: EvmNetwork[],
+  evmNetworks?: SimpleEvmNetwork[],
 ): PortfolioNetwork => {
   const chain = chains?.find((c) => c.id === id)
   const evmNetwork = evmNetworks?.find((n) => n.id === id)

--- a/apps/extension/src/ui/domains/Ramps/shared/RampsTokenPicker.tsx
+++ b/apps/extension/src/ui/domains/Ramps/shared/RampsTokenPicker.tsx
@@ -1,4 +1,4 @@
-import { Chain, EvmNetwork, Token } from "@talismn/chaindata-provider"
+import { Chain, SimpleEvmNetwork, Token } from "@talismn/chaindata-provider"
 import { CheckCircleIcon } from "@talismn/icons"
 import { TokenRates, TokenRatesList } from "@talismn/token-rates"
 import { classNames } from "@talismn/util"
@@ -18,7 +18,7 @@ import { useChainsMap, useEvmNetworksMap, useRemoteConfig, useSelectedCurrency }
 import { RampsPickerLayout } from "./RampsPickerLayout"
 
 type TokenDisplay = Token & {
-  network: Chain | EvmNetwork
+  network: Chain | SimpleEvmNetwork
   rates?: TokenRates
 }
 

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsProgress.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsProgress.tsx
@@ -1,5 +1,5 @@
 import { HexString } from "@polkadot/util/types"
-import { Chain, EvmNetwork } from "@talismn/chaindata-provider"
+import { Chain, SimpleEvmNetwork } from "@talismn/chaindata-provider"
 import { ExternalLinkIcon, RocketIcon, XCircleIcon } from "@talismn/icons"
 import { EvmWalletTransaction, SubWalletTransaction, WalletTransaction } from "extension-core"
 import { FC, useCallback, useMemo, useState } from "react"
@@ -13,7 +13,7 @@ import { useChainByGenesisHash, useEvmNetwork, useTransaction } from "@ui/state"
 import { TxReplaceDrawer, TxReplaceType } from "../Transactions"
 
 const getBlockExplorerUrl = (
-  network: EvmNetwork | undefined | null,
+  network: SimpleEvmNetwork | undefined | null,
   chain: Chain | undefined | null,
   hash: string,
 ) => {

--- a/apps/extension/src/ui/domains/SendFunds/useNetworkDetails.ts
+++ b/apps/extension/src/ui/domains/SendFunds/useNetworkDetails.ts
@@ -1,4 +1,4 @@
-import { Chain, CustomChain, CustomEvmNetwork, EvmNetwork } from "@talismn/chaindata-provider"
+import { Chain, CustomChain, SimpleEvmNetwork } from "@talismn/chaindata-provider"
 import { useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -18,7 +18,7 @@ export const useFormatNetworkName = () => {
   const [t] = useTranslation()
 
   return useCallback(
-    (chain?: Chain | CustomChain | null, evmNetwork?: EvmNetwork | CustomEvmNetwork | null) =>
+    (chain?: Chain | CustomChain | null, evmNetwork?: SimpleEvmNetwork | null) =>
       chain?.name
         ? `${chain.name}${chain.evmNetworks?.length > 0 ? ` (${t("Polkadot")})` : ""}`
         : evmNetwork

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/EvmNetworkForm.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/EvmNetworkForm.tsx
@@ -1,11 +1,6 @@
 import { yupResolver } from "@hookform/resolvers/yup"
 import { CustomSubNativeToken } from "@talismn/balances"
-import {
-  CustomEvmNetwork,
-  EvmNetwork,
-  EvmNetworkId,
-  isCustomEvmNetwork,
-} from "@talismn/chaindata-provider"
+import { EvmNetworkId, isCustomEvmNetwork, SimpleEvmNetwork } from "@talismn/chaindata-provider"
 import { ArrowRightIcon, InfoIcon, RotateCcwIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
 import { useQuery } from "@tanstack/react-query"
@@ -359,7 +354,7 @@ const useEditMode = (evmNetworkId?: EvmNetworkId) => {
 }
 
 const evmNetworkToFormData = (
-  network?: EvmNetwork | CustomEvmNetwork,
+  network?: SimpleEvmNetwork,
   nativeToken?: CustomSubNativeToken,
 ): EvmNetworkFormData | undefined => {
   if (!network || !nativeToken) return undefined
@@ -369,7 +364,10 @@ const evmNetworkToFormData = (
     name: network.name ?? "",
     rpcs: network.rpcs ?? [],
     blockExplorerUrl:
-      network.explorerUrl ?? ("explorerUrls" in network ? network.explorerUrls?.[0] : undefined),
+      network.explorerUrl ??
+      ("explorerUrls" in network && Array.isArray(network.explorerUrls)
+        ? network.explorerUrls?.[0]
+        : undefined),
     isTestnet: !!network.isTestnet,
     tokenCoingeckoId: nativeToken.coingeckoId ?? "",
     tokenSymbol: nativeToken.symbol,

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/RemoveEvmNetworkButton.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/RemoveEvmNetworkButton.tsx
@@ -1,4 +1,4 @@
-import { CustomEvmNetwork, EvmNetwork } from "extension-core"
+import { SimpleEvmNetwork } from "extension-core"
 import { FC, useCallback } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -8,9 +8,7 @@ import { notify } from "@talisman/components/Notifications"
 import { useOpenClose } from "@talisman/hooks/useOpenClose"
 import { api } from "@ui/api"
 
-export const RemoveEvmNetworkButton: FC<{ network: EvmNetwork | CustomEvmNetwork }> = ({
-  network,
-}) => {
+export const RemoveEvmNetworkButton: FC<{ network: SimpleEvmNetwork }> = ({ network }) => {
   const { t } = useTranslation("admin")
   const navigate = useNavigate()
   const { isOpen, open, close } = useOpenClose()

--- a/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/ResetEvmNetworkButton.tsx
+++ b/apps/extension/src/ui/domains/Settings/ManageNetworks/NetworkForm/Ethereum/ResetEvmNetworkButton.tsx
@@ -1,5 +1,5 @@
 import { sleep } from "@talismn/util"
-import { CustomEvmNetwork, EvmNetwork } from "extension-core"
+import { SimpleEvmNetwork } from "extension-core"
 import { FC, useCallback, useEffect, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -9,9 +9,7 @@ import { notify } from "@talisman/components/Notifications"
 import { useOpenClose } from "@talisman/hooks/useOpenClose"
 import { api } from "@ui/api"
 
-export const ResetEvmNetworkButton: FC<{ network: EvmNetwork | CustomEvmNetwork }> = ({
-  network,
-}) => {
+export const ResetEvmNetworkButton: FC<{ network: SimpleEvmNetwork }> = ({ network }) => {
   const { t } = useTranslation("admin")
   const { isOpen, open, close } = useOpenClose()
   const navigate = useNavigate()

--- a/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamContractButton.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamContractButton.tsx
@@ -1,5 +1,5 @@
 import { isEthereumAddress } from "@talismn/util"
-import { CustomEvmNetwork, EvmAddress, EvmNetwork } from "extension-core"
+import { EvmAddress, SimpleEvmNetwork } from "extension-core"
 import { FC, useMemo } from "react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
 
@@ -12,7 +12,7 @@ import { SignParamButton } from "./SignParamButton"
 
 type SignParamNetworkAddressButtonProps = {
   address: string
-  network: EvmNetwork | CustomEvmNetwork
+  network: SimpleEvmNetwork
   className?: string
   name?: string
 }

--- a/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamErc20TokenButton.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamErc20TokenButton.tsx
@@ -1,4 +1,4 @@
-import { CustomEvmNetwork, EvmAddress, EvmNetwork } from "extension-core"
+import { EvmAddress, SimpleEvmNetwork } from "extension-core"
 import { FC } from "react"
 
 import { AssetLogo } from "@ui/domains/Asset/AssetLogo"
@@ -7,7 +7,7 @@ import { useErc20Token } from "@ui/hooks/useErc20Token"
 import { SignParamButton } from "./SignParamButton"
 
 type SignParamErc20TokenButtonProps = {
-  network: EvmNetwork | CustomEvmNetwork
+  network: SimpleEvmNetwork
   asset: { symbol?: string }
   address: string
   withIcon?: boolean

--- a/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamTokensButton.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/shared/SignParamTokensButton.tsx
@@ -1,13 +1,13 @@
 import { BalanceFormatter } from "@talismn/balances"
+import { SimpleEvmNetwork } from "@talismn/chaindata-provider"
 import { classNames } from "@talismn/util"
-import { CustomEvmNetwork, EvmNetwork } from "extension-core"
 import { FC } from "react"
 
 import { SignParamButton } from "./SignParamButton"
 import { SignParamTokensDisplay } from "./SignParamTokensDisplay"
 
 type SignParamTokensButtonProps = {
-  network: EvmNetwork | CustomEvmNetwork
+  network: SimpleEvmNetwork
   address: string
   withIcon?: boolean
   tokenId: string | undefined

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryContext.ts
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryContext.ts
@@ -1,6 +1,6 @@
 import { HexString } from "@polkadot/util/types"
 import { normalizeAddress } from "@talismn/util"
-import { Chain, EvmNetwork, EvmNetworkId, WalletTransaction } from "extension-core"
+import { Chain, EvmNetworkId, SimpleEvmNetwork, WalletTransaction } from "extension-core"
 import uniq from "lodash/uniq"
 import { useCallback, useMemo, useState } from "react"
 
@@ -47,7 +47,7 @@ const useTxHistoryProvider = () => {
     )
       .filter((evmNetworkId): evmNetworkId is string => !!evmNetworkId)
       .map((evmNetworkId) => evmNetworksMap[evmNetworkId])
-      .filter<EvmNetwork>((n): n is EvmNetwork => !!n)
+      .filter<SimpleEvmNetwork>((n): n is SimpleEvmNetwork => !!n)
 
     const chains = uniq(
       accountTransactions?.map((tx) => (tx.networkType === "substrate" ? tx.genesisHash : null)),
@@ -59,7 +59,7 @@ const useTxHistoryProvider = () => {
     return [...evmNetworks, ...chains].sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""))
   }, [encodedAddresses, allTransactions, chainsByGenesisHash, evmNetworksMap])
 
-  const network = useMemo<Chain | EvmNetwork | null>(
+  const network = useMemo<Chain | SimpleEvmNetwork | null>(
     () =>
       chainsByGenesisHash[(networkId ?? "") as HexString] ??
       evmNetworksMap[networkId ?? ""] ??

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryNetworkPicker.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryNetworkPicker.tsx
@@ -6,7 +6,7 @@ import {
   XIcon,
 } from "@talismn/icons"
 import { classNames } from "@talismn/util"
-import { Chain, EvmNetwork } from "extension-core"
+import { Chain, SimpleEvmNetwork } from "extension-core"
 import { FC, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { IconButton, Modal } from "talisman-ui"
@@ -18,7 +18,7 @@ import { useNetworkInfo } from "@ui/hooks/useNetworkInfo"
 import { useChain, useChainByGenesisHash, useEvmNetwork } from "@ui/state"
 import { IS_POPUP } from "@ui/util/constants"
 
-type Network = Chain | EvmNetwork
+type Network = Chain | SimpleEvmNetwork
 
 const getNetworkId = (network: Network): string => {
   const genesisHash = "genesisHash" in network ? network.genesisHash : undefined

--- a/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
@@ -1,5 +1,5 @@
 import { HexString } from "@polkadot/util/types"
-import { Chain, EvmNetwork } from "@talismn/chaindata-provider"
+import { Chain, SimpleEvmNetwork } from "@talismn/chaindata-provider"
 import { ExternalLinkIcon, RocketIcon, XCircleIcon } from "@talismn/icons"
 import { EvmWalletTransaction, SubWalletTransaction, WalletTransaction } from "extension-core"
 import { FC, useCallback, useMemo, useState } from "react"
@@ -14,7 +14,7 @@ import { TxReplaceDrawer } from "./TxReplaceDrawer"
 import { TxReplaceType } from "./types"
 
 const getBlockExplorerUrl = (
-  network: EvmNetwork | undefined | null,
+  network: SimpleEvmNetwork | undefined | null,
   chain: Chain | undefined | null,
   hash: string,
 ) => {

--- a/apps/extension/src/ui/hooks/useLoginCheck.ts
+++ b/apps/extension/src/ui/hooks/useLoginCheck.ts
@@ -4,11 +4,9 @@ import { combineLatest, map } from "rxjs"
 import { currentMigration$, isLoggedIn$, isOnboarded$ } from "@ui/state"
 
 export const [useLoginCheck] = bind(
-  combineLatest([isLoggedIn$, isOnboarded$, currentMigration$]).pipe(
-    map(([isLoggedIn, isOnboarded, currentMigration]) => ({
-      isLoggedIn,
-      isOnboarded,
-      isMigrating: !!currentMigration,
-    })),
-  ),
+  combineLatest({
+    isLoggedIn: isLoggedIn$,
+    isOnboarded: isOnboarded$,
+    isMigrating: currentMigration$.pipe(map((currentMigration) => !!currentMigration)),
+  }),
 )

--- a/apps/extension/src/ui/state/balances.ts
+++ b/apps/extension/src/ui/state/balances.ts
@@ -26,20 +26,12 @@ import { debugObservable } from "./util/debugObservable"
 const BALANCES_CHAINDATA_QUERY = { includeTestnets: true, activeOnly: true }
 
 export const [useBalancesHydrate, balancesHydrate$] = bind(
-  combineLatest([
-    getChainsMap$(BALANCES_CHAINDATA_QUERY),
-    getEvmNetworksMap$(BALANCES_CHAINDATA_QUERY),
-    getTokensMap$(BALANCES_CHAINDATA_QUERY),
-    tokenRatesMap$,
-  ]).pipe(
-    map(([chains, evmNetworks, tokens, tokenRates]) => ({
-      chains,
-      evmNetworks,
-      tokens,
-      tokenRates,
-    })),
-    debugObservable("balancesHydrate$"),
-  ),
+  combineLatest({
+    chains: getChainsMap$(BALANCES_CHAINDATA_QUERY),
+    evmNetworks: getEvmNetworksMap$(BALANCES_CHAINDATA_QUERY),
+    tokens: getTokensMap$(BALANCES_CHAINDATA_QUERY),
+    tokenRates: tokenRatesMap$,
+  }).pipe(debugObservable("balancesHydrate$")),
 )
 
 // Reading this atom triggers the balances backend subscription

--- a/apps/extension/src/ui/state/chaindata.ts
+++ b/apps/extension/src/ui/state/chaindata.ts
@@ -5,7 +5,8 @@ import {
   ChainList,
   CustomChain,
   EvmNetworkId,
-  EvmNetworkList,
+  SimpleEvmNetwork,
+  SimpleEvmNetworkList,
   Token,
   TokenId,
   TokenList,
@@ -17,7 +18,6 @@ import {
   isChainActive,
   isEvmNetworkActive,
   isTokenActive,
-  SimpleEvmNetwork,
 } from "extension-core"
 import { combineLatest, map, Observable, shareReplay } from "rxjs"
 
@@ -61,14 +61,14 @@ const allChains$ = new Observable<AnyChain[]>((subscriber) => {
 
 const allEvmNetworksMap$ = allEvmNetworks$.pipe(
   map(
-    (evmNetworks) =>
-      Object.fromEntries(evmNetworks.map((network) => [network.id, network])) as EvmNetworkList,
+    (evmNetworks): SimpleEvmNetworkList =>
+      Object.fromEntries(evmNetworks.map((network) => [network.id, network])),
   ),
   shareReplay(1),
 )
 
 const allChainsMap$ = allChains$.pipe(
-  map((chains) => Object.fromEntries(chains.map((network) => [network.id, network])) as ChainList),
+  map((chains): ChainList => Object.fromEntries(chains.map((network) => [network.id, network]))),
   shareReplay(1),
 )
 
@@ -84,13 +84,13 @@ const allChainsWithoutTestnets$ = allChains$.pipe(
 
 const allEvmNetworksWithoutTestnetsMap$ = allEvmNetworksWithoutTestnets$.pipe(
   map(
-    (evmNetworks) =>
-      Object.fromEntries(evmNetworks.map((network) => [network.id, network])) as EvmNetworkList,
+    (evmNetworks): SimpleEvmNetworkList =>
+      Object.fromEntries(evmNetworks.map((network) => [network.id, network])),
   ),
   shareReplay(1),
 )
 const allChainsWithoutTestnetsMap$ = allChainsWithoutTestnets$.pipe(
-  map((chains) => Object.fromEntries(chains.map((network) => [network.id, network])) as ChainList),
+  map((chains): ChainList => Object.fromEntries(chains.map((network) => [network.id, network]))),
   shareReplay(1),
 )
 
@@ -111,14 +111,14 @@ const activeChainsWithTestnets$ = combineLatest([allChains$, activeChainsState$]
 
 const activeEvmNetworksWithTestnetsMap$ = activeEvmNetworksWithTestnets$.pipe(
   map(
-    (evmNetworks) =>
-      Object.fromEntries(evmNetworks.map((network) => [network.id, network])) as EvmNetworkList,
+    (evmNetworks): SimpleEvmNetworkList =>
+      Object.fromEntries(evmNetworks.map((network) => [network.id, network])),
   ),
   shareReplay(1),
 )
 
 const activeChainsWithTestnetsMap$ = activeChainsWithTestnets$.pipe(
-  map((chains) => Object.fromEntries(chains.map((network) => [network.id, network])) as ChainList),
+  map((chains): ChainList => Object.fromEntries(chains.map((network) => [network.id, network]))),
   shareReplay(1),
 )
 
@@ -134,14 +134,14 @@ const activeChainsWithoutTestnets$ = activeChainsWithTestnets$.pipe(
 
 const activeEvmNetworksWithoutTestnetsMap$ = activeEvmNetworksWithoutTestnets$.pipe(
   map(
-    (evmNetworks) =>
-      Object.fromEntries(evmNetworks.map((network) => [network.id, network])) as EvmNetworkList,
+    (evmNetworks): SimpleEvmNetworkList =>
+      Object.fromEntries(evmNetworks.map((network) => [network.id, network])),
   ),
   shareReplay(1),
 )
 
 const activeChainsWithoutTestnetsMap$ = activeChainsWithoutTestnets$.pipe(
-  map((chains) => Object.fromEntries(chains.map((network) => [network.id, network])) as ChainList),
+  map((chains): ChainList => Object.fromEntries(chains.map((network) => [network.id, network]))),
   shareReplay(1),
 )
 
@@ -181,12 +181,12 @@ export const [useChainsMap, getChainsMap$] = bind(
 export const [useChainsMapByGenesisHash, allChainsByGenesisHash$] = bind(
   allChains$.pipe(
     map(
-      (chains) =>
+      (chains): ChainList =>
         Object.fromEntries(
           chains
             .filter((network) => network.genesisHash)
             .map((network) => [network.genesisHash, network]),
-        ) as ChainList,
+        ),
     ),
   ),
 )
@@ -271,7 +271,7 @@ const activeTokensWithTestnets$ = combineLatest([
 )
 
 const activeTokensWithTestnetsMap$ = activeTokensWithTestnets$.pipe(
-  map((tokens) => Object.fromEntries(tokens.map((token) => [token.id, token])) as TokenList),
+  map((tokens): TokenList => Object.fromEntries(tokens.map((token) => [token.id, token]))),
   shareReplay(1),
 )
 
@@ -291,7 +291,7 @@ const activeTokensWithoutTestnets$ = combineLatest([
 )
 
 const activeTokensWithoutTestnetsMap$ = activeTokensWithoutTestnets$.pipe(
-  map((tokens) => Object.fromEntries(tokens.map((token) => [token.id, token])) as TokenList),
+  map((tokens): TokenList => Object.fromEntries(tokens.map((token) => [token.id, token]))),
   shareReplay(1),
 )
 

--- a/apps/extension/src/ui/state/portfolio.ts
+++ b/apps/extension/src/ui/state/portfolio.ts
@@ -1,6 +1,6 @@
 import { bind } from "@react-rxjs/core"
 import { HydrateDb } from "@talismn/balances"
-import { Chain, ChainId, EvmNetwork, EvmNetworkId, Token } from "@talismn/chaindata-provider"
+import { Chain, ChainId, EvmNetworkId, SimpleEvmNetwork, Token } from "@talismn/chaindata-provider"
 import { AddressEncoding, detectAddressEncoding } from "@talismn/crypto"
 import { isAddressEqual, isTruthy } from "@talismn/util"
 import { Account, Balances } from "extension-core"
@@ -24,7 +24,7 @@ export type NetworkOption = {
 type PortfolioGlobalData = {
   chains: Chain[]
   tokens: Token[]
-  evmNetworks: EvmNetwork[]
+  evmNetworks: SimpleEvmNetwork[]
   hydrate: HydrateDb
   allBalances: Balances
   portfolioBalances: Balances
@@ -66,7 +66,7 @@ const getNetworkOptions = ({
 }: {
   tokens: Token[]
   chains: Chain[]
-  evmNetworks: EvmNetwork[]
+  evmNetworks: SimpleEvmNetwork[]
   addressEncoding?: AddressEncoding
   balances?: Balances
 }) => {
@@ -167,40 +167,26 @@ export const portfolioSearch$ = new BehaviorSubject<string>("")
 
 const setSearch = (search: string) => portfolioSearch$.next(search)
 
-export const [usePortfolioGlobalData, portfolioGlobalData$] = bind(
-  combineLatest([
-    getChains$({ activeOnly: true, includeTestnets: true }),
-    getEvmNetworks$({ activeOnly: true, includeTestnets: true }),
-    getTokens$({ activeOnly: true, includeTestnets: true }),
-    balancesHydrate$,
-    getBalances$("all"),
-    getBalances$("portfolio"),
-    isBalanceInitialising$,
-  ]).pipe(
-    map(
-      ([chains, evmNetworks, tokens, hydrate, allBalances, portfolioBalances, isInitialising]) =>
-        ({
-          chains,
-          evmNetworks,
-          tokens,
-          hydrate,
-          allBalances,
-          portfolioBalances,
-          isInitialising,
-          isProvisioned: true,
-        }) as PortfolioGlobalData,
-    ),
-  ),
+export const [usePortfolioGlobalData, portfolioGlobalData$] = bind<PortfolioGlobalData>(
+  combineLatest({
+    chains: getChains$({ activeOnly: true, includeTestnets: true }),
+    evmNetworks: getEvmNetworks$({ activeOnly: true, includeTestnets: true }),
+    tokens: getTokens$({ activeOnly: true, includeTestnets: true }),
+    hydrate: balancesHydrate$,
+    allBalances: getBalances$("all"),
+    portfolioBalances: getBalances$("portfolio"),
+    isInitialising: isBalanceInitialising$,
+  }).pipe(map((data): PortfolioGlobalData => ({ ...data, isProvisioned: true }))),
   {
     chains: [],
-    tokens: [],
     evmNetworks: [],
+    tokens: [],
     hydrate: {},
     allBalances: new Balances([]),
     portfolioBalances: new Balances([]),
-    isProvisioned: false,
     isInitialising: false,
-  } as PortfolioGlobalData,
+    isProvisioned: false,
+  },
 )
 
 const portfolioForSelectedNetwork$ = combineLatest([

--- a/packages/balances/src/types/balances.ts
+++ b/packages/balances/src/types/balances.ts
@@ -1,4 +1,4 @@
-import { ChainList, EvmNetworkList, TokenList } from "@talismn/chaindata-provider"
+import { ChainList, SimpleEvmNetworkList, TokenList } from "@talismn/chaindata-provider"
 import { newTokenRates, TokenRateCurrency, TokenRates, TokenRatesList } from "@talismn/token-rates"
 import {
   BigMath,
@@ -79,7 +79,7 @@ export type BalanceSource = BalanceJson["source"]
 /** TODO: Remove this in favour of a frontend-friendly `ChaindataProvider` */
 export type HydrateDb = Partial<{
   chains: ChainList
-  evmNetworks: EvmNetworkList
+  evmNetworks: SimpleEvmNetworkList
   tokens: TokenList
   tokenRates: TokenRatesList
 }>

--- a/packages/chaindata-provider/src/types/EvmNetwork.ts
+++ b/packages/chaindata-provider/src/types/EvmNetwork.ts
@@ -2,6 +2,7 @@ import { BalancesConfig, BalancesMetadata, ChainId } from "./Chain"
 import { TokenId } from "./Token"
 
 export type EvmNetworkList = Record<EvmNetworkId, EvmNetwork>
+export type SimpleEvmNetworkList = Record<EvmNetworkId, SimpleEvmNetwork>
 
 export type EvmNetworkId = string
 export type EvmNetwork = {


### PR DESCRIPTION
Our ui exclusively deals with `SimpleEvmNetwork`, not `EvmNetwork`:
```ts
export type SimpleEvmNetwork = Omit<
  EvmNetwork | CustomEvmNetwork,
  "balancesConfig" | "balancesMetadata"
>
```

This PR updates the types used in the UI, so that if we try to access the `EvmNetwork.balancesConfig` or `EvmNetwork.balancesMetadata` keys from the ui, typescript will let us know they're not available there.

I've also snuck in 3 uses of `combineLatest(Record)` instead of `combineLatest(Array).pipe(map(Array => Record))`, which makes the code a bit more concise.