### PR TITLE
feat: improved formatPrice and cleanup signature

### DIFF
--- a/.changeset/silly-llamas-fly.md
+++ b/.changeset/silly-llamas-fly.md
@@ -1,0 +1,5 @@
+---
+"@talismn/util": patch
+---
+
+improved formatPrice

--- a/packages/util/src/formatPrice.test.ts
+++ b/packages/util/src/formatPrice.test.ts
@@ -1,0 +1,16 @@
+import { formatPrice } from "./formatPrice"
+
+describe("formatDecimals", () => {
+  it("works", () => {
+    expect(formatPrice(0.0000001, "usd", true)).toEqual("$0.000000100")
+    expect(formatPrice(0.0000001, "usd", false)).toEqual("$0.000000100")
+    expect(formatPrice(1, "usd", true)).toEqual("$1.00")
+    expect(formatPrice(1, "usd", false)).toEqual("$1.00")
+    expect(formatPrice(97156.156156485, "usd", true)).toEqual("$97.16K")
+    expect(formatPrice(97156.156156485, "usd", false)).toEqual("$97,156.156156485")
+    expect(formatPrice(609.325645498, "usd", true)).toEqual("$609.3")
+    expect(formatPrice(609.325645498, "usd", false)).toEqual("$609.325645498")
+    expect(formatPrice(609.325645498, "eth", true)).toEqual("ETH 609.3")
+    expect(formatPrice(609.325645498, "eth", false)).toEqual("ETH 609.325645498")
+  })
+})

--- a/packages/util/src/formatPrice.ts
+++ b/packages/util/src/formatPrice.ts
@@ -1,15 +1,11 @@
-export const formatPrice = (
-  price: number,
-  currency: string,
-  compact: boolean,
-  forceTickerAfter?: boolean,
-) => {
+export const formatPrice = (price: number, currency: string, compact: boolean) => {
   return Intl.NumberFormat(undefined, {
     style: "currency",
     currency,
-    currencyDisplay: forceTickerAfter ? "code" : currency === "usd" ? "narrowSymbol" : "symbol",
+    currencyDisplay: currency === "usd" ? "narrowSymbol" : "symbol",
+    minimumSignificantDigits: 3,
     maximumSignificantDigits: compact ? (price < 1 ? 3 : 4) : undefined,
     roundingPriority: compact ? "auto" : "morePrecision",
-    notation: compact && price >= 10_000 ? "compact" : "standard",
+    notation: compact ? "compact" : "standard",
   }).format(price)
 }


### PR DESCRIPTION
- always display at least 3 significant digits ($1 will display $1.00)
- added tests for formatPrice method
- removed the last argument of the method as it's not used anywhere (added it while working on ramps but didnt use it)