### PR TITLE
fix: call Asset Discovery api only when necessary

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
@@ -391,8 +391,8 @@ const Header: FC = () => {
     )
   }, [activeNetworks, allNetworks])
 
-  const allAccounts = useAccounts("all")
-  const addresses = allAccounts.map((a) => a.address)
+  const allAccounts = useAccounts("all-except-contacts")
+  const addresses = useMemo(() => allAccounts.map((a) => a.address), [allAccounts])
 
   const effectivePercent = isInitializing ? 0 : percent
 

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
@@ -402,6 +402,7 @@ const Header: FC = () => {
       await api.assetDiscoveryStartScan({
         networkIds: (all ? allNetworks : recommendedNetworks).map((n) => n.id),
         addresses,
+        withApi: true,
       })
       isInitializingScan$.next(false)
     },

--- a/apps/extension/src/ui/domains/Account/AccountContextMenu.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountContextMenu.tsx
@@ -131,7 +131,7 @@ export const AccountContextMenu = forwardRef<HTMLElement, Props>(function Accoun
   const canScanTokens = useMemo(() => isEthereumAddress(account?.address), [account])
   const scanTokensClick = useCallback(() => {
     if (!account) return
-    api.assetDiscoveryStartScan({ networkIds, addresses: [account.address] })
+    api.assetDiscoveryStartScan({ networkIds, addresses: [account.address], withApi: true })
     if (IS_POPUP) {
       api.dashboardOpen("/settings/networks-tokens/asset-discovery")
       if (IS_EMBEDDED_POPUP) window.close()

--- a/apps/extension/src/ui/state/accounts.ts
+++ b/apps/extension/src/ui/state/accounts.ts
@@ -1,6 +1,13 @@
 import { bind } from "@react-rxjs/core"
 import { normalizeAddress } from "@talismn/util"
-import { Account, isAccountOfType, isAccountOwned, isAccountPortfolio, Trees } from "extension-core"
+import {
+  Account,
+  isAccountNotContact,
+  isAccountOfType,
+  isAccountOwned,
+  isAccountPortfolio,
+  Trees,
+} from "extension-core"
 import { map, Observable, shareReplay } from "rxjs"
 
 import { api } from "@ui/api"
@@ -42,7 +49,13 @@ export const [useAccountByAddress, getAccountByAddress$] = bind(
     ),
 )
 
-export type AccountCategory = "all" | "watched" | "owned" | "portfolio" | "signet"
+export type AccountCategory =
+  | "all"
+  | "watched"
+  | "owned"
+  | "portfolio"
+  | "signet"
+  | "all-except-contacts"
 
 export const [useAccounts, getAccountsByCategory$] = bind((category: AccountCategory = "all") =>
   accounts$.pipe(
@@ -56,6 +69,8 @@ export const [useAccounts, getAccountsByCategory$] = bind((category: AccountCate
           return accounts.filter(isAccountOwned)
         case "signet":
           return accounts.filter((acc) => isAccountOfType(acc, "signet"))
+        case "all-except-contacts":
+          return accounts.filter(isAccountNotContact)
         case "all":
           return accounts
       }

--- a/apps/extension/src/ui/state/accounts.ts
+++ b/apps/extension/src/ui/state/accounts.ts
@@ -57,23 +57,24 @@ export type AccountCategory =
   | "signet"
   | "all-except-contacts"
 
-export const [useAccounts, getAccountsByCategory$] = bind((category: AccountCategory = "all") =>
-  accounts$.pipe(
-    map((accounts) => {
-      switch (category) {
-        case "portfolio":
-          return accounts.filter(isAccountPortfolio)
-        case "watched":
-          return accounts.filter((acc) => isAccountOfType(acc, "watch-only"))
-        case "owned":
-          return accounts.filter(isAccountOwned)
-        case "signet":
-          return accounts.filter((acc) => isAccountOfType(acc, "signet"))
-        case "all-except-contacts":
-          return accounts.filter(isAccountNotContact)
-        case "all":
-          return accounts
-      }
-    }),
-  ),
+export const [useAccounts, getAccountsByCategory$] = bind(
+  (category: AccountCategory = "all-except-contacts") =>
+    accounts$.pipe(
+      map((accounts) => {
+        switch (category) {
+          case "portfolio":
+            return accounts.filter(isAccountPortfolio)
+          case "watched":
+            return accounts.filter((acc) => isAccountOfType(acc, "watch-only"))
+          case "owned":
+            return accounts.filter(isAccountOwned)
+          case "signet":
+            return accounts.filter((acc) => isAccountOfType(acc, "signet"))
+          case "all-except-contacts":
+            return accounts.filter(isAccountNotContact)
+          case "all":
+            return accounts
+        }
+      }),
+    ),
 )

--- a/packages/extension-core/src/domains/assetDiscovery/scanner.ts
+++ b/packages/extension-core/src/domains/assetDiscovery/scanner.ts
@@ -264,6 +264,78 @@ class AssetDiscoveryScanner {
     }
   }
 
+  /** modifies the scope of next scan if necessary */
+  private async getEffectiveCurrentScanScope(): Promise<AssetDiscoveryScanScope | null> {
+    const scope = await assetDiscoveryStore.get("currentScanScope")
+    if (!scope) return null
+
+    if (!scope.withApi) return scope
+
+    const foundTokenIds = await fetchMissingTokens(scope.addresses)
+
+    const [allTokens, evmNetworks, activeTokens, activeNetworks] = await Promise.all([
+      chaindataProvider.tokens(),
+      chaindataProvider.evmNetworksById(),
+      activeTokensStore.get(),
+      activeEvmNetworksStore.get(),
+    ])
+
+    const tokensMap = Object.fromEntries(allTokens.map((token) => [token.id, token]))
+
+    // add all networks that contain an asset that was discovered and whose enabled status is not set yet
+    // key idea: dont scan mainnet (8K tokens) unless a new token is found on it
+    const additionalNetworkIds: string[] = foundTokenIds
+      .map((tokenId) => tokensMap[tokenId])
+      .filter((token) => {
+        if (!token || token.noDiscovery) return false
+
+        switch (token.type) {
+          case "evm-erc20":
+            return activeTokens[token.id] === undefined
+          case "evm-native":
+            return (
+              activeNetworks[token.evmNetwork.id] === undefined ||
+              activeTokens[token.id] === undefined
+            )
+          default:
+            return false
+        }
+      })
+      .map((t) => {
+        log.debug("[AssetDiscovery] Forcing scan because of", t.id)
+        return t.evmNetwork?.id
+      })
+      .filter((id): id is string => !!id)
+
+    const networkIdsToScan = [...new Set([...scope.networkIds, ...additionalNetworkIds])]
+
+    const tokensToScan = allTokens
+      .filter(isEvmToken)
+      .filter((t) => networkIdsToScan.includes(t.evmNetwork?.id ?? ""))
+      .filter((token) => {
+        const evmNetwork = evmNetworks[token.evmNetwork?.id ?? ""]
+        if (!evmNetwork) return false
+        if (!evmNetwork.forceScan && (evmNetwork.isTestnet || token.isTestnet)) return false
+        if (token.coingeckoId && IGNORED_COINGECKO_IDS.includes(token.coingeckoId)) return false
+        if (token.noDiscovery) return false
+        // scan only if token has never been enabled or disabled
+        return activeTokens[token.id] === undefined
+      })
+
+    await assetDiscoveryStore.mutate((prev) => ({
+      ...prev,
+      currentScanScope: {
+        ...(prev.currentScanScope ?? { addresses: scope.addresses }),
+        networkIds: networkIdsToScan,
+        withApi: false, // dot not call api again if scan is stopped then resumed
+      },
+      currentScanTokensCount: tokensToScan.length,
+    }))
+
+    // refresh scope and return
+    return await assetDiscoveryStore.get("currentScanScope")
+  }
+
   private async executeNextScan(): Promise<void> {
     if (this.#isBusy) return
     this.#isBusy = true
@@ -273,16 +345,14 @@ class AssetDiscoveryScanner {
     try {
       await this.dequeue()
 
-      const scope = await assetDiscoveryStore.get("currentScanScope")
+      const scope = await this.getEffectiveCurrentScanScope()
       if (!scope) return
 
       log.debug("[AssetDiscovery] Scanner proceeding with scan", scope)
 
-      const foundTokenIds = scope.withApi ? await fetchMissingTokens(scope.addresses) : []
-
       const { currentScanCursors: cursors } = await assetDiscoveryStore.get()
 
-      const [allTokens, evmNetworks, activeTokens, activeNetworks] = await Promise.all([
+      const [allTokens, evmNetworks, activeTokens] = await Promise.all([
         chaindataProvider.tokens(),
         chaindataProvider.evmNetworksById(),
         activeTokensStore.get(),
@@ -291,36 +361,9 @@ class AssetDiscoveryScanner {
 
       const tokensMap = Object.fromEntries(allTokens.map((token) => [token.id, token]))
 
-      // add all networks that contain an asset that was discovered and whose enabled status is not set yet
-      // key idea: dont scan mainnet (8K tokens) unless a new token is found on it
-      const additionalNetworkIds: string[] = foundTokenIds
-        .map((tokenId) => tokensMap[tokenId])
-        .filter((token) => {
-          if (!token || token.noDiscovery) return false
-
-          switch (token.type) {
-            case "evm-erc20":
-              return activeTokens[token.id] === undefined
-            case "evm-native":
-              return (
-                activeNetworks[token.evmNetwork.id] === undefined ||
-                activeTokens[token.id] === undefined
-              )
-            default:
-              return false
-          }
-        })
-        .map((t) => {
-          log.debug("[AssetDiscovery] Forcing scan because of", t.id)
-          return t.evmNetwork?.id
-        })
-        .filter((id): id is string => !!id)
-
-      const networkIdsToScan = [...new Set([...scope.networkIds, ...additionalNetworkIds])]
-
       const tokensToScan = allTokens
         .filter(isEvmToken)
-        .filter((t) => networkIdsToScan.includes(t.evmNetwork?.id ?? ""))
+        .filter((t) => scope.networkIds.includes(t.evmNetwork?.id ?? ""))
         .filter((token) => {
           const evmNetwork = evmNetworks[token.evmNetwork?.id ?? ""]
           if (!evmNetwork) return false
@@ -330,16 +373,6 @@ class AssetDiscoveryScanner {
           // scan only if token has never been enabled or disabled
           return activeTokens[token.id] === undefined
         })
-
-      await assetDiscoveryStore.mutate((prev) => ({
-        ...prev,
-        currentScanScope: {
-          ...(prev.currentScanScope ?? { addresses: scope.addresses }),
-          networkIds: networkIdsToScan,
-          withApi: false, // dot not call api again if scan is stopped then resumed
-        },
-        currentScanTokensCount: tokensToScan.length,
-      }))
 
       const tokensByNetwork: Record<EvmNetworkId, Token[]> = groupBy(
         tokensToScan,
@@ -353,12 +386,13 @@ class AssetDiscoveryScanner {
         "[AssetDiscovery] Starting scan: %d tokens, %d total checks",
         totalTokens,
         totalChecks,
-        { networkIdsToScan },
+        { networkIds: scope.networkIds },
       )
 
       const subScopeChange = assetDiscoveryStore.observable
         .pipe(distinctUntilKeyChanged("currentScanScope", isEqual), skip(1))
         .subscribe(() => {
+          log.debug("[AssetDiscovery] Scan cancelled due to currentScanScope change")
           abortController.abort()
           subScopeChange.unsubscribe()
         })

--- a/packages/extension-core/src/domains/assetDiscovery/scanner.ts
+++ b/packages/extension-core/src/domains/assetDiscovery/scanner.ts
@@ -2,7 +2,7 @@ import PromisePool from "@supercharge/promise-pool"
 import { erc20Abi, erc20BalancesAggregatorAbi, EvmErc20Token } from "@talismn/balances"
 import { abiMulticall } from "@talismn/balances/src/modules/abis/multicall"
 import { EvmNetwork, EvmNetworkId, Token, TokenId, TokenList } from "@talismn/chaindata-provider"
-import { isAccountEthereum } from "@talismn/keyring"
+import { isAccountEthereum, isAccountNotContact } from "@talismn/keyring"
 import { isEthereumAddress, sleep, throwAfter } from "@talismn/util"
 import { DEBUG, log } from "extension-shared"
 import { isEqual, uniq } from "lodash"
@@ -77,7 +77,12 @@ class AssetDiscoveryScanner {
     // identify newly added accounts and scan those
     keyringStore.accounts$
       .pipe(
-        map((accounts) => accounts.map((account) => account.address).sort()),
+        map((accounts) =>
+          accounts
+            .filter(isAccountNotContact)
+            .map((account) => account.address)
+            .sort(),
+        ),
         distinct((addresses) => addresses.join("")),
       )
       .subscribe(async (allAddresses) => {
@@ -128,7 +133,7 @@ class AssetDiscoveryScanner {
 
             if (networkIds.length) {
               const accounts = await keyringStore.getAccounts()
-              const addresses = accounts.map((acc) => acc.address)
+              const addresses = accounts.filter(isAccountNotContact).map((acc) => acc.address)
 
               log.debug("[AssetDiscovery] New enabled networks detected, starting scan", {
                 addresses,
@@ -158,7 +163,7 @@ class AssetDiscoveryScanner {
       .subscribe(async () => {
         try {
           const accounts = await keyringStore.getAccounts()
-          const addresses = accounts.map((acc) => acc.address)
+          const addresses = accounts.filter(isAccountNotContact).map((acc) => acc.address)
           const networkIds = await getNetworkIdsToForceScan()
 
           if (!addresses.length || !networkIds.length) return
@@ -500,7 +505,10 @@ class AssetDiscoveryScanner {
 
     // addresses of all ethereum accounts
     const accounts = await keyringStore.getAccounts()
-    const addresses = accounts.filter(isAccountEthereum).map((acc) => acc.address)
+    const addresses = accounts
+      .filter(isAccountNotContact)
+      .filter(isAccountEthereum)
+      .map((acc) => acc.address)
 
     // all active evm networks
     const [evmNetworks, activeEvmNetworks] = await Promise.all([

--- a/packages/extension-core/src/domains/assetDiscovery/scanner.ts
+++ b/packages/extension-core/src/domains/assetDiscovery/scanner.ts
@@ -135,7 +135,8 @@ class AssetDiscoveryScanner {
                 networkIds,
               })
 
-              await this.startScan({ networkIds, addresses, withApi: true })
+              // `withApi: false` because api always scans all networks, we dont need to call it again
+              await this.startScan({ networkIds, addresses, withApi: false })
             }
           }
 

--- a/packages/extension-core/src/domains/assetDiscovery/scanner.ts
+++ b/packages/extension-core/src/domains/assetDiscovery/scanner.ts
@@ -240,15 +240,24 @@ class AssetDiscoveryScanner {
 
         await db.assetDiscovery.clear()
 
-        await assetDiscoveryStore.mutate((state): AssetDiscoveryScanState => {
-          const [next, ...others] = state.queue ?? []
+        await assetDiscoveryStore.mutate((prev): AssetDiscoveryScanState => {
+          // merge queue
+          const queue = prev.queue ?? []
+          const mergedScope: AssetDiscoveryScanScope = {
+            addresses: uniq(queue.map((s) => s.addresses).flat()),
+            networkIds: uniq(queue.map((s) => s.networkIds).flat()),
+            withApi: queue.some((s) => s.withApi),
+          }
+          const currentScanScope =
+            mergedScope.networkIds.length && mergedScope.addresses.length ? mergedScope : null
+
           return {
-            ...state,
-            currentScanScope: next ?? null,
+            ...prev,
+            currentScanScope,
             currentScanProgressPercent: 0,
             currentScanTokensCount: 0,
             currentScanCursors: {},
-            queue: others,
+            queue: [],
           }
         })
       }

--- a/packages/extension-core/src/domains/assetDiscovery/scanner.ts
+++ b/packages/extension-core/src/domains/assetDiscovery/scanner.ts
@@ -95,7 +95,7 @@ class AssetDiscoveryScanner {
                 networkIds,
               })
 
-              await this.startScan({ networkIds, addresses })
+              await this.startScan({ networkIds, addresses, withApi: true })
             }
           }
 
@@ -135,7 +135,7 @@ class AssetDiscoveryScanner {
                 networkIds,
               })
 
-              await this.startScan({ networkIds, addresses })
+              await this.startScan({ networkIds, addresses, withApi: true })
             }
           }
 
@@ -164,7 +164,7 @@ class AssetDiscoveryScanner {
 
           // on wallet unlock, scan networks with forceScan:true
           // this helps discovery during growth campagins, where users are incentivized to send tokens from CEXs
-          await this.startScan({ addresses, networkIds })
+          await this.startScan({ addresses, networkIds, withApi: true })
         } catch (err) {
           log.error("[AssetDiscovery] Failed to start scan on unlock", { err })
         }
@@ -192,7 +192,7 @@ class AssetDiscoveryScanner {
     // add to queue
     await assetDiscoveryStore.mutate((state) => ({
       ...state,
-      queue: [...(state.queue ?? []), { addresses, networkIds }],
+      queue: [...(state.queue ?? []), { ...scope, addresses, networkIds }],
     }))
 
     // for front end calls, dequeue as part of this promise to keep UI in sync
@@ -263,7 +263,7 @@ class AssetDiscoveryScanner {
 
       log.debug("[AssetDiscovery] Scanner proceeding with scan", scope)
 
-      const foundTokenIds = await fetchMissingTokens(scope.addresses)
+      const foundTokenIds = scope.withApi ? await fetchMissingTokens(scope.addresses) : []
 
       const { currentScanCursors: cursors } = await assetDiscoveryStore.get()
 
@@ -321,6 +321,7 @@ class AssetDiscoveryScanner {
         currentScanScope: {
           ...(prev.currentScanScope ?? { addresses: scope.addresses }),
           networkIds: networkIdsToScan,
+          withApi: false, // dot not call api again if scan is stopped then resumed
         },
         currentScanTokensCount: tokensToScan.length,
       }))
@@ -491,6 +492,7 @@ class AssetDiscoveryScanner {
     this.executeNextScan()
   }
 
+  /** Used bym migrations */
   public async startPendingScan(): Promise<void> {
     const isAssetDiscoveryScanPending = await appStore.get("isAssetDiscoveryScanPending")
     if (!isAssetDiscoveryScanPending) return
@@ -512,7 +514,7 @@ class AssetDiscoveryScanner {
     await appStore.set({ isAssetDiscoveryScanPending: false })
 
     // enqueue scan
-    await this.startScan({ networkIds, addresses })
+    await this.startScan({ networkIds, addresses, withApi: true })
   }
 
   private async enableDiscoveredTokens(): Promise<void> {

--- a/packages/extension-core/src/domains/assetDiscovery/types.ts
+++ b/packages/extension-core/src/domains/assetDiscovery/types.ts
@@ -11,6 +11,8 @@ export type DiscoveredBalance = {
 export type AssetDiscoveryScanScope = {
   networkIds: (EvmNetworkId | ChainId)[]
   addresses: Address[]
+  /** indicates whether aad api should be called at the begining of the scan */
+  withApi: boolean
 }
 
 export interface AssetDiscoveryMessages {

--- a/packages/extension-core/src/domains/keyring/exports.ts
+++ b/packages/extension-core/src/domains/keyring/exports.ts
@@ -12,6 +12,7 @@ export {
   isAccountLedgerPolkadotGeneric,
   isAccountLedgerPolkadotLegacy,
   isAccountBitcoin,
+  isAccountNotContact,
   getAccountGenesisHash,
   getAccountSignetUrl,
 } from "@talismn/keyring"

--- a/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
+++ b/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
@@ -92,6 +92,7 @@ export const watchEthereumTransaction = async (
           assetDiscoveryScanner.startScan({
             networkIds: [evmNetworkId],
             addresses: [unsigned.from],
+            withApi: false,
           })
       }
     } catch (err) {


### PR DESCRIPTION
- exclude contacts from scans
- call AD api only in 3 cases: unlock, add account, manual scans
- merge all pending scans into one
- update scan scope before scan starts to prevent it from aborting and restarting instantly

Bonus: changes the default filter for useAccounts() to exclude contacts.
This prevents contacts from appearing in copy address modal's accounts list, and some other glitches.
