### PR TITLE
fix: connected accounts fix bundle

### DIFF
--- a/apps/extension/src/ui/domains/Site/ConnectedAccountsPill.tsx
+++ b/apps/extension/src/ui/domains/Site/ConnectedAccountsPill.tsx
@@ -13,7 +13,7 @@ import { ConnectedSiteIndicator } from "./ConnectedSiteIndicator"
 export const ConnectedAccountsPill: FC = () => {
   const { t } = useTranslation()
   const currentSite = useCurrentSite()
-  const accounts = useAccounts()
+  const accounts = useAccounts("all")
   const authorisedSites = useAuthorisedSites()
   const site = useMemo(
     () => (currentSite?.id ? authorisedSites[currentSite?.id] : null),
@@ -74,10 +74,11 @@ export const ConnectedAccountsPill: FC = () => {
       >
         <div className="bg-grey-850 group-hover:bg-grey-800 flex h-full items-center gap-3 overflow-hidden rounded-full px-4">
           <ConnectedSiteIndicator status={count ? "connected" : "disconnected"} />
-          <div className="text-body truncate text-sm">{label}</div>
-          <div className="bg-grey-700 h-6 w-0.5 shrink-0"></div>
-          <div className="text-body-secondary truncate text-xs">{host}</div>
-          <div className="grow"></div>
+          <div className="flex grow items-center gap-3 truncate">
+            <div className="text-body max-w-[50%] shrink-0 truncate text-sm">{label}</div>
+            <div className="bg-grey-700 h-6 w-0.5 shrink-0"></div>
+            <div className="text-body-secondary grow text-left text-xs">{host}</div>
+          </div>
           <ChevronDownIcon className="shrink-0" />
         </div>
       </button>

--- a/apps/extension/src/ui/hooks/useAccountsForSite.ts
+++ b/apps/extension/src/ui/hooks/useAccountsForSite.ts
@@ -1,15 +1,24 @@
 import { AuthorizedSite } from "extension-core"
 import { isTalismanUrl } from "extension-shared"
+import { useMemo } from "react"
 
 import { useAccounts, useSettingValue } from "@ui/state"
 
 export const useAccountsForSite = (site: AuthorizedSite | string | null) => {
   const url = typeof site === "string" ? site : site?.url
-  const requestUrlIsTalisman = isTalismanUrl(url)
-  const isDevMode = useSettingValue("developerMode")
-  const allOrOwnedAccounts = useAccounts(requestUrlIsTalisman || isDevMode ? "all" : "owned")
-  const signetAccounts = useAccounts("signet")
+  const isTalismanApp = isTalismanUrl(url)
+  const developerMode = useSettingValue("developerMode")
 
-  // returns all if url is talisman, else return owned + signet accounts
-  return requestUrlIsTalisman ? allOrOwnedAccounts : [...allOrOwnedAccounts, ...signetAccounts]
+  const allAccounts = useAccounts("all")
+
+  return useMemo(
+    () =>
+      allAccounts.filter((a) => {
+        // same logic as in getPublicAccounts
+        if (developerMode) return true
+        if (isTalismanApp) return a.type !== "contact"
+        return !["watch-only", "contact"].includes(a.type)
+      }),
+    [allAccounts, developerMode, isTalismanApp],
+  )
 }

--- a/packages/extension-core/src/domains/accounts/helpers.ts
+++ b/packages/extension-core/src/domains/accounts/helpers.ts
@@ -84,7 +84,7 @@ export const filterAccountsByAddresses =
   }
 
 type GetPublicAccountsOptions = {
-  includeWatchedAccounts?: boolean
+  developerMode?: boolean
   includePortalOnlyInfo?: boolean
 }
 
@@ -92,12 +92,16 @@ export const getPublicAccounts = (
   accounts: Account[],
   filterFn: (accounts: Account[]) => Account[] = (accounts) => accounts,
   options: GetPublicAccountsOptions = {
-    includeWatchedAccounts: false,
+    developerMode: false,
     includePortalOnlyInfo: false,
   },
 ) =>
   filterFn(accounts)
-    .filter((a) => !!options.includeWatchedAccounts || !["watch-only", "contact"].includes(a.type))
+    .filter((a) => {
+      if (options.developerMode) return true
+      if (options.includePortalOnlyInfo) return a.type !== "contact"
+      return !["watch-only", "contact"].includes(a.type)
+    })
     .sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0)) // TODO apply catalog order ?
     .map((x) =>
       getPjsInjectedAccount(x, { includePortalOnlyInfo: !!options.includePortalOnlyInfo }),

--- a/packages/extension-core/src/domains/accounts/helpers.ts
+++ b/packages/extension-core/src/domains/accounts/helpers.ts
@@ -83,16 +83,25 @@ export const filterAccountsByAddresses =
       })
   }
 
+type GetPublicAccountsOptions = {
+  includeWatchedAccounts?: boolean
+  includePortalOnlyInfo?: boolean
+}
+
 export const getPublicAccounts = (
   accounts: Account[],
   filterFn: (accounts: Account[]) => Account[] = (accounts) => accounts,
-  options = { includeWatchedAccounts: false },
+  options: GetPublicAccountsOptions = {
+    includeWatchedAccounts: false,
+    includePortalOnlyInfo: false,
+  },
 ) =>
   filterFn(accounts)
-    .filter((a) => a.type !== "contact")
-    .filter((a) => options.includeWatchedAccounts || a.type !== "watch-only")
+    .filter((a) => !!options.includeWatchedAccounts || !["watch-only", "contact"].includes(a.type))
     .sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0)) // TODO apply catalog order ?
-    .map((x) => getPjsInjectedAccount(x, { includePortalOnlyInfo: options.includeWatchedAccounts }))
+    .map((x) =>
+      getPjsInjectedAccount(x, { includePortalOnlyInfo: !!options.includePortalOnlyInfo }),
+    )
 
 export const getDerivationPathForCurve = (curve: KeypairCurve, accountIndex: number) => {
   switch (curve) {

--- a/packages/extension-core/src/domains/ethereum/handler.tabs.ts
+++ b/packages/extension-core/src/domains/ethereum/handler.tabs.ts
@@ -170,7 +170,7 @@ export class EthTabsHandler extends TabsHandler {
       getPublicAccounts(
         await keyringStore.getAccounts(),
         filterAccountsByAddresses(site.ethAddresses),
-        { includeWatchedAccounts: await this.stores.settings.get("developerMode") },
+        { developerMode: await this.stores.settings.get("developerMode") },
       )
         .filter(({ type }) => type === "ethereum")
         // send as

--- a/packages/extension-core/src/domains/ethereum/handler.tabs.ts
+++ b/packages/extension-core/src/domains/ethereum/handler.tabs.ts
@@ -3,7 +3,7 @@ import { isEthereumAddress } from "@polkadot/util-crypto"
 import { CustomEvmErc20Token, evmErc20TokenId } from "@talismn/balances"
 import { githubUnknownTokenLogoUrl } from "@talismn/chaindata-provider"
 import { convertAddress, throwAfter } from "@talismn/util"
-import { DEFAULT_ETH_CHAIN_ID, log } from "extension-shared"
+import { DEFAULT_ETH_CHAIN_ID, isTalismanUrl, log } from "extension-shared"
 import i18next from "i18next"
 import {
   createClient,
@@ -170,7 +170,10 @@ export class EthTabsHandler extends TabsHandler {
       getPublicAccounts(
         await keyringStore.getAccounts(),
         filterAccountsByAddresses(site.ethAddresses),
-        { developerMode: await this.stores.settings.get("developerMode") },
+        {
+          developerMode: await this.stores.settings.get("developerMode"),
+          includePortalOnlyInfo: isTalismanUrl(site.url),
+        },
       )
         .filter(({ type }) => type === "ethereum")
         // send as

--- a/packages/extension-core/src/handlers/Tabs.ts
+++ b/packages/extension-core/src/handlers/Tabs.ts
@@ -105,7 +105,7 @@ export default class Tabs extends TabsHandler {
     return getPublicAccounts(
       await keyringStore.getAccounts(),
       filterAccountsByAddresses(site.addresses, anyType),
-      { includeWatchedAccounts: developerMode, includePortalOnlyInfo: isTalismanUrl(site.url) },
+      { developerMode, includePortalOnlyInfo: isTalismanUrl(site.url) },
     )
   }
 
@@ -137,7 +137,7 @@ export default class Tabs extends TabsHandler {
         const site = sites[siteId]
         if (!site || !site.addresses) return []
 
-        return this.#getFilteredAccounts(site, { anyType: true }, settings.developerMode)
+        return await this.#getFilteredAccounts(site, { anyType: true }, settings.developerMode)
       },
     )
   }

--- a/packages/extension-core/src/handlers/Tabs.ts
+++ b/packages/extension-core/src/handlers/Tabs.ts
@@ -105,7 +105,7 @@ export default class Tabs extends TabsHandler {
     return getPublicAccounts(
       await keyringStore.getAccounts(),
       filterAccountsByAddresses(site.addresses, anyType),
-      { includeWatchedAccounts: developerMode || isTalismanUrl(site.url) },
+      { includeWatchedAccounts: developerMode, includePortalOnlyInfo: isTalismanUrl(site.url) },
     )
   }
 


### PR DESCRIPTION
- fixes the connected accounts pill so that the account name can use up to 50% (it was truncating after 1 character on websites with a long url)
- dev mode can now inject both watched-only and contacts properly (contacts were listed in the picker but wouldnt inject)
- for logic that injects account there is now a clear separation between dev mode (allow readonly & contacts) and portal infos => dev mode wont leak if an account is read-only or not.