### PR TITLE
fix: do not log webapp rpc calls

### DIFF
--- a/packages/extension-core/src/handlers/index.ts
+++ b/packages/extension-core/src/handlers/index.ts
@@ -38,6 +38,9 @@ const IGNORED_LOG_MESSAGES: MessageTypes[] = [
   "pri(keepalive)",
   "pri(keepunlocked)",
   "pri(app.analyticsCapture)",
+  "pub(talisman.rpc.byGenesisHash.subscribe)",
+  "pub(talisman.rpc.byGenesisHash.unsubscribe)",
+  "pub(talisman.rpc.byGenesisHash.send)",
 ]
 
 const formatFrom = (source: string) => {

--- a/packages/extension-core/src/handlers/index.ts
+++ b/packages/extension-core/src/handlers/index.ts
@@ -35,6 +35,7 @@ const OBFUSCATED_PAYLOAD = "#OBFUSCATED#"
 
 // ignore the ones that generate too much spam, making it hard to debug other things
 const IGNORED_LOG_MESSAGES: MessageTypes[] = [
+  "pub(ping)",
   "pri(keepalive)",
   "pri(keepunlocked)",
   "pri(app.analyticsCapture)",


### PR DESCRIPTION
webapp is using wallet to relay all its rpc calls.
all those calls were being logged, making it hard to use the log.
those wont be logged anymore.