### PR TITLE
feat: vs_currency tao in AssetPriceChart

### DIFF
--- a/apps/extension/src/ui/domains/Asset/AssetPriceChart.tsx
+++ b/apps/extension/src/ui/domains/Asset/AssetPriceChart.tsx
@@ -221,17 +221,36 @@ const useMarketChart = (
       if (!coingeckoId) return null
       const config = CHART_TIMESPANS[timespan]
 
-      const query = new URLSearchParams({
-        vs_currency: currency,
-        days: config.days,
-      })
+      const getMarketChart = async (
+        coingeckoId: string | null,
+        vs_currency: TokenRateCurrency,
+        days: string,
+      ): Promise<{ prices: [number, number][] }> => {
+        const query = new URLSearchParams({ vs_currency, days })
+        const url = `/api/v3/coins/${coingeckoId}/market_chart?${query.toString()}`
+        const result = await fetchFromCoingecko(url)
+        if (!result.ok) throw new Error("Failed to fetch market chart for " + coingeckoId)
+        return { prices: (await result.json())?.prices }
+      }
 
-      const result = await fetchFromCoingecko(
-        `/api/v3/coins/${coingeckoId}/market_chart?${query.toString()}`,
-      )
-      if (!result.ok) throw new Error("Failed to fetch market chart for " + coingeckoId)
+      // We support showing balances in TAO just like we support BTC/ETH/DOT, but coingecko doesn't support TAO as a vs_currency rate.
+      // We can macgyver our own TOKEN<>TAO rate by combining the TOKEN<>USD data with the TAO<>USD data.
+      if (currency === "tao") {
+        const taoUsdChart = await getMarketChart("bittensor", "usd", config.days)
+        const tokenUsdChart = await getMarketChart(coingeckoId, "usd", config.days)
 
-      return result.json() as Promise<{ prices: [number, number][] }>
+        const tokenTaoChart = tokenUsdChart.prices.map(
+          ([timestamp, price], index): [number, number] => [
+            timestamp,
+            price / (taoUsdChart.prices[index]?.[1] ?? 1),
+          ],
+        )
+
+        return { prices: tokenTaoChart }
+      }
+
+      // for any other currency, just return the result of getMarketChart
+      return getMarketChart(coingeckoId, currency, config.days)
     },
     select: (data) => {
       switch (timespan) {


### PR DESCRIPTION
Adds TAO as a vs_currency to asset price charts.

TAO vs USD
<img width="987" alt="Screenshot 2025-05-19 at 17 35 50" src="https://github.com/user-attachments/assets/f57ab363-8565-4a5c-a0de-ba1d1fb1873d" />

DOT vs USD
<img width="956" alt="Screenshot 2025-05-19 at 17 35 57" src="https://github.com/user-attachments/assets/186d643d-741a-4d9f-8789-b2e442ed839c" />

DOT vs TAO (created by combining the data from the above two charts)
<img width="961" alt="Screenshot 2025-05-19 at 17 36 12" src="https://github.com/user-attachments/assets/bce957ca-455e-460a-83a1-f85bf17630c6" />

You can see in the middle that as TAO rose in price relative to USD while DOT maintained its current price with USD, DOT lowered in price relative to TAO.