### PR TITLE
feat: bump polkadot in copy address format picker

### DIFF
--- a/apps/extension/src/ui/domains/CopyAddress/CopyAddressChainForm.tsx
+++ b/apps/extension/src/ui/domains/CopyAddress/CopyAddressChainForm.tsx
@@ -177,6 +177,9 @@ export const CopyAddressChainForm = () => {
         (c) => !isAccountLedgerPolkadotGeneric(account) || c.hasCheckMetadataHash,
       )
       .sort((a, b) => {
+        if (a.id === "polkadot") return -1
+        if (b.id === "polkadot") return 1
+
         if (balancesPerNetwork[a.id] || balancesPerNetwork[b.id])
           return (balancesPerNetwork[b.id] ?? 0) - (balancesPerNetwork[a.id] ?? 0)
         return (a.name ?? "").localeCompare(b.name ?? "")


### PR DESCRIPTION
This is a follow-up on unified address format.
If Polkadot is amongst the valid results, it will be displayed as the 2nd entry, just after the substrate generic format

![image](https://github.com/user-attachments/assets/d403bd1a-bf1a-4e1c-a9f0-62ae1ac87f8d)
