### PR TITLE
feat: yeet show testnets checkboxes

### DIFF
--- a/apps/extension/src/@talisman/components/TogglePill.tsx
+++ b/apps/extension/src/@talisman/components/TogglePill.tsx
@@ -33,6 +33,7 @@ type TogglePillProps = {
   defaultChecked?: boolean
   onChange: (checked: boolean) => void
   className?: string
+  disabled?: boolean
 }
 
 export const TogglePill: FC<TogglePillProps> = ({
@@ -41,6 +42,7 @@ export const TogglePill: FC<TogglePillProps> = ({
   defaultChecked,
   onChange,
   className,
+  disabled,
 }) => {
   const [isChecked, setIsChecked] = useState(() => checked ?? defaultChecked ?? false)
 
@@ -65,6 +67,7 @@ export const TogglePill: FC<TogglePillProps> = ({
       onClick={handleClick}
       size="xs"
       className={className}
+      disabled={disabled}
     >
       {label}
     </PillButton>

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/ChainsList.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/ChainsList.tsx
@@ -21,15 +21,14 @@ import {
 import { ANALYTICS_PAGE } from "./analytics"
 import { CustomPill, TestnetPill } from "./Pills"
 
-export const ChainsList: FC<{ activeOnly: boolean; showTestnets: boolean; search?: string }> = ({
+export const ChainsList: FC<{ activeOnly: boolean; search?: string }> = ({
   activeOnly,
-  showTestnets,
   search,
 }) => {
   const { t } = useTranslation("admin")
   const { recommendedNetworks } = useRemoteConfig()
   const networksActiveState = useActiveChainsState()
-  const chains = useChains({ activeOnly: false, includeTestnets: showTestnets })
+  const chains = useChains()
 
   const allSortedNetworks = useMemo(() => {
     return chains.concat().sort((n1, n2) => {
@@ -41,6 +40,9 @@ export const ChainsList: FC<{ activeOnly: boolean; showTestnets: boolean; search
         if (idx2 === -1) return -1
         return idx1 - idx2
       }
+
+      if (n1.isTestnet && !n2.isTestnet) return 1
+      if (!n1.isTestnet && n2.isTestnet) return -1
 
       return (n1.name ?? "").localeCompare(n2.name ?? "")
     })
@@ -136,16 +138,10 @@ export const ChainsList: FC<{ activeOnly: boolean; showTestnets: boolean; search
           <ResetAllNetworksModalContent onClose={ocResetAllModal.close} />
         </Modal>
         <Modal isOpen={ocActivateAllModal.isOpen} onDismiss={ocActivateAllModal.close}>
-          <ActivateNetworksModalContent
-            showTestnets={showTestnets}
-            onClose={ocActivateAllModal.close}
-          />
+          <ActivateNetworksModalContent onClose={ocActivateAllModal.close} />
         </Modal>
         <Modal isOpen={ocDeactivateAllModal.isOpen} onDismiss={ocDeactivateAllModal.close}>
-          <DeactivateNetworksModalContent
-            showTestnets={showTestnets}
-            onClose={ocDeactivateAllModal.close}
-          />
+          <DeactivateNetworksModalContent onClose={ocDeactivateAllModal.close} />
         </Modal>
       </div>
       <VirtualizedRows networks={sortedChains} activeNetworksState={networksActiveState} />
@@ -267,21 +263,19 @@ const ResetAllNetworksModalContent: FC<{
 type ActivateMode = "recommended" | "all"
 
 const ActivateNetworksModalContent: FC<{
-  showTestnets: boolean
   onClose: () => void
-}> = ({ showTestnets, onClose }) => {
+}> = ({ onClose }) => {
   const { t } = useTranslation("admin")
 
-  const networks = useChains({ activeOnly: false, includeTestnets: showTestnets })
+  const networks = useChains()
   const activeNetworks = useActiveChainsState()
 
   const recommendedNetworkIds = useMemo(() => {
-    // all networks that are either default or have an enabled token
     return networks
-      .filter((n) => n.isDefault && (!n.isTestnet || showTestnets))
+      .filter((n) => n.isDefault)
       .filter((n) => !isChainActive(n, activeNetworks))
       .map((n) => n.id)
-  }, [activeNetworks, networks, showTestnets])
+  }, [activeNetworks, networks])
 
   const allNetworkIds = useMemo(() => {
     return networks.filter((n) => !isChainActive(n, activeNetworks)).map((n) => n.id)
@@ -345,13 +339,12 @@ const ActivateNetworksModalContent: FC<{
 type DeactivateMode = "all" | "unused"
 
 const DeactivateNetworksModalContent: FC<{
-  showTestnets: boolean
   onClose: () => void
-}> = ({ showTestnets, onClose }) => {
+}> = ({ onClose }) => {
   const { t } = useTranslation("admin")
   const isBalancesInitializing = useIsBalanceInitializing()
   const balances = useBalances("all")
-  const chains = useChains({ activeOnly: true, includeTestnets: showTestnets })
+  const chains = useChains({ activeOnly: true, includeTestnets: true })
 
   const [activeChainIds, unusedChainIds] = useMemo(() => {
     const networkIds = chains.map((chain) => chain.id)

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/ChainsList.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/ChainsList.tsx
@@ -52,7 +52,7 @@ export const ChainsList: FC<{ activeOnly: boolean; search?: string }> = ({
     const lowerSearch = search?.toLowerCase() ?? ""
 
     const filter = (network: Chain) => {
-      if (activeOnly && !isChainActive(network, networksActiveState)) return false
+      if (!search && activeOnly && !isChainActive(network, networksActiveState)) return false
 
       return (
         network.name?.toLowerCase().includes(lowerSearch) ||

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/EvmNetworksList.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/EvmNetworksList.tsx
@@ -28,13 +28,12 @@ import { CustomPill, TestnetPill } from "./Pills"
 
 export const EvmNetworksList: FC<{
   activeOnly: boolean
-  showTestnets: boolean
   search?: string
-}> = ({ showTestnets, activeOnly, search }) => {
+}> = ({ activeOnly, search }) => {
   const { t } = useTranslation("admin")
 
   const { recommendedNetworks } = useRemoteConfig()
-  const evmNetworks = useEvmNetworks({ activeOnly: false, includeTestnets: showTestnets })
+  const evmNetworks = useEvmNetworks()
 
   const allSortedNetworks = useMemo(() => {
     return evmNetworks.concat().sort((n1, n2) => {
@@ -46,6 +45,9 @@ export const EvmNetworksList: FC<{
         if (idx2 === -1) return -1
         return idx1 - idx2
       }
+
+      if (n1.isTestnet && !n2.isTestnet) return 1
+      if (!n1.isTestnet && n2.isTestnet) return -1
 
       return (n1.name ?? "").localeCompare(n2.name ?? "")
     })
@@ -135,16 +137,10 @@ export const EvmNetworksList: FC<{
           <ResetAllNetworksModalContent onClose={ocResetAllModal.close} />
         </Modal>
         <Modal isOpen={ocActivateAllModal.isOpen} onDismiss={ocActivateAllModal.close}>
-          <ActivateNetworksModalContent
-            showTestnets={showTestnets}
-            onClose={ocActivateAllModal.close}
-          />
+          <ActivateNetworksModalContent onClose={ocActivateAllModal.close} />
         </Modal>
         <Modal isOpen={ocDeactivateAllModal.isOpen} onDismiss={ocDeactivateAllModal.close}>
-          <DeactivateNetworksModalContent
-            showTestnets={showTestnets}
-            onClose={ocDeactivateAllModal.close}
-          />
+          <DeactivateNetworksModalContent onClose={ocDeactivateAllModal.close} />
         </Modal>
       </div>
       <VirtualizedRows networks={sortedNetworks} activeNetworksState={networksActiveState} />
@@ -269,21 +265,19 @@ const ResetAllNetworksModalContent: FC<{
 type ActivateMode = "recommended" | "all"
 
 const ActivateNetworksModalContent: FC<{
-  showTestnets: boolean
   onClose: () => void
-}> = ({ showTestnets, onClose }) => {
+}> = ({ onClose }) => {
   const { t } = useTranslation("admin")
 
-  const evmNetworks = useEvmNetworks({ activeOnly: false, includeTestnets: showTestnets })
+  const evmNetworks = useEvmNetworks()
   const activeNetworks = useActiveEvmNetworksState()
 
   const recommendedNetworkIds = useMemo(() => {
-    // all networks that are either default or have an enabled token
     return evmNetworks
-      .filter((n) => n.isDefault && (!n.isTestnet || showTestnets))
+      .filter((n) => n.isDefault)
       .filter((n) => !isEvmNetworkActive(n, activeNetworks))
       .map((n) => n.id)
-  }, [activeNetworks, evmNetworks, showTestnets])
+  }, [activeNetworks, evmNetworks])
 
   const allNetworkIds = useMemo(() => {
     return evmNetworks.filter((n) => !isEvmNetworkActive(n, activeNetworks)).map((n) => n.id)
@@ -347,14 +341,13 @@ const ActivateNetworksModalContent: FC<{
 type DeactivateMode = "all" | "unused"
 
 const DeactivateNetworksModalContent: FC<{
-  showTestnets: boolean
   onClose: () => void
-}> = ({ showTestnets, onClose }) => {
+}> = ({ onClose }) => {
   const { t } = useTranslation("admin")
   const isBalancesInitializing = useIsBalanceInitializing()
 
   const balances = useBalances("all")
-  const evmNetworks = useEvmNetworks({ activeOnly: true, includeTestnets: showTestnets })
+  const evmNetworks = useEvmNetworks({ activeOnly: true, includeTestnets: true })
 
   const [activeEvmNetworkIds, unusedEvmNetworkIds] = useMemo(() => {
     const networkIds = evmNetworks.map((chain) => chain.id)

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/EvmNetworksList.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/EvmNetworksList.tsx
@@ -59,7 +59,8 @@ export const EvmNetworksList: FC<{
     const lowerSearch = search?.toLowerCase() ?? ""
 
     const filter = (network: SimpleEvmNetwork) => {
-      if (activeOnly && !isEvmNetworkActive(network, networksActiveState)) return false
+      if (!lowerSearch && activeOnly && !isEvmNetworkActive(network, networksActiveState))
+        return false
 
       return (
         network.name?.toLowerCase().includes(lowerSearch) ||

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/NetworksPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/NetworksPage.tsx
@@ -97,6 +97,7 @@ const Content = () => {
           label={t("Active only")}
           checked={activeOnly}
           onChange={() => setActiveOnly((prev) => !prev)}
+          disabled={!!search}
         />
       </div>
       <Spacer small />

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/NetworksPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/NetworksPage.tsx
@@ -63,7 +63,6 @@ const Content = () => {
 
   const [search, setSearch] = useState("")
   const [activeOnly, setActiveOnly] = useState(false)
-  const [showTestnets, setShowTestnets] = useState(false)
 
   return (
     <>
@@ -99,11 +98,6 @@ const Content = () => {
           checked={activeOnly}
           onChange={() => setActiveOnly((prev) => !prev)}
         />
-        <TogglePill
-          label={t("Show testnets")}
-          checked={showTestnets}
-          onChange={() => setShowTestnets((prev) => !prev)}
-        />
       </div>
       <Spacer small />
       <div className="flex gap-4">
@@ -111,9 +105,9 @@ const Content = () => {
       </div>
       <Spacer small />
       {networksType === "polkadot" ? (
-        <ChainsList activeOnly={activeOnly} search={search} showTestnets={showTestnets} />
+        <ChainsList activeOnly={activeOnly} search={search} />
       ) : (
-        <EvmNetworksList activeOnly={activeOnly} search={search} showTestnets={showTestnets} />
+        <EvmNetworksList activeOnly={activeOnly} search={search} />
       )}
     </>
   )

--- a/apps/extension/src/ui/apps/dashboard/routes/Tokens/TokensPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Tokens/TokensPage.tsx
@@ -271,10 +271,9 @@ const Content = () => {
   useAnalyticsPageView(ANALYTICS_PAGE)
   const navigate = useNavigate()
   const location = useLocation()
-  const [includeTestnets, setIncludeTestnets] = useState(false)
-  const evmNetworks = useEvmNetworks({ activeOnly: true, includeTestnets })
-  const evmNetworksMap = useEvmNetworksMap({ activeOnly: true, includeTestnets })
-  const tokens = useTokens({ activeOnly: false, includeTestnets })
+  const evmNetworks = useEvmNetworks({ activeOnly: true, includeTestnets: true })
+  const evmNetworksMap = useEvmNetworksMap({ activeOnly: true, includeTestnets: true })
+  const tokens = useTokens()
   const activeTokens = useActiveTokensState()
   const [isActiveOnly, setIsActiveOnly] = useState(true)
   const [isCustomOnly, setIsCustomOnly] = useState(false)
@@ -283,11 +282,10 @@ const Content = () => {
   const toggleIsActiveOnly = useCallback(() => setIsActiveOnly((prev) => !prev), [])
   const toggleIsCustomOnly = useCallback(() => setIsCustomOnly((prev) => !prev), [])
   const toggleIsHidePools = useCallback(() => setIsHidePools((prev) => !prev), [])
-  const toggleShowTestnets = useCallback(() => setIncludeTestnets((prev) => !prev), [])
 
   const networkOptions = useMemo(() => {
     return [
-      { id: "ALL", name: "All networks" } as SimpleEvmNetwork,
+      { id: "ALL", name: "All active networks" } as SimpleEvmNetwork,
       ...evmNetworks.concat().sort((n1, n2) => n1.name?.localeCompare(n2.name ?? "") ?? 0),
     ]
   }, [evmNetworks])
@@ -304,9 +302,11 @@ const Content = () => {
     const result = tokens
       .filter((t) => isErc20Token(t) || isUniswapV2Token(t))
       .filter((t) => !!t.evmNetwork?.id && evmNetworksMap[t.evmNetwork.id])
-      .filter((t) => !isActiveOnly || isTokenActive(t, activeTokens))
-      .filter((t) => !isCustomOnly || isCustomErc20Token(t) || isCustomUniswapV2Token(t))
-      .filter((t) => !isHidePools || !isUniswapV2Token(t))
+      .filter((t) => !!search || !isActiveOnly || isTokenActive(t, activeTokens))
+      .filter(
+        (t) => !!search || !isCustomOnly || isCustomErc20Token(t) || isCustomUniswapV2Token(t),
+      )
+      .filter((t) => !!search || !isHidePools || !isUniswapV2Token(t))
       .filter((t) => evmNetworkId === "ALL" || t.evmNetwork?.id === evmNetworkId)
 
     return sortBy(
@@ -314,7 +314,16 @@ const Content = () => {
       (t) => evmNetworksMap[t.evmNetwork!.id]?.name,
       (t) => t.symbol,
     )
-  }, [activeTokens, evmNetworkId, evmNetworksMap, isActiveOnly, isCustomOnly, isHidePools, tokens])
+  }, [
+    activeTokens,
+    evmNetworkId,
+    evmNetworksMap,
+    isActiveOnly,
+    isCustomOnly,
+    isHidePools,
+    search,
+    tokens,
+  ])
 
   const displayTokens = useMemo(() => {
     const lowerSearch = search.trim().toLowerCase()
@@ -383,13 +392,23 @@ const Content = () => {
             {t("Reset active states")}
           </PillButton>
         </div>
-        <TogglePill label={t("Active only")} checked={isActiveOnly} onChange={toggleIsActiveOnly} />
-        <TogglePill label={t("Custom only")} checked={isCustomOnly} onChange={toggleIsCustomOnly} />
-        <TogglePill label={t("Enable pools")} checked={!isHidePools} onChange={toggleIsHidePools} />
         <TogglePill
-          label={t("Show testnets")}
-          checked={includeTestnets}
-          onChange={toggleShowTestnets}
+          label={t("Active only")}
+          checked={isActiveOnly}
+          onChange={toggleIsActiveOnly}
+          disabled={!!search}
+        />
+        <TogglePill
+          label={t("Custom only")}
+          checked={isCustomOnly}
+          onChange={toggleIsCustomOnly}
+          disabled={!!search}
+        />
+        <TogglePill
+          label={t("Enable pools")}
+          checked={!isHidePools}
+          onChange={toggleIsHidePools}
+          disabled={!!search}
         />
       </div>
       <Spacer />

--- a/apps/extension/src/ui/domains/Ethereum/EvmNetworkSelectDrawer.tsx
+++ b/apps/extension/src/ui/domains/Ethereum/EvmNetworkSelectDrawer.tsx
@@ -87,7 +87,7 @@ const DrawerContent: FC<{ onClose: () => void }> = ({ onClose }) => {
   return (
     <div className="flex flex-col overflow-hidden">
       <div className="px-12">
-        <div className="font-bold">{t("Select Network for this site")}</div>
+        <div className="font-bold">{t("Select network for this site")}</div>
 
         <div className="my-8">
           <SearchInput

--- a/apps/extension/src/ui/domains/Ethereum/EvmNetworkSelectDrawer.tsx
+++ b/apps/extension/src/ui/domains/Ethereum/EvmNetworkSelectDrawer.tsx
@@ -4,7 +4,7 @@ import { activeEvmNetworksStore, isEvmNetworkActive, SimpleEvmNetwork } from "ex
 import { FC, useCallback, useMemo, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useIntersection } from "react-use"
-import { Checkbox, Drawer, IconButton } from "talisman-ui"
+import { Drawer, IconButton } from "talisman-ui"
 
 import { AppPill } from "@talisman/components/AppPill"
 import { ScrollContainer } from "@talisman/components/ScrollContainer"
@@ -21,21 +21,6 @@ import {
 
 import { NetworkLogo } from "./NetworkLogo"
 
-const searchNetworks = (
-  networks: SimpleEvmNetwork[],
-  currentNetworkId: string | undefined,
-  search: string,
-) => {
-  const lowerSearch = search.toLowerCase()
-  return networks
-    .filter((n) => n.name?.toLowerCase().includes(lowerSearch))
-    .sort((n1, n2) => {
-      if (n1.id === currentNetworkId) return -1
-      if (n2.id === currentNetworkId) return 1
-      return (n1.name ?? "").localeCompare(n2.name ?? "")
-    })
-}
-
 const DrawerContent: FC<{ onClose: () => void }> = ({ onClose }) => {
   const { t } = useTranslation()
   const currentSite = useCurrentSite()
@@ -47,37 +32,41 @@ const DrawerContent: FC<{ onClose: () => void }> = ({ onClose }) => {
   // persist initial setting to prevent reordering when changing networks
   const [initialNetworkId] = useState(() => site?.ethChainId?.toString())
   const currentNetwork = useEvmNetwork(initialNetworkId)
-  const [isTestnet] = useState(() => !!currentNetwork?.isTestnet)
-  const [settingUseTestnets, setUseTestnets] = useState(isTestnet)
 
-  // show testnets only if initial network was a testnet when opening the drawer, or if testnets are enabled in settings
-  const showTestnets = useMemo(
-    () => isTestnet || settingUseTestnets,
-    [isTestnet, settingUseTestnets],
-  )
-
-  const evmNetworks = useEvmNetworks({ activeOnly: false, includeTestnets: showTestnets })
+  const evmNetworks = useEvmNetworks()
   const activeEvmNetworksState = useActiveEvmNetworksState()
 
   const [allActiveEvmNetworks, allInactiveEvmNetworks] = useMemo(() => {
-    return evmNetworks.reduce(
-      (acc, network) => {
-        const arr = isEvmNetworkActive(network, activeEvmNetworksState) ? acc[0] : acc[1]
-        arr.push(network)
-        return acc
-      },
-      [[] as SimpleEvmNetwork[], [] as SimpleEvmNetwork[]],
-    )
-  }, [activeEvmNetworksState, evmNetworks])
+    return evmNetworks
+      .concat()
+      .sort((n1, n2) => {
+        if (n1.id === currentNetwork?.id) return -1
+        if (n2.id === currentNetwork?.id) return 1
+
+        if (n1.isTestnet && !n2.isTestnet) return 1
+        if (!n1.isTestnet && n2.isTestnet) return -1
+
+        return (n1.name ?? "").localeCompare(n2.name ?? "")
+      })
+      .reduce(
+        (acc, network) => {
+          const arr = isEvmNetworkActive(network, activeEvmNetworksState) ? acc[0] : acc[1]
+          arr.push(network)
+          return acc
+        },
+        [[] as SimpleEvmNetwork[], [] as SimpleEvmNetwork[]],
+      )
+  }, [activeEvmNetworksState, currentNetwork?.id, evmNetworks])
 
   const [search, setSearch] = useDebouncedState("", 150)
 
   const [activeEvmNetworks, inactiveEvmNetworks] = useMemo(() => {
+    const lowerSearch = search.toLowerCase()
     return [
-      searchNetworks(allActiveEvmNetworks, currentNetwork?.id, search),
-      searchNetworks(allInactiveEvmNetworks, currentNetwork?.id, search),
+      allActiveEvmNetworks.filter((n) => n.name?.toLowerCase().includes(lowerSearch)),
+      allInactiveEvmNetworks.filter((n) => n.name?.toLowerCase().includes(lowerSearch)),
     ]
-  }, [allActiveEvmNetworks, allInactiveEvmNetworks, currentNetwork?.id, search])
+  }, [allActiveEvmNetworks, allInactiveEvmNetworks, search])
 
   const handleNetworkClick = useCallback(
     async (id: string) => {
@@ -98,18 +87,8 @@ const DrawerContent: FC<{ onClose: () => void }> = ({ onClose }) => {
   return (
     <div className="flex flex-col overflow-hidden">
       <div className="px-12">
-        <div className="font-bold">{t("Select Network")}</div>
-        <div className="mt-8 flex w-full items-center justify-between">
-          <div className="text-body-secondary text-sm">{t("Select EVM network for this site")}</div>
-          <Checkbox
-            className={classNames("text-xs", isTestnet && "opacity-50")}
-            checked={showTestnets}
-            disabled={isTestnet}
-            onChange={(e) => setUseTestnets(e.target.checked)}
-          >
-            <span className="text-body-secondary">{t("Enable testnets")}</span>
-          </Checkbox>
-        </div>
+        <div className="font-bold">{t("Select Network for this site")}</div>
+
         <div className="my-8">
           <SearchInput
             small={false}


### PR DESCRIPTION
- removes "show testnets" checkboxs from network selector, networks list pages, and tokens list page
- changes the "All networks" label to "All active networks" in the tokens list page
- disables filters while a search is active, on both tokens and networks pages