### PR TITLE
feat: f**k google translate

### DIFF
--- a/apps/extension/src/template.dashboard.html
+++ b/apps/extension/src/template.dashboard.html
@@ -9,6 +9,7 @@
     <link rel="apple-touch-icon" href="./logo192.png" />
     <link rel="manifest" href="./manifest.json" />
     <title><%= htmlWebpackPlugin.options.title || 'Talisman'%></title>
+    <meta name="google" content="notranslate" />
     <style>
       html,
       body {
@@ -18,7 +19,7 @@
     </style>
   </head>
 
-  <body>
+  <body class="notranslate">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root" />
   </body>

--- a/apps/extension/src/template.onboarding.html
+++ b/apps/extension/src/template.onboarding.html
@@ -9,6 +9,7 @@
     <link rel="apple-touch-icon" href="./logo192.png" />
     <link rel="manifest" href="./manifest.json" />
     <title><%= htmlWebpackPlugin.options.title || 'Talisman'%></title>
+    <meta name="google" content="notranslate" />
     <style>
       html {
         /* prevents bg flickering on page load */
@@ -17,7 +18,7 @@
     </style>
   </head>
 
-  <body>
+  <body class="notranslate">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root" />
   </body>

--- a/apps/extension/src/template.popup.html
+++ b/apps/extension/src/template.popup.html
@@ -9,6 +9,7 @@
     <link rel="apple-touch-icon" href="./logo192.png" />
     <link rel="manifest" href="./manifest.json" />
     <title><%= htmlWebpackPlugin.options.title || 'Talisman'%></title>
+    <meta name="google" content="notranslate" />
     <style>
       html,
       body {
@@ -42,7 +43,7 @@
     </style>
   </head>
 
-  <body>
+  <body class="notranslate">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root" />
   </body>

--- a/apps/extension/src/template.support.html
+++ b/apps/extension/src/template.support.html
@@ -9,6 +9,7 @@
     <link rel="apple-touch-icon" href="./logo192.png" />
     <link rel="manifest" href="./manifest.json" />
     <title><%= htmlWebpackPlugin.options.title || 'Talisman'%></title>
+    <meta name="google" content="notranslate" />
     <style>
       html,
       body {
@@ -18,7 +19,7 @@
     </style>
   </head>
 
-  <body>
+  <body class="notranslate">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root" />
   </body>


### PR DESCRIPTION
- Fixes #2012
- Fixes #1904
- Fixes #1145

Disables google translate all around Talisman, which causes crashes

note: cant disable it entirely, user will still be able to highlight => right-click => translate words for it to translate. 
but it wont automatically translate the whole page anymore