### PR TITLE
feat: dry runs in send funds

### DIFF
--- a/apps/extension/src/ui/domains/SendFunds/useSendFunds.ts
+++ b/apps/extension/src/ui/domains/SendFunds/useSendFunds.ts
@@ -685,6 +685,10 @@ const useSendFundsProvider = () => {
     setSendErrorMessage(undefined)
   }, [location])
 
+  useEffect(() => {
+    if (dryRun) log.debug("Dry run result", dryRun)
+  }, [dryRun])
+
   return {
     from,
     to,

--- a/apps/extension/src/ui/domains/SendFunds/useSendFunds.ts
+++ b/apps/extension/src/ui/domains/SendFunds/useSendFunds.ts
@@ -22,6 +22,7 @@ import { TransactionRequest } from "viem"
 import { provideContext } from "@talisman/util/provideContext"
 import { api } from "@ui/api"
 import { useSendFundsWizard } from "@ui/apps/popup/pages/SendFunds/context"
+import { useSubstrateDryRun } from "@ui/hooks/useSubstrateDryRun"
 import { useTip } from "@ui/hooks/useTip"
 import {
   useAccountByAddress,
@@ -414,6 +415,8 @@ const useSendFundsProvider = () => {
 
   const isSendingEnough = useIsSendingEnough(recipientBalance, token, transfer)
 
+  const { data: dryRun, isLoading: isLoadingDryRun } = useSubstrateDryRun(subTransaction?.unsigned)
+
   const { isValid, error, errorDetails } = useMemo(() => {
     try {
       if (fromAccount?.type === "watch-only")
@@ -457,7 +460,8 @@ const useSendFundsProvider = () => {
         !tokensToBeReaped ||
         !feeToken ||
         !feeTokenBalance ||
-        !estimatedFee
+        !estimatedFee ||
+        isLoadingDryRun
       )
         return { isValid: false, error: undefined }
 
@@ -493,6 +497,12 @@ const useSendFundsProvider = () => {
         }
       }
 
+      if (dryRun?.available && !dryRun.ok)
+        return {
+          isValid: false,
+          error: t("Transaction would fail: ") + dryRun.errorMessage,
+        }
+
       const txError = evmTransaction?.error || subTransaction?.error
       if (txError)
         return {
@@ -524,11 +534,13 @@ const useSendFundsProvider = () => {
     maxCostBreakdown,
     tokensToBeReaped,
     isSendingEnough,
+    dryRun,
     evmTransaction?.error,
     subTransaction?.error,
+    isLoadingDryRun,
   ])
 
-  const isLoading = evmTransaction?.isLoading || subTransaction?.isLoading
+  const isLoading = evmTransaction?.isLoading || subTransaction?.isLoading || isLoadingDryRun
   const isEstimatingMaxAmount = sendMax && !maxAmount
 
   const onSendMaxClick = useCallback(() => {

--- a/apps/extension/src/ui/hooks/useSubstrateDryRun.ts
+++ b/apps/extension/src/ui/hooks/useSubstrateDryRun.ts
@@ -20,8 +20,6 @@ export const useSubstrateDryRun = (jsonPayload: SignerPayloadJSON | null | undef
       if (!jsonPayload) return null
 
       const sapi = await getSapiFromSignerPayloadJSON(jsonPayload)
-      if (!sapi) return null
-
       if (!sapi?.isApiAvailable("DryRunApi", "dry_run_call")) return null
 
       const decodedCall = sapi.getDecodedCallFromPayload(jsonPayload)

--- a/apps/extension/src/ui/hooks/useSubstrateDryRun.ts
+++ b/apps/extension/src/ui/hooks/useSubstrateDryRun.ts
@@ -1,0 +1,62 @@
+import type { polkadot, polkadotAssetHub } from "@polkadot-api/descriptors"
+import { getScaleApi } from "@talismn/sapi"
+import { useQuery } from "@tanstack/react-query"
+import { SignerPayloadJSON } from "extension-core"
+import { getMetadataRpcFromDef } from "extension-shared"
+import { firstValueFrom } from "rxjs"
+
+import { api } from "@ui/api"
+import { getChainByGenesisHash$, getToken$ } from "@ui/state"
+
+export type DryRunResult = (
+  | typeof polkadot
+  | typeof polkadotAssetHub
+)["descriptors"]["apis"]["DryRunApi"]["dry_run_call"][1]
+
+export const useSubstrateDryRun = (jsonPayload: SignerPayloadJSON | null | undefined) => {
+  return useQuery({
+    queryKey: ["useSubstrateDryRun", jsonPayload],
+    queryFn: async () => {
+      if (!jsonPayload) return null
+
+      const sapi = await getSapiFromSignerPayloadJSON(jsonPayload)
+      if (!sapi) return null
+
+      if (!sapi?.isApiAvailable("DryRunApi", "dry_run_call")) return null
+
+      const decodedCall = sapi.getDecodedCallFromPayload(jsonPayload)
+
+      return sapi.getDryRunCall<DryRunResult>(jsonPayload.address, decodedCall)
+    },
+    refetchInterval: 10_000,
+  })
+}
+
+const getSapiFromSignerPayloadJSON = async (jsonPayload: SignerPayloadJSON | null | undefined) => {
+  if (!jsonPayload) return null
+
+  const chain = await firstValueFrom(getChainByGenesisHash$(jsonPayload.genesisHash))
+  if (!chain) return null
+
+  const token = await firstValueFrom(getToken$(chain.nativeToken?.id))
+  if (!token) return null
+
+  const metadataDef = await api.subChainMetadata(jsonPayload.genesisHash)
+  if (!metadataDef) return null
+
+  const metadataRpc = getMetadataRpcFromDef(metadataDef)
+  if (!metadataRpc) return null
+
+  return getScaleApi(
+    {
+      chainId: chain.id,
+      send: (...args) => api.subSend(chain.id, ...args),
+      submit: api.subSubmit,
+    },
+    metadataRpc,
+    token,
+    chain.hasCheckMetadataHash,
+    chain.signedExtensions,
+    chain.registryTypes,
+  )
+}


### PR DESCRIPTION
dry runs send funds transactions to prevent submitting transactions that would fail.

for example, if trying to send MYTH to an account that is not active (has no sufficient assets), as MYTH isnt a sufficient asset itself, the transaction would fail.

For QA might want to simulate transactions on all substrate chains/assets to see if adding dry runs doesnt cause any issue