### PR TITLE
fix: popup content flickering on suspense

### DIFF
--- a/apps/extension/src/@talisman/components/ScrollContainer.tsx
+++ b/apps/extension/src/@talisman/components/ScrollContainer.tsx
@@ -50,9 +50,6 @@ export const ScrollContainer = forwardRef<HTMLDivElement, ScrollContainerProps>(
       }
     }, [refDiv])
 
-    const [isMounted, setIsMounted] = useState(false)
-    useEffect(() => setIsMounted(true), [])
-
     if (typeof forwardedRef === "function")
       throw new Error("forwardRef as function is not supported")
 
@@ -72,10 +69,7 @@ export const ScrollContainer = forwardRef<HTMLDivElement, ScrollContainerProps>(
             innerClassName,
           )}
         >
-          {/* In case of suspense, revDiv.current might be null on first render. This causes problems with child row virtualizers which memoize it, on production builds only */}
-          {isMounted && (
-            <ScrollContainerProvider refContainer={refDiv}>{children}</ScrollContainerProvider>
-          )}
+          <ScrollContainerProvider refContainer={refDiv}>{children}</ScrollContainerProvider>
         </div>
         <div
           className={classNames(


### PR DESCRIPTION
follow-up to #2011 which introduces flickering on first render: 
- header+footer appear with content empty (which shouldnt happen)
- header+footer disappear while spinner displays
- everything reappears

with this PR the first step should not render anymore