### PR TITLE
fix: include all fees in swaps fee display

### DIFF
--- a/apps/extension/src/ui/domains/Swap/components/SwapDetailsCard.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapDetailsCard.tsx
@@ -1,5 +1,6 @@
 import { ClockIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
+import BigNumber from "bignumber.js"
 import { intervalToDuration } from "date-fns"
 import { useAtomValue, useSetAtom } from "jotai"
 import { useMemo } from "react"
@@ -72,8 +73,9 @@ export const SwapDetailsCard = ({
       quote.fees
         .reduce((acc, fee) => {
           const rate = tokenRates[fee.tokenId]?.[currency]?.price ?? 0
-          return acc + fee.amount.toNumber() * rate
-        }, 0)
+          return acc.plus(fee.amount.times(rate))
+        }, BigNumber(0))
+        .toNumber()
         .toLocaleString(undefined, { style: "currency", currency, maximumSignificantDigits: 2 }),
     [currency, quote.fees, tokenRates],
   )

--- a/apps/extension/src/ui/domains/Swap/swap-modules/common.swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/common.swap-module.ts
@@ -45,7 +45,7 @@ export type SwappableAssetWithDecimals<TContext = Partial<Record<SupportedSwapPr
   decimals: number
 } & SwappableAssetBaseType<TContext>
 
-type QuoteFee = {
+export type QuoteFee = {
   name: string
   amount: Decimal
   tokenId: string

--- a/apps/extension/src/ui/domains/Swap/swap-modules/common.swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/common.swap-module.ts
@@ -7,6 +7,7 @@ import { evmErc20TokenId, evmNativeTokenId, subNativeTokenId } from "@talismn/ba
 import { isEthereumAddress, isSs58Address } from "@talismn/crypto"
 import { isBitcoinAddress } from "@talismn/crypto/src/address/encoding/bitcoin"
 import { ScaleApi } from "@talismn/sapi"
+import BigNumber from "bignumber.js"
 import {
   Account,
   isAccountCompatibleWithChain,
@@ -47,7 +48,7 @@ export type SwappableAssetWithDecimals<TContext = Partial<Record<SupportedSwapPr
 
 export type QuoteFee = {
   name: string
-  amount: Decimal
+  amount: BigNumber
   tokenId: string
 }
 

--- a/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
@@ -27,7 +27,7 @@ import {
 
 import { accounts$, getChains$, getEvmNetworksMap$, getToken$, getTokensMap$ } from "@ui/state"
 
-import type { QuoteResponse } from "./common.swap-module.ts"
+import type { QuoteFee, QuoteResponse } from "./common.swap-module.ts"
 import { apiPromiseAtom } from "../swaps-port/apiPromiseAtom"
 import { Decimal } from "../swaps-port/Decimal"
 import { publicClientAtomFamily } from "../swaps-port/publicClientAtomFamily"
@@ -540,6 +540,15 @@ const quote: QuoteFunction = loadable(
     }
 
     const gasFee = await estimateGas(get)
+    // add talisman fee
+    const fees: QuoteFee[] = (gasFee ? [gasFee] : []).concat({
+      amount: Decimal.fromPlanck(
+        BigNumber(fromAmount.planck.toString()).times(TALISMAN_FEE).toString(),
+        fromAsset.decimals,
+      ),
+      name: "Talisman Fee",
+      tokenId: fromAsset.id,
+    })
 
     return {
       decentralisationScore: DECENTRALISATION_SCORE,
@@ -548,7 +557,7 @@ const quote: QuoteFunction = loadable(
       outputAmountBN: Decimal.fromUserInput(output, toAsset.decimals).planck,
       // swaps take about 5mins according to their faq: https://simpleswap.io/faq#crypto-to-crypto-exchanges--how-long-does-it-take-to-exchange-coins
       timeInSec: 5 * 60,
-      fees: gasFee ? [gasFee] : [],
+      fees,
       providerLogo: LOGO,
       providerName: PROTOCOL_NAME,
       talismanFee: TALISMAN_FEE,

--- a/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
@@ -542,10 +542,9 @@ const quote: QuoteFunction = loadable(
     const gasFee = await estimateGas(get)
     // add talisman fee
     const fees: QuoteFee[] = (gasFee ? [gasFee] : []).concat({
-      amount: Decimal.fromPlanck(
-        BigNumber(fromAmount.planck.toString()).times(TALISMAN_FEE).toString(),
-        fromAsset.decimals,
-      ),
+      amount: BigNumber(fromAmount.planck.toString())
+        .times(BigNumber(10).pow(-fromAmount.decimals))
+        .times(TALISMAN_FEE),
       name: "Talisman Fee",
       tokenId: fromAsset.id,
     })
@@ -802,9 +801,9 @@ const estimateGas: GetEstimateGasTxFunction = async (get) => {
         to: fromAsset.contractAddress ? (fromAsset.contractAddress as `0x${string}`) : fromAddress,
         value: 0n,
       })
-      const amount = Decimal.fromPlanck(gasPrice * gasLimit, nativeToken.decimals ?? 0, {
-        currency: nativeToken.symbol,
-      })
+      const amount = BigNumber(gasPrice.toString())
+        .times(gasLimit.toString())
+        .times(BigNumber(10).pow(-(nativeToken.decimals ?? 0)))
       return { name: "Est. Gas Fees", tokenId: nativeToken.id, amount }
     }
 
@@ -834,12 +833,11 @@ const estimateGas: GetEstimateGasTxFunction = async (get) => {
           fromAmount.planck,
         )
   const decimals = transferTx.registry.chainDecimals[0] ?? 10 // default to polkadot decimals 10
-  const symbol = transferTx.registry.chainTokens[0] ?? "DOT" // default to polkadot symbol 'DOT'
   const paymentInfo = await transferTx.paymentInfo(fromAddress)
   return {
     name: "Est. Gas Fees",
     tokenId: substrateChain?.nativeToken?.id ?? "polkadot-substrate-native",
-    amount: Decimal.fromPlanck(paymentInfo.partialFee.toBigInt(), decimals, { currency: symbol }),
+    amount: BigNumber(paymentInfo.partialFee.toString()).times(BigNumber(10).pow(-decimals)),
   }
 }
 

--- a/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
@@ -538,10 +538,9 @@ const quote: QuoteFunction = loadable(
       const talismanFee = Math.max(getTalismanTotalFee({ fromAsset, toAsset }), BUILT_IN_FEE)
       // add talisman fee
       const fees: QuoteFee[] = (gasFee ? [gasFee] : []).concat({
-        amount: Decimal.fromPlanck(
-          BigNumber(fromAmount.planck.toString()).times(talismanFee).toString(),
-          fromAsset.decimals,
-        ),
+        amount: BigNumber(fromAmount.planck.toString())
+          .times(BigNumber(10).pow(-fromAmount.decimals))
+          .times(talismanFee),
         name: "Talisman Fee",
         tokenId: fromAsset.id,
       })
@@ -794,9 +793,9 @@ const estimateGas: GetEstimateGasTxFunction = async (get) => {
         to: fromAsset.contractAddress ? (fromAsset.contractAddress as `0x${string}`) : fromAddress,
         value: 0n,
       })
-      const amount = Decimal.fromPlanck(gasPrice * gasLimit, nativeToken.decimals ?? 0, {
-        currency: nativeToken.symbol,
-      })
+      const amount = BigNumber(gasPrice.toString())
+        .times(gasLimit.toString())
+        .times(BigNumber(10).pow(-(nativeToken.decimals ?? 0)))
       return { name: "Est. Gas Fees", tokenId: nativeToken.id, amount }
     }
 
@@ -826,12 +825,11 @@ const estimateGas: GetEstimateGasTxFunction = async (get) => {
           fromAmount.planck,
         )
   const decimals = transferTx.registry.chainDecimals[0] ?? 10 // default to polkadot decimals 10
-  const symbol = transferTx.registry.chainTokens[0] ?? "DOT" // default to polkadot symbol 'DOT'
   const paymentInfo = await transferTx.paymentInfo(fromAddress)
   return {
     name: "Est. Gas Fees",
     tokenId: substrateChain?.nativeToken?.id ?? "polkadot-substrate-native",
-    amount: Decimal.fromPlanck(paymentInfo.partialFee.toBigInt(), decimals, { currency: symbol }),
+    amount: BigNumber(paymentInfo.partialFee.toString()).times(BigNumber(10).pow(-decimals)),
   }
 }
 

--- a/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
@@ -28,7 +28,7 @@ import {
 
 import { accounts$, getChains$, getEvmNetworksMap$, getToken$, getTokensMap$ } from "@ui/state"
 
-import type { QuoteResponse } from "./common.swap-module.ts"
+import type { QuoteFee, QuoteResponse } from "./common.swap-module.ts"
 import type {
   paths as StealthexApi,
   SchemaCurrency as StealthexCurrency,
@@ -534,6 +534,17 @@ const quote: QuoteFunction = loadable(
       })
 
       const gasFee = await estimateGas(get)
+      // relative fee, multiply by fromAmount to get planck fee
+      const talismanFee = Math.max(getTalismanTotalFee({ fromAsset, toAsset }), BUILT_IN_FEE)
+      // add talisman fee
+      const fees: QuoteFee[] = (gasFee ? [gasFee] : []).concat({
+        amount: Decimal.fromPlanck(
+          BigNumber(fromAmount.planck.toString()).times(talismanFee).toString(),
+          fromAsset.decimals,
+        ),
+        name: "Talisman Fee",
+        tokenId: fromAsset.id,
+      })
 
       return {
         decentralisationScore: DECENTRALISATION_SCORE,
@@ -542,10 +553,10 @@ const quote: QuoteFunction = loadable(
         outputAmountBN: Decimal.fromUserInput(String(estimate), toAsset.decimals).planck,
         // simpleswap swaps take about 5mins, assuming here that stealthex takes a similar amount of time
         timeInSec: 5 * 60,
-        fees: gasFee ? [gasFee] : [],
+        fees,
         providerLogo: LOGO,
         providerName: PROTOCOL_NAME,
-        talismanFee: Math.max(getTalismanTotalFee({ fromAsset, toAsset }), BUILT_IN_FEE),
+        talismanFee,
       }
     } catch (cause) {
       // eslint-disable-next-line no-console

--- a/apps/extension/src/ui/domains/Swap/swaps.api.ts
+++ b/apps/extension/src/ui/domains/Swap/swaps.api.ts
@@ -1,5 +1,6 @@
 import type { PrimitiveAtom } from "jotai"
 import { evmErc20TokenId } from "@talismn/balances"
+import BigNumber from "bignumber.js"
 import { isAccountAddressEthereum, isAccountAddressSs58, remoteConfigStore } from "extension-core"
 import { Atom, atom, Getter, useAtom, useAtomValue, useSetAtom } from "jotai"
 import { atomFamily, atomWithObservable, loadable } from "jotai/utils"
@@ -403,10 +404,12 @@ export const sortedQuotesAtom = atom(async (get) => {
   return quotes.data
     ?.map((q) => {
       if (q.state !== "hasData") return { quote: q, fees: 0 }
-      const fees = q.data?.fees.reduce((acc, fee) => {
-        const rate = tokenRates[fee.tokenId]?.usd?.price ?? 0
-        return acc + fee.amount.toNumber() * rate
-      }, 0)
+      const fees = q.data?.fees
+        .reduce((acc, fee) => {
+          const rate = tokenRates[fee.tokenId]?.usd?.price ?? 0
+          return acc.plus(fee.amount.times(rate))
+        }, BigNumber(0))
+        ?.toNumber()
       return {
         quote: q,
         fees,


### PR DESCRIPTION
Previously we only included gas fees in the `Fees` section, now we include everything