### PR TITLE
fix: swaps fee calculation when fromAsset is ETH

### DIFF
--- a/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
@@ -543,7 +543,7 @@ const quote: QuoteFunction = loadable(
     // add talisman fee
     const fees: QuoteFee[] = (gasFee ? [gasFee] : []).concat({
       amount: BigNumber(fromAmount.planck.toString())
-        .times(BigNumber(10).pow(-fromAmount.decimals))
+        .times(10 ** -fromAmount.decimals)
         .times(TALISMAN_FEE),
       name: "Talisman Fee",
       tokenId: fromAsset.id,
@@ -803,7 +803,7 @@ const estimateGas: GetEstimateGasTxFunction = async (get) => {
       })
       const amount = BigNumber(gasPrice.toString())
         .times(gasLimit.toString())
-        .times(BigNumber(10).pow(-(nativeToken.decimals ?? 0)))
+        .times(10 ** -(nativeToken.decimals ?? 0))
       return { name: "Est. Gas Fees", tokenId: nativeToken.id, amount }
     }
 
@@ -837,7 +837,7 @@ const estimateGas: GetEstimateGasTxFunction = async (get) => {
   return {
     name: "Est. Gas Fees",
     tokenId: substrateChain?.nativeToken?.id ?? "polkadot-substrate-native",
-    amount: BigNumber(paymentInfo.partialFee.toString()).times(BigNumber(10).pow(-decimals)),
+    amount: BigNumber(paymentInfo.partialFee.toBigInt().toString()).times(10 ** -decimals),
   }
 }
 

--- a/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
@@ -539,7 +539,7 @@ const quote: QuoteFunction = loadable(
       // add talisman fee
       const fees: QuoteFee[] = (gasFee ? [gasFee] : []).concat({
         amount: BigNumber(fromAmount.planck.toString())
-          .times(BigNumber(10).pow(-fromAmount.decimals))
+          .times(10 ** -fromAmount.decimals)
           .times(talismanFee),
         name: "Talisman Fee",
         tokenId: fromAsset.id,
@@ -795,7 +795,7 @@ const estimateGas: GetEstimateGasTxFunction = async (get) => {
       })
       const amount = BigNumber(gasPrice.toString())
         .times(gasLimit.toString())
-        .times(BigNumber(10).pow(-(nativeToken.decimals ?? 0)))
+        .times(10 ** -(nativeToken.decimals ?? 0))
       return { name: "Est. Gas Fees", tokenId: nativeToken.id, amount }
     }
 
@@ -829,7 +829,7 @@ const estimateGas: GetEstimateGasTxFunction = async (get) => {
   return {
     name: "Est. Gas Fees",
     tokenId: substrateChain?.nativeToken?.id ?? "polkadot-substrate-native",
-    amount: BigNumber(paymentInfo.partialFee.toString()).times(BigNumber(10).pow(-decimals)),
+    amount: BigNumber(paymentInfo.partialFee.toBigInt().toString()).times(10 ** -decimals),
   }
 }
 


### PR DESCRIPTION
`BigNumber(10).pow(-fromAmount.decimals)` loses precision, whereas `10 ** -fromAmount.decimals` maintains it (and is what we already use in our `tokensToPlanck`/`planckToTokens` utils).

When swapping from ETH (decimals 18), this was enough loss of precision to round to `$0.00` for the fees display!