### PR TITLE
fix: toLocaleDateString/toLocaleTimeString not using user locale

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
@@ -572,7 +572,7 @@ const ScanInfo: FC = () => {
 
   const formatedTimestamp = useMemo(() => {
     const date = new Date(lastScanTimestamp)
-    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
+    return `${date.toLocaleDateString(window.navigator.language)} ${date.toLocaleTimeString(window.navigator.language)}`
   }, [lastScanTimestamp])
 
   const accounts = useAccounts()

--- a/apps/extension/src/ui/domains/Asset/AssetPriceChart.tsx
+++ b/apps/extension/src/ui/domains/Asset/AssetPriceChart.tsx
@@ -382,8 +382,8 @@ const Chart: FC<{
               title: function (tooltipItems) {
                 const date = new Date(tooltipItems[0].label)
                 return CHART_TIMESPANS[timespan].time
-                  ? `${date.toLocaleDateString(undefined, { dateStyle: "short" })} ${date.toLocaleTimeString(undefined, { timeStyle: "short" })}`
-                  : date.toLocaleDateString(undefined, { dateStyle: "short" })
+                  ? `${date.toLocaleDateString(window.navigator.language, { dateStyle: "short" })} ${date.toLocaleTimeString(window.navigator.language, { timeStyle: "short" })}`
+                  : date.toLocaleDateString(window.navigator.language, { dateStyle: "short" })
               },
               label: function () {
                 return ""


### PR DESCRIPTION
On some browsers the default (when `locale` is `undefined`) locale used is `us` instead of the user's browser locale.

This affects the date format in the asset price chart and asset discovery page. (MM-DD-YYYY instead of DD-MM-YYYY for people outside of the US)