### PR TITLE
fix: crazy swaps error message when insufficient funds available for gas

### DIFF
--- a/apps/extension/src/ui/domains/Swap/components/SwapConfirmEvm.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapConfirmEvm.tsx
@@ -10,11 +10,13 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { Button } from "talisman-ui"
+import { EstimateGasExecutionError } from "viem"
 
 import { notify } from "@talisman/components/Notifications"
 import { api } from "@ui/api"
 import { useEthTransaction } from "@ui/domains/Ethereum/useEthTransaction"
 import { SignHardwareEthereum } from "@ui/domains/Sign/SignHardwareEthereum"
+import { useNetworkById, useToken } from "@ui/state"
 import { useAccountByAddress } from "@ui/state/accounts"
 
 import { useSwapTokensModal } from "../hooks/useSwapTokensModal"
@@ -232,6 +234,9 @@ export const SwapConfirmEvm = ({
 
   const onSentToDevice = useCallback(() => setIsPayloadLocked(true), [])
 
+  const fromEvmNetwork = useNetworkById(fromAsset?.chainId?.toString(), "ethereum")
+  const gasTokenSymbol = useToken(fromEvmNetwork?.nativeTokenId)?.symbol ?? "ETH"
+
   return (
     <>
       <FeeEstimateEvm
@@ -247,11 +252,16 @@ export const SwapConfirmEvm = ({
         networkUsage={networkUsage}
       />
 
-      {evmTxLoadable?.state === "hasError" && (
-        <div className="bg-black-tertiary text-tiny mb-10 w-full rounded px-4 py-8 text-center text-red-400">
-          {t("Error loading transaction:")} {String(evmTxLoadable.error)}
-        </div>
-      )}
+      {evmTxLoadable?.state === "hasError" &&
+        (evmTxLoadable.error instanceof EstimateGasExecutionError ? (
+          <div className="bg-black-tertiary text-tiny mb-10 w-full rounded px-4 py-8 text-center text-red-400">
+            {t("Insufficient {{symbol}} available to pay for gas", { symbol: gasTokenSymbol })}
+          </div>
+        ) : (
+          <div className="bg-black-tertiary text-tiny mb-10 w-full rounded px-4 py-8 text-center text-red-400">
+            {t("Error loading transaction:")} {String(evmTxLoadable.error)}
+          </div>
+        ))}
 
       {evmTxLoadable?.state === "loading" || isProcessing ? (
         <Button className="w-full" primary disabled>


### PR DESCRIPTION
Fixes the huge warning we get when there's not enough funds available to pay for gas.

NOTE: We should merge this *after* merging https://github.com/TalismanSociety/talisman/pull/2075, which contains a refactor of the tx submission button.

Closes https://github.com/TalismanSociety/talisman/issues/2047.

<img width="427" alt="Screenshot 2025-07-10 at 17 34 43" src="https://github.com/user-attachments/assets/dd0ee478-fbf8-47b9-8feb-8aca6d040b48" />
