### PR TITLE
Chore/remove managed delegation

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/AssetState.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/AssetState.tsx
@@ -1,4 +1,5 @@
 import { Address } from "extension-core"
+import { Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
 
 import { PortfolioAccount } from "../PortfolioAccount"
 
@@ -25,7 +26,12 @@ export const AssetState = ({
       <div className="flex w-full items-baseline gap-4 overflow-hidden">
         <div className="shrink-0 whitespace-nowrap font-bold capitalize text-white">{title}</div>
         {/* show description next to title when address is set */}
-        {description && address && <div className="grow truncate text-sm">{description}</div>}
+        {description && address && (
+          <Tooltip>
+            <TooltipTrigger className="max-w-full truncate text-sm">{description}</TooltipTrigger>
+            <TooltipContent>{description}</TooltipContent>
+          </Tooltip>
+        )}
         {!description && address && isLoading && (
           <div className="bg-grey-800 rounded-xs h-[1.4rem] w-60 animate-pulse" />
         )}
@@ -40,7 +46,10 @@ export const AssetState = ({
         <div className="bg-grey-800 rounded-xs h-[1.6rem] w-60 animate-pulse" />
       )}
       {description && !address && (
-        <div className="flex-shrink-0 truncate text-sm">{description}</div>
+        <Tooltip>
+          <TooltipTrigger className="max-w-full truncate text-sm">{description}</TooltipTrigger>
+          <TooltipContent>{description}</TooltipContent>
+        </Tooltip>
       )}
     </div>
   )

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/AssetState.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/AssetState.tsx
@@ -47,7 +47,9 @@ export const AssetState = ({
       )}
       {description && !address && (
         <Tooltip>
-          <TooltipTrigger className="max-w-full truncate text-sm">{description}</TooltipTrigger>
+          <TooltipTrigger className="max-w-full truncate text-left text-sm">
+            {description}
+          </TooltipTrigger>
           <TooltipContent>{description}</TooltipContent>
         </Tooltip>
       )}

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupTokenBalances/TokenBalancesDetailRow.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/PopupTokenBalances/TokenBalancesDetailRow.tsx
@@ -3,6 +3,7 @@ import { LockIcon } from "@talismn/icons"
 import { classNames, planckToTokens } from "@talismn/util"
 import { BigNumber } from "bignumber.js"
 import { useMemo } from "react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
 
 import { Fiat } from "@ui/domains/Asset/Fiat"
 import { Tokens } from "@ui/domains/Asset/Tokens"
@@ -68,8 +69,13 @@ export const TokenBalancesDetailRow = ({
           <div className="bg-grey-800 rounded-xs h-[1.4rem] max-w-48 animate-pulse" />
         )}
         {!row.address && row.description && (
-          <div className="overflow-hidden text-ellipsis whitespace-nowrap text-xs">
-            {row.description}
+          <div className="text-left text-xs">
+            <Tooltip>
+              <TooltipTrigger className="max-w-full truncate">{row.description}</TooltipTrigger>
+              <TooltipContent className="rounded-xs text-body-secondary border-grey-700 z-20 border-[0.5px] bg-black p-3 text-[1.1rem] shadow">
+                {row.description}
+              </TooltipContent>
+            </Tooltip>
           </div>
         )}
       </div>

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/useTokenBalances.ts
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/useTokenBalances.ts
@@ -164,8 +164,8 @@ const useEnhanceDetailRows = (detailRows: BalanceDetailRow[]) => {
           return {
             ...row,
             description:
-              combinedValidatorsData?.find((v) => v?.poolId === row.meta.hotkey)?.name ??
-              "Managed delegation",
+              combinedValidatorsData?.find((v) => v?.poolId === row.meta.hotkey)?.name ||
+              row.meta.hotkey,
             isLoading: isLoadingCombinedValidators,
           } as BalanceDetailRow
 


### PR DESCRIPTION
# Description

Removes "Managed delegation" copy, and displays stake hotkey instead. This helps displaying the correct hotkey for dTao miners.

🖼️ Screenshots:

## Popup view single account:
(Tooltip is not being picked up by screenshot) 

<img width="405" height="600" alt="Screenshot 2025-08-07 at 10 39 10" src="https://github.com/user-attachments/assets/f95a5a32-58d3-49e1-a6c2-1aa2d6c89820" />

## Popup view all accounts, nothing changed:

<img width="409" height="601" alt="Screenshot 2025-08-07 at 10 41 45" src="https://github.com/user-attachments/assets/c3c80729-ca3d-4048-8922-75dc025dd9c5" />

## Expanded view single account:
<img width="959" height="458" alt="Screenshot 2025-08-07 at 10 39 34" src="https://github.com/user-attachments/assets/dcc5400a-b100-4b4a-b667-cc94c0c1400e" />

## Expanded view all accounst:

<img width="952" height="437" alt="Screenshot 2025-08-07 at 10 39 20" src="https://github.com/user-attachments/assets/f2111695-ab2c-4d87-ad96-17c1ee1534f5" />




