### PR TITLE
fix: ignore zoraTestnet from viem chains

### DIFF
--- a/.changeset/plenty-eels-build.md
+++ b/.changeset/plenty-eels-build.md
@@ -1,0 +1,5 @@
+---
+"@talismn/chain-connectors": patch
+---
+
+ignore zora testnet from viem

--- a/apps/balances-bench/src/common/utils.ts
+++ b/apps/balances-bench/src/common/utils.ts
@@ -1,11 +1,16 @@
 import { EthNetwork, EthNetworkId } from "@talismn/chaindata-provider"
 import { camelCase, fromPairs, toPairs } from "lodash-es"
 import { Chain, ChainContract, createPublicClient, fallback, http, PublicClient } from "viem"
-import * as chains from "viem/chains"
+import * as viemChains from "viem/chains"
 
-const VIEM_CHAINS = Object.keys(chains).reduce(
+// exclude zoraTestnet which uses Hyperliquid's chain id
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { zoraTestnet, ...validViemChains } = viemChains
+
+// viem chains benefit from multicall config & other viem goodies
+const VIEM_CHAINS = Object.keys(validViemChains).reduce(
   (acc, curr) => {
-    const chain = chains[curr as keyof typeof chains]
+    const chain = validViemChains[curr as keyof typeof validViemChains]
     acc[chain.id] = chain
     return acc
   },

--- a/apps/extension/src/ui/domains/Swap/swaps-port/allEvmChains.ts
+++ b/apps/extension/src/ui/domains/Swap/swaps-port/allEvmChains.ts
@@ -3,7 +3,11 @@ import * as allViemEvmChains from "viem/chains"
 
 import { vanaMainnet } from "../swaps-port/vana"
 
+// exclude zoraTestnet which uses Hyperliquid's chain id
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { zoraTestnet, ...validViemChains } = allViemEvmChains
+
 export const allEvmChains: Record<string, ViemChain | undefined> = {
-  ...allViemEvmChains,
+  ...validViemChains,
   vanaMainnet,
 }

--- a/packages/chain-connectors/src/eth/getChainFromEvmNetwork.ts
+++ b/packages/chain-connectors/src/eth/getChainFromEvmNetwork.ts
@@ -1,12 +1,16 @@
 import { EthNetwork, EthNetworkId } from "@talismn/chaindata-provider"
 import { camelCase, fromPairs, toPairs } from "lodash-es"
 import { Chain, ChainContract } from "viem"
-import * as chains from "viem/chains"
+import * as viemChains from "viem/chains"
+
+// exclude zoraTestnet which uses Hyperliquid's chain id
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { zoraTestnet, ...validViemChains } = viemChains
 
 // viem chains benefit from multicall config & other viem goodies
-const VIEM_CHAINS = Object.keys(chains).reduce(
+const VIEM_CHAINS = Object.keys(validViemChains).reduce(
   (acc, curr) => {
-    const chain = chains[curr as keyof typeof chains]
+    const chain = validViemChains[curr as keyof typeof validViemChains]
     acc[chain.id] = chain
     return acc
   },


### PR DESCRIPTION
in Viem, zoraTestnet network is defined and uses network id 999, which belongs to HyperLiquid.
This PR makes sure that zora testnet's config wont override hyperliquid's network settings