### PR TITLE
fix: copy of deactivate all and reset all modals in networks page

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/NetworksList.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/NetworksList.tsx
@@ -257,19 +257,19 @@ const ResetAllNetworksModalContent: FC<{
   return (
     <ModalDialog
       title={
-        platform
-          ? t("Reset {{platform}} networks", { platform: startCase(platform) })
-          : t("Reset all networks")
+        platform === "all"
+          ? t("Reset all networks")
+          : t("Reset {{platform}} networks", { platform: startCase(platform) })
       }
       onClose={onClose}
     >
       <p className="text-body-secondary mb-8 text-sm">
-        {platform
-          ? t(
+        {platform === "all"
+          ? t("This will reset active state of all networks to their Talisman defaults.")
+          : t(
               "This will reset active state of all {{platform}} networks to their Talisman defaults.",
               { platform },
-            )
-          : t("This will reset active state of all networks to their Talisman defaults.")}
+            )}
       </p>
 
       <div className="mt-4 flex justify-end gap-8">
@@ -324,9 +324,9 @@ const DeactivateNetworksModalContent: FC<{
   return (
     <ModalDialog
       title={
-        platform
-          ? t("Deactivate {{platform}} networks", { platform: startCase(platform) })
-          : t("Deactivate networks")
+        platform === "all"
+          ? t("Deactivate networks")
+          : t("Deactivate {{platform}} networks", { platform: startCase(platform) })
       }
       onClose={onClose}
     >
@@ -356,12 +356,12 @@ const DeactivateNetworksModalContent: FC<{
         <Radio
           name="deactivateMode"
           label={
-            platform
-              ? t("Deactivate all {{platform}} networks ({{count}})", {
+            platform === "all"
+              ? t("Deactivate all networks ({{count}})", { count: networks.length })
+              : t("Deactivate all {{platform}} networks ({{count}})", {
                   platform: startCase(platform),
                   count: networks.length,
                 })
-              : t("Deactivate all networks ({{count}})", { count: networks.length })
           }
           value="all"
           checked={mode === "all"}
@@ -370,12 +370,12 @@ const DeactivateNetworksModalContent: FC<{
         <Radio
           name="deactivateMode"
           label={
-            platform
-              ? t("Deactivate unused {{platform}} networks ({{count}})", {
-                  platform: startCase(platform),
+            platform === "all"
+              ? t("Deactivate all unused networks ({{count}})", {
                   count: unusedNetworkIds.length,
                 })
-              : t("Deactivate all unused networks ({{count}})", {
+              : t("Deactivate unused {{platform}} networks ({{count}})", {
+                  platform: startCase(platform),
                   count: unusedNetworkIds.length,
                 })
           }


### PR DESCRIPTION
Fixes copy of both dialogs when "All" tab is selected.

Before: 
<img width="466" height="375" alt="Screenshot 2025-08-14 at 9 47 21 AM" src="https://github.com/user-attachments/assets/58022653-cb44-4108-b835-9fce7ae41564" />
<img width="476" height="242" alt="Screenshot 2025-08-14 at 9 47 33 AM" src="https://github.com/user-attachments/assets/4f8669af-38db-49a2-854f-6a5c5e434b7f" />

After:
<img width="451" height="356" alt="Screenshot 2025-08-14 at 9 48 07 AM" src="https://github.com/user-attachments/assets/17a21ddc-7a8b-4bfe-8a6d-b3d0f271ac03" />
<img width="474" height="228" alt="Screenshot 2025-08-14 at 9 48 17 AM" src="https://github.com/user-attachments/assets/75799c11-0663-4f03-9e1b-9f0a44d6a81a" />

