### PR TITLE
feat: auto detect new solana tokens

### DIFF
--- a/.changeset/eight-nails-compete.md
+++ b/.changeset/eight-nails-compete.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": patch
+---
+
+auto detect new tokens

--- a/packages/balances/src/BalancesProvider.ts
+++ b/packages/balances/src/BalancesProvider.ts
@@ -36,6 +36,7 @@ import { withRetry } from "viem"
 import { Balance, BALANCE_MODULES, ChainConnectors } from "."
 import { getMiniMetadatas, getSpecVersion } from "./getMiniMetadatas"
 import log from "./log"
+import { getDetectedTokensIds$ } from "./modules/shared/detectedTokens"
 import { Address, deriveMiniMetadataId, getBalanceId, IBalance, MiniMetadata } from "./types"
 import { TokensWithAddresses } from "./types/IBalanceModule"
 
@@ -159,6 +160,10 @@ export class BalancesProvider {
         map(({ balances }) => balances),
       ),
     )
+  }
+
+  public getDetectedTokensId$(address: string): Observable<TokenId[]> {
+    return getDetectedTokensIds$(address)
   }
 
   private getNetworkBalances$(

--- a/packages/balances/src/modules/shared/detectedTokens.ts
+++ b/packages/balances/src/modules/shared/detectedTokens.ts
@@ -1,0 +1,22 @@
+import { parseTokenId, TokenId, TokenType } from "@talismn/chaindata-provider"
+import { isEqual } from "lodash-es"
+import { BehaviorSubject, distinctUntilChanged, map } from "rxjs"
+
+const tokenIdsByAddress = new BehaviorSubject<Record<string, TokenId[]>>({})
+
+export const setDetectedTokenIds = (address: string, type: TokenType, tokenIds: TokenId[]) => {
+  // keep token ids from other token types (will be useful once we add token2022)
+  const otherTokens =
+    tokenIdsByAddress.value[address]?.filter((id) => parseTokenId(id).type !== type) ?? []
+
+  tokenIdsByAddress.next({
+    ...tokenIdsByAddress.value,
+    [address]: otherTokens.concat(tokenIds).sort(),
+  })
+}
+
+export const getDetectedTokensIds$ = (address: string) =>
+  tokenIdsByAddress.pipe(
+    map((ownedTokens) => ownedTokens[address] ?? []),
+    distinctUntilChanged<TokenId[]>(isEqual),
+  )

--- a/packages/balances/src/modules/sol-spl/fetchBalances.ts
+++ b/packages/balances/src/modules/sol-spl/fetchBalances.ts
@@ -53,8 +53,7 @@ export const fetchBalances: IBalanceModule<typeof MODULE_TYPE>["fetchBalances"] 
         })
         .filter(isNotNil)
 
-      // update the cache of owned token.
-      // this is used by the wallet to detect new tokens, and enable them
+      // allows the wallet to detect new tokens, and enable them automatically
       setDetectedTokenIds(
         address,
         MODULE_TYPE,

--- a/packages/balances/src/modules/sol-spl/fetchBalances.ts
+++ b/packages/balances/src/modules/sol-spl/fetchBalances.ts
@@ -7,6 +7,7 @@ import log from "../../log"
 import { IBalance } from "../../types"
 import { IBalanceModule } from "../../types/IBalanceModule"
 import { getBalanceDefs } from "../shared"
+import { setDetectedTokenIds } from "../shared/detectedTokens"
 import { MODULE_TYPE } from "./config"
 
 const SPL_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -51,6 +52,14 @@ export const fetchBalances: IBalanceModule<typeof MODULE_TYPE>["fetchBalances"] 
           }
         })
         .filter(isNotNil)
+
+      // update the cache of owned token.
+      // this is used by the wallet to detect new tokens, and enable them
+      setDetectedTokenIds(
+        address,
+        MODULE_TYPE,
+        balances.map((b) => b.tokenId),
+      )
 
       return [address, balances] as const
     }),

--- a/packages/extension-core/src/domains/assetDiscovery/solana.ts
+++ b/packages/extension-core/src/domains/assetDiscovery/solana.ts
@@ -1,16 +1,15 @@
 import { Connection, PublicKey } from "@solana/web3.js"
-import { solSplTokenId } from "@talismn/chaindata-provider"
+import { networkIdFromTokenId, solSplTokenId, TokenId } from "@talismn/chaindata-provider"
 import { isSolanaAddress } from "@talismn/crypto"
 import { isAccountNotContact, isAccountPlatformSolana } from "@talismn/keyring"
-import { liveQuery } from "dexie"
 import { log } from "extension-shared"
 import { isEqual, uniq } from "lodash-es"
-import { combineLatest, distinctUntilChanged, filter, first, map, pairwise } from "rxjs"
+import { combineLatest, distinctUntilChanged, filter, first, map, pairwise, switchMap } from "rxjs"
 
-import { db } from "../../db"
 import { isWalletReady$ } from "../../libs/isWalletReady"
 import { chainConnectorSol } from "../../rpcs/chain-connector-sol"
 import { chaindataProvider } from "../../rpcs/chaindata"
+import { balancesProvider } from "../balances/balancesProvider"
 import { activeNetworksStore } from "../balances/store.activeNetworks"
 import { activeTokensStore } from "../balances/store.activeTokens"
 import { keyringStore } from "../keyring/store"
@@ -126,29 +125,48 @@ export const initialiseSolanaAssetDiscovery = () => {
       discoverSolanaAssets(newSolanaAddresses)
     })
 
-  // launch a scan after every confirmed solana transaction
+  // enable solana mainnet tokens found by balance modules (no scan needed)
   combineLatest({
     isWalletReady: isWalletReady$,
-    transactions: liveQuery(() =>
-      db.transactionsV2
-        //.where({ networkId: "solana-mainnet", status: "success", confirmed: true })
-        .toArray(),
-    ),
+    accounts: keyringStore.accounts$,
   })
     .pipe(
       filter(({ isWalletReady }) => !!isWalletReady),
-      map(
-        ({ transactions }) =>
-          transactions.filter(
-            (tx) => tx.networkId === MAINNET_NETWORK_ID && tx.status === "success" && tx.confirmed,
-          ).length,
+      map(({ accounts }) =>
+        accounts
+          .filter(isAccountNotContact)
+          .filter(isAccountPlatformSolana)
+          .map((acc) => acc.address),
       ),
-      distinctUntilChanged(),
-      pairwise(), // Emit pairs of [previous, current] transaction count
-      filter(([previous, current]) => previous < current), // Only emit when it increases
+      switchMap((addresses) =>
+        combineLatest([...addresses.map(balancesProvider.getDetectedTokensId$)]).pipe(
+          map((allTokenIds) => uniq(allTokenIds.flat()).sort()),
+        ),
+      ),
+      distinctUntilChanged<TokenId[]>(isEqual),
     )
-    .subscribe(() => {
-      log.debug("[discoverSolanaAssets] new confirmed solana transaction, launching scan")
-      discoverSolanaAssets()
+    .subscribe(async (tokenIds: TokenId[]) => {
+      log.debug("[discoverSolanaAssets] detectedTokens$")
+
+      const [activeTokens, existingTokenIds] = await Promise.all([
+        activeTokensStore.get(),
+        chaindataProvider.getTokenIds(),
+      ])
+
+      const tokenIdsToActivate = tokenIds.filter((tokenId) => {
+        if (activeTokens[tokenId] !== undefined) return false // already set
+        if (networkIdFromTokenId(tokenId) !== MAINNET_NETWORK_ID) return false // only process solana mainnet tokens
+        return existingTokenIds.includes(tokenId) // consider only tokens that talisman knows about
+      })
+
+      if (tokenIdsToActivate.length) {
+        log.debug("[discoverSolanaAssets] activating detected tokens:", tokenIdsToActivate)
+
+        await activeTokensStore.mutate((prev) => {
+          const next = { ...prev }
+          for (const tokenId of tokenIdsToActivate) next[tokenId] = true
+          return next
+        })
+      }
     })
 }

--- a/packages/extension-core/src/domains/balances/balancesProvider.ts
+++ b/packages/extension-core/src/domains/balances/balancesProvider.ts
@@ -32,4 +32,8 @@ export const balancesProvider = {
     const provider = await firstValueFrom(balancesProvider$)
     return provider.fetchBalances(...args)
   },
+
+  getDetectedTokensId$: (address: string) => {
+    return balancesProvider$.pipe(switchMap((provider) => provider.getDetectedTokensId$(address)))
+  },
 }


### PR DESCRIPTION
- balances provider now exposes a getDetectedTokens$(address) observable
- detected tokens will be automatically enabled by the solana asset discovery module

Note: this only works for Solana SPL tokens for now, but it is not balance module specific. in the future more balance modules may leverage it too (ex: Token2022)