### PR TITLE
fix: bundle of fixes for v3

### DIFF
--- a/apps/extension/src/ui/apps/popup/pages/WhatsNew/assets/index.ts
+++ b/apps/extension/src/ui/apps/popup/pages/WhatsNew/assets/index.ts
@@ -21,6 +21,7 @@ import content_v2_9_0 from "./v2.9.0"
 import content_v2_10_0 from "./v2.10.0"
 import content_v2_11_0 from "./v2.11.0"
 import content_v2_12_0 from "./v2.12.0"
+import content_v3_0_0 from "./v3.0.0"
 
 export const latestUpdates: WhatsNewVersionData = {
   ...content_v1_21_0,
@@ -45,4 +46,5 @@ export const latestUpdates: WhatsNewVersionData = {
   ...content_v2_10_0,
   ...content_v2_11_0,
   ...content_v2_12_0,
+  ...content_v3_0_0,
 }

--- a/apps/extension/src/ui/apps/popup/pages/WhatsNew/assets/v3.0.0/content.md
+++ b/apps/extension/src/ui/apps/popup/pages/WhatsNew/assets/v3.0.0/content.md
@@ -1,0 +1,5 @@
+<!-- version: v3.0.0 -->
+
+**<span class="icon">🎉</span> Solana support:** Add or import Solana accounts, and connect to dapps.
+
+**<span class="icon">⚡️</span> Defi Position:** Browse DeFi positions of your Ethereum and Solana accounts.

--- a/apps/extension/src/ui/apps/popup/pages/WhatsNew/assets/v3.0.0/index.ts
+++ b/apps/extension/src/ui/apps/popup/pages/WhatsNew/assets/v3.0.0/index.ts
@@ -1,0 +1,11 @@
+import { WhatsNewVersionData } from "../types"
+import content from "./content.md"
+
+const content_v3_0_0: WhatsNewVersionData = {
+  "3.0.0": {
+    content,
+    date: "September 2025",
+  },
+}
+
+export default content_v3_0_0

--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddPrivateKeyForm.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddPrivateKeyForm.tsx
@@ -181,7 +181,10 @@ export const AccountAddPrivateKeyForm = ({ onSuccess }: AccountAddPageProps) => 
             <AccountPlatformDropdown
               value={field.state.value}
               platforms={SUPPORTED_ACCOUNT_PLATFORMS}
-              onChange={(platform) => field.handleChange(platform)}
+              onChange={(platform) => {
+                field.handleChange(platform)
+                field.form.validateField("privateKey", "change")
+              }}
               className="h-28"
             />
           )}
@@ -241,6 +244,7 @@ export const AccountAddPrivateKeyForm = ({ onSuccess }: AccountAddPageProps) => 
           validators={{
             onChange: ({ value, fieldApi }) => {
               const platform = fieldApi.form.getFieldValue("platform")
+              if (!platform) return null // don't validate until a platform is chosen
               const address = privateKeyToAddress(value, platform)
               if (value && !address) return t("Invalid private key")
               if (address && existingAccountAddresses.includes(address))

--- a/apps/extension/src/ui/domains/Account/AccountIcon.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountIcon.tsx
@@ -1,4 +1,5 @@
-import { isEthereumAddress } from "@talismn/crypto"
+import type { IconTheme } from "@polkadot/react-identicon/types"
+import { detectAddressEncoding } from "@talismn/crypto"
 import { TalismanOrb } from "@talismn/orb"
 import { classNames } from "@talismn/util"
 import { Address, IdenticonType } from "extension-core"
@@ -31,8 +32,16 @@ const ChainBadge = ({ genesisHash }: { genesisHash: `0x${string}` }) => {
   ) : null
 }
 
-const PolkadotAvatar = ({ seed }: { seed: string }) => {
-  const theme = useMemo(() => (isEthereumAddress(seed) ? "ethereum" : "polkadot"), [seed])
+export const PolkadotAvatar = ({ seed }: { seed: string }) => {
+  const theme = useMemo<IconTheme>(() => {
+    try {
+      const encoding = detectAddressEncoding(seed)
+      return encoding === "ss58" ? "polkadot" : "ethereum"
+    } catch {
+      return "ethereum" // works for any string
+    }
+  }, [seed])
+
   return (
     <IdentIcon
       value={seed}

--- a/apps/extension/src/ui/util/getAccountAvatarDataUri.tsx
+++ b/apps/extension/src/ui/util/getAccountAvatarDataUri.tsx
@@ -1,15 +1,15 @@
-import Identicon from "@polkadot/react-identicon"
-import { isEthereumAddress } from "@polkadot/util-crypto"
 import * as Sentry from "@sentry/browser"
 import { TalismanOrb } from "@talismn/orb"
 import { IdenticonType } from "extension-core"
 import { renderToString } from "react-dom/server"
 
+import { PolkadotAvatar } from "@ui/domains/Account/AccountIcon"
+
 const generateAccountAvatarDataUri = (address: string, iconType: IdenticonType) => {
   try {
     const component =
       iconType === "polkadot-identicon" ? (
-        <Identicon value={address} theme={isEthereumAddress(address) ? "ethereum" : "polkadot"} />
+        <PolkadotAvatar seed={address} />
       ) : (
         <TalismanOrb seed={address} />
       )


### PR DESCRIPTION
- import from PK form: revalidate PK after setting platform
- display fallback avatar (same one as ethereum) for solana accounts, when using classic avatars setting