### PR TITLE
fix: crash on tx history due to swaps status

### DIFF
--- a/apps/extension/src/ui/domains/Swap/hooks/useSwapStatus.ts
+++ b/apps/extension/src/ui/domains/Swap/hooks/useSwapStatus.ts
@@ -1,5 +1,14 @@
 import { state, useStateObservable } from "@react-rxjs/core"
-import { firstValueFrom, Observable, of, ReplaySubject, switchMap, tap } from "rxjs"
+import {
+  concatMap,
+  firstValueFrom,
+  Observable,
+  of,
+  ReplaySubject,
+  Subject,
+  switchMap,
+  tap,
+} from "rxjs"
 
 import {
   SimpleswapExchange,
@@ -39,7 +48,7 @@ const getSwapStatus$ = state((protocolAndId?: string): Observable<SwapStatus | u
 
           // update cache with latest value
           // this will prevent further api requests for this swap
-          setSwapCache(protocolAndId, status)
+          cacheSwapStatus$.next({ protocolAndId, status })
         }),
       )
     }),
@@ -70,16 +79,23 @@ completedSwapsCache$.subscribe((cache) =>
   localStorage.setItem(completedSwapsCacheKey, JSON.stringify(cache ?? {})),
 )
 
-// setSwapCache makes sure that there's no race condition when saving new swap statuses to the cache.
+// cacheSwapStatus$ makes sure that there's no race condition when saving new swap statuses to the cache.
 // it prevents this specific timing issue:
 // 1. swap1 reads cache
 // 2. swap2 reads cache
 // 3. swap1 stores new cached value
 // 4. swap2 stores new cached value (deleting swap1's cached value)
-let _latestCacheValue: Record<string, CachedSwapStatus> | null = null
-const setSwapCache = async (protocolAndId: string, status: CachedSwapStatus) => {
-  if (!_latestCacheValue) _latestCacheValue = await firstValueFrom(completedSwapsCache$)
-
-  _latestCacheValue[protocolAndId] = status
-  completedSwapsCache$.next(_latestCacheValue)
-}
+//
+// instead, each new cached value is emitted from the cacheSwapStatus$ subject and processed in sequence using concatMap, like a queue.
+const cacheSwapStatus$ = new Subject<{ protocolAndId: string; status: CachedSwapStatus }>()
+cacheSwapStatus$
+  .pipe(
+    // save each new value in sequence, to prevent race conditions
+    concatMap((newValue) =>
+      firstValueFrom(completedSwapsCache$).then((cache) => {
+        cache[newValue.protocolAndId] = newValue.status
+        return completedSwapsCache$.next(cache)
+      }),
+    ),
+  )
+  .subscribe()

--- a/apps/extension/src/ui/domains/Swap/hooks/useSwapStatus.ts
+++ b/apps/extension/src/ui/domains/Swap/hooks/useSwapStatus.ts
@@ -1,84 +1,85 @@
-import { atom, useAtom, useAtomValue } from "jotai"
-import { atomFamily, unwrap } from "jotai/utils"
-import { useEffect } from "react"
+import { state, useStateObservable } from "@react-rxjs/core"
+import { firstValueFrom, Observable, of, ReplaySubject, switchMap, tap } from "rxjs"
 
 import {
-  retryStatus as retrySimpleswapStatus,
   SimpleswapExchange,
+  swapStatus$ as simpleswapStatus$,
 } from "../swap-modules/simpleswap-swap-module"
 import {
-  retryStatus as retryStealthexStatus,
   StealthexExchange,
+  swapStatus$ as stealthexStatus$,
 } from "../swap-modules/stealthex-swap-module"
 
-export const useSwapStatus = (
-  protocol?: string,
-  id?: string,
-): { status: (SimpleswapExchange | StealthexExchange)["status"] } | undefined => {
+type SwapStatus = (SimpleswapExchange | StealthexExchange)["status"]
+
+export const useSwapStatus = (protocol?: string, id?: string): SwapStatus | undefined => {
   const protocolAndId = protocol && id && `${protocol}::${id}`
-
-  const swapStatus = useAtomValue(swapStatusSwrAtom(protocolAndId))
-  const [cache, setCache] = useAtom(completedSwapsCacheAtom)
-
-  useEffect(() => {
-    if (!protocolAndId) return
-    if (cache[protocolAndId]) return
-    if (!swapStatus?.status) return
-
-    const { status } = swapStatus
-    if (
-      status !== "failed" &&
-      status !== "finished" &&
-      status !== "expired" &&
-      status !== "refunded"
-    )
-      return
-
-    const newCache = { ...cache, [protocolAndId]: status }
-    setCache(newCache)
-    saveCompletedSwapsCache(newCache)
-  }, [cache, protocolAndId, setCache, swapStatus])
-
-  return swapStatus
+  return useStateObservable(getSwapStatus$(protocolAndId))
 }
 
-const swapStatusSyncAtom = atomFamily((protocolAndId?: string) =>
-  unwrap(swapStatusAtom(protocolAndId), (prev) => prev),
-)
-const swapStatusSwrAtom = atomFamily((protocolAndId?: string) =>
-  atom((get) => get(swapStatusSyncAtom(protocolAndId)) ?? get(swapStatusAtom(protocolAndId))),
-)
+const getSwapStatus$ = state((protocolAndId?: string): Observable<SwapStatus | undefined> => {
+  if (!protocolAndId) return of(undefined)
 
-export const swapStatusAtom = atomFamily((protocolAndId?: string) =>
-  atom(async (get) => {
-    if (!protocolAndId) return
+  return completedSwapsCache$.pipe(
+    switchMap((cache) => {
+      // if value is cached, return it from the cache
+      if (cache[protocolAndId]) return of(cache[protocolAndId])
 
-    const cache = get(completedSwapsCacheAtom)
-    if (cache[protocolAndId]) return { status: cache[protocolAndId] }
+      // otherwise fetch it from the api
+      return getStatus$(protocolAndId).pipe(
+        tap((status) => {
+          // don't update cache if status isn't one of these
+          if (
+            status !== "failed" &&
+            status !== "finished" &&
+            status !== "expired" &&
+            status !== "refunded"
+          )
+            return
 
-    const [protocol, id] = protocolAndId.split("::")
-    const retryStatus = (() => {
-      switch (protocol) {
-        case "swap-simpleswap":
-          return retrySimpleswapStatus
-        case "swap-stealthex":
-          return retryStealthexStatus
-        default:
-          return
-      }
-    })()
-    if (!retryStatus) return
+          // update cache with latest value
+          // this will prevent further api requests for this swap
+          setSwapCache(protocolAndId, status)
+        }),
+      )
+    }),
+  )
+})
 
-    return await retryStatus(get, id)
-  }),
-)
+const getStatus$ = state((protocolAndId: string): Observable<SwapStatus | undefined> => {
+  const [protocol, id] = protocolAndId.split("::")
+  const swapStatus$ = (() => {
+    if (protocol === "swap-simpleswap") return simpleswapStatus$
+    if (protocol === "swap-stealthex") return stealthexStatus$
+    return
+  })()
+  if (!swapStatus$) return of(undefined)
 
+  return swapStatus$(id)
+})
+
+type CachedSwapStatus = "finished" | "failed" | "expired" | "refunded"
 const completedSwapsCacheKey = "TalismanCompletedSwapsCache"
-export const loadCompletedSwapsCache = (): Record<
-  string,
-  "finished" | "failed" | "expired" | "refunded"
-> => JSON.parse(localStorage.getItem(completedSwapsCacheKey) ?? "{}")
-const saveCompletedSwapsCache = (
-  cache: Record<string, "finished" | "failed" | "expired" | "refunded">,
-) => localStorage.setItem(completedSwapsCacheKey, JSON.stringify(cache ?? {}))
-const completedSwapsCacheAtom = atom(loadCompletedSwapsCache())
+const completedSwapsCache$ = new ReplaySubject<Record<string, CachedSwapStatus>>(1)
+
+// load cache from localstorage on startup
+completedSwapsCache$.next(JSON.parse(localStorage.getItem(completedSwapsCacheKey) ?? "{}"))
+
+// save cache changes to localstorage
+completedSwapsCache$.subscribe((cache) =>
+  localStorage.setItem(completedSwapsCacheKey, JSON.stringify(cache ?? {})),
+)
+
+// setSwapCache makes sure that there's no race condition when saving new swap statuses to the cache.
+// it prevents this specific timing issue:
+// 1. swap1 reads cache
+// 2. swap2 reads cache
+// 3. swap1 stores new cached value
+// 4. swap2 stores new cached value (deleting swap1's cached value)
+let _latestCacheValue: Record<string, CachedSwapStatus> | null = null
+const setSwapCache = async (protocolAndId: string, status: CachedSwapStatus) => {
+  if (!_latestCacheValue) _latestCacheValue = await firstValueFrom(completedSwapsCache$)
+
+  _latestCacheValue[protocolAndId] = status
+  completedSwapsCache$.next(_latestCacheValue)
+}

--- a/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
@@ -12,9 +12,19 @@ import { ScaleApi } from "@talismn/sapi"
 import BigNumber from "bignumber.js"
 import { remoteConfigStore } from "extension-core"
 import { UNKNOWN_TOKEN_URL } from "extension-shared"
-import { atom, ExtractAtomValue, Getter } from "jotai"
-import { withAtomEffect } from "jotai-effect"
+import { atom, ExtractAtomValue } from "jotai"
 import { atomWithObservable, loadable } from "jotai/utils"
+import {
+  catchError,
+  defer,
+  interval,
+  Observable,
+  of,
+  retry,
+  startWith,
+  switchMap,
+  takeWhile,
+} from "rxjs"
 import { encodeFunctionData, erc20Abi, publicActions, TransactionRequest } from "viem"
 import {
   arbitrum,
@@ -884,37 +894,35 @@ export const simpleswapSwapModule: SwapModule = {
   decentralisationScore: DECENTRALISATION_SCORE,
 }
 
-export const retryStatus = async (
-  get: Getter,
-  id: string,
-  attempts = 0,
-): Promise<{ status: Exchange["status"] }> => {
-  try {
-    const exchange = await simpleSwapSdk.getExchange(id)
+export const swapStatus$ = (id: string): Observable<Exchange["status"] | undefined> =>
+  retryStatus$(id).pipe(
+    switchMap((status) => {
+      if (status === undefined) return of(undefined)
 
-    if (!["finished", "failed"].includes(exchange.status) && exchange.code !== 401) {
-      get(refreshSwapStatusAtom)
-    }
+      const shouldRefresh = (status: Exchange["status"] | undefined) =>
+        !(status && ["finished", "failed", "expired", "refunded"].includes(status))
 
-    return { status: exchange.status }
-  } catch (cause) {
-    const error = cause as Error & { response?: { status?: number } }
-    // because we're using a broker, the tx isnt always available immediately in their api service
-    // so we wait a bit and retry
-    if (error.name === "AxiosError" && error?.response?.status === 404 && attempts < 10) {
-      await new Promise((resolve) => setTimeout(resolve, 5000))
-      return retryStatus(get, id, attempts + 1)
-    }
-    throw cause
-  }
-}
-
-const _refreshSwapStatusAtom = atom(0)
-const refreshSwapStatusAtom = withAtomEffect(_refreshSwapStatusAtom, (_get, set) => {
-  const intervalId = setInterval(
-    // increment _refreshSwapStatus by 1 every 20s
-    () => set(_refreshSwapStatusAtom, (i) => (i + 1) % Number.MAX_SAFE_INTEGER),
-    20_000,
+      // refresh every 20s if status isn't final
+      if (shouldRefresh(status)) {
+        return interval(20_000).pipe(
+          startWith(-1),
+          switchMap((i) => (i === -1 ? of(status) : retryStatus$(id))),
+          takeWhile((status) => shouldRefresh(status), true),
+        )
+      }
+      return of(status)
+    }),
   )
-  return () => clearInterval(intervalId)
-})
+
+const retryStatus$ = (id: string): Observable<Exchange["status"] | undefined> =>
+  defer(() => simpleSwapSdk.getExchange(id).then((exchange) => exchange.status)).pipe(
+    // retry up to 10 times, wait 5s between each retry
+    retry({ count: 10, delay: 5_000 }),
+
+    // log when all retries failed, and return undefined
+    catchError((error) => {
+      // eslint-disable-next-line no-console
+      console.error(`Failed to fetch exchange status for '${id}'`, error)
+      return of(undefined)
+    }),
+  )

--- a/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
@@ -10,10 +10,20 @@ import { encodeAnyAddress, isAddressEqual, isEthereumAddress } from "@talismn/cr
 import { ScaleApi } from "@talismn/sapi"
 import BigNumber from "bignumber.js"
 import { UNKNOWN_TOKEN_URL } from "extension-shared"
-import { atom, ExtractAtomValue, Getter } from "jotai"
-import { withAtomEffect } from "jotai-effect"
+import { atom, ExtractAtomValue } from "jotai"
 import { atomWithObservable, loadable } from "jotai/utils"
 import createClient from "openapi-fetch"
+import {
+  catchError,
+  defer,
+  interval,
+  Observable,
+  of,
+  retry,
+  startWith,
+  switchMap,
+  takeWhile,
+} from "rxjs"
 import { encodeFunctionData, erc20Abi, publicActions, TransactionRequest } from "viem"
 import {
   arbitrum,
@@ -861,37 +871,35 @@ export const stealthexSwapModule: SwapModule = {
   decentralisationScore: DECENTRALISATION_SCORE,
 }
 
-export const retryStatus = async (
-  get: Getter,
-  id: string,
-  attempts = 0,
-): Promise<{ status: StealthexExchange["status"] }> => {
-  try {
-    const exchange = await stealthexSdk.getExchange(id)
+export const swapStatus$ = (id: string): Observable<StealthexExchange["status"] | undefined> =>
+  retryStatus$(id).pipe(
+    switchMap((status) => {
+      if (status === undefined) return of(undefined)
 
-    if (!["finished", "failed"].includes(exchange.status)) {
-      get(refreshSwapStatusAtom)
-    }
+      const shouldRefresh = (status: StealthexExchange["status"] | undefined) =>
+        !(status && ["finished", "failed", "expired", "refunded"].includes(status))
 
-    return { status: exchange.status }
-  } catch (cause) {
-    const error = cause as Error & { response?: { status?: number } }
-    // because we're using a broker, the tx isnt always available immediately in their api service
-    // so we wait a bit and retry
-    if (error.name === "AxiosError" && error?.response?.status === 404 && attempts < 10) {
-      await new Promise((resolve) => setTimeout(resolve, 5000))
-      return retryStatus(get, id, attempts + 1)
-    }
-    throw cause
-  }
-}
-
-const _refreshSwapStatusAtom = atom(0)
-const refreshSwapStatusAtom = withAtomEffect(_refreshSwapStatusAtom, (_get, set) => {
-  const intervalId = setInterval(
-    // increment _refreshSwapStatus by 1 every 20s
-    () => set(_refreshSwapStatusAtom, (i) => (i + 1) % Number.MAX_SAFE_INTEGER),
-    20_000,
+      // refresh every 20s if status isn't final
+      if (shouldRefresh(status)) {
+        return interval(20_000).pipe(
+          startWith(-1),
+          switchMap((i) => (i === -1 ? of(status) : retryStatus$(id))),
+          takeWhile((status) => shouldRefresh(status), true),
+        )
+      }
+      return of(status)
+    }),
   )
-  return () => clearInterval(intervalId)
-})
+
+const retryStatus$ = (id: string): Observable<StealthexExchange["status"] | undefined> =>
+  defer(() => stealthexSdk.getExchange(id).then((exchange) => exchange.status)).pipe(
+    // retry up to 10 times, wait 5s between each retry
+    retry({ count: 10, delay: 5_000 }),
+
+    // log when all retries failed, and return undefined
+    catchError((error) => {
+      // eslint-disable-next-line no-console
+      console.error(`Failed to fetch exchange status for '${id}'`, error)
+      return of(undefined)
+    }),
+  )

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -474,7 +474,7 @@ const SwapTransactionStatusLabel = ({ tx }: { tx: WalletTransaction }) => {
   // show regular tx status while tx is still submitting
   if (tx.status !== "success") return <TransactionStatusLabel status={tx.status} />
 
-  switch (swapStatus?.status) {
+  switch (swapStatus) {
     case "waiting":
     case "confirming":
     case "exchanging":
@@ -482,11 +482,11 @@ const SwapTransactionStatusLabel = ({ tx }: { tx: WalletTransaction }) => {
     case "verifying":
       return (
         <>
-          {swapStatus?.status === "waiting" ? <span>{t("Depositing funds")} </span> : null}
-          {swapStatus?.status === "confirming" ? <span>{t("Confirming")} </span> : null}
-          {swapStatus?.status === "exchanging" ? <span>{t("Exchanging")} </span> : null}
-          {swapStatus?.status === "sending" ? <span>{t("Sending")} </span> : null}
-          {swapStatus?.status === "verifying" ? <span>{t("Verifying")} </span> : null}
+          {swapStatus === "waiting" ? <span>{t("Depositing funds")} </span> : null}
+          {swapStatus === "confirming" ? <span>{t("Confirming")} </span> : null}
+          {swapStatus === "exchanging" ? <span>{t("Exchanging")} </span> : null}
+          {swapStatus === "sending" ? <span>{t("Sending")} </span> : null}
+          {swapStatus === "verifying" ? <span>{t("Verifying")} </span> : null}
           <LoaderIcon className="animate-spin-slow text-body-disabled" />
         </>
       )


### PR DESCRIPTION
After failing to fetch the status from the upstream API, we'll now default to an `Unknown` status instead of throwing an error.
Prevents the UI from crashing due to that unhandled error.

I also took the opportunity to tidy up the cache & retry & refresh logic using Observables, because I noticed a bug with the existing cache mechanism and it was easier to just comprehensibly rewrite it than to try and fix the existing bug.

Also long term we wanna use rxjs instead of jotai