### PR TITLE
chore: use less memory when minifying js

### DIFF
--- a/apps/extension/webpack/webpack.prod.js
+++ b/apps/extension/webpack/webpack.prod.js
@@ -97,6 +97,7 @@ const config = (env) => {
       minimize: true,
       minimizer: [
         new TerserPlugin({
+          parallel: 1,
           terserOptions: {
             compress: {
               defaults: true,


### PR DESCRIPTION
To test this, I tried running the firefox build in an environment which only has access to 4GB of memory.

On `dev`, this causes it to exit with code 137 (out of memory).

On this branch, it builds successfully.