### PR TITLE
chore: run ff build script without sudo when BUILD_NOSUDO=true

### DIFF
--- a/packages/chaindata-provider/tsconfig.json
+++ b/packages/chaindata-provider/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
-  "include": ["src"],
+  "include": ["src", "src/state/initChaindata.json"],
   "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/scripts/build-review-firefox.sh
+++ b/scripts/build-review-firefox.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+if [ -n "${BUILD_NOSUDO:-}" ]; then
+    DOCKER_CMD="docker"
+else
+    DOCKER_CMD="sudo docker"
+fi
+
 rm -rf review
 mkdir review
-sudo docker build . --tag talisman-builder
-sudo docker run --rm --volume "$(pwd)/review":/review talisman-builder bash -c ' \
+$DOCKER_CMD build . --tag talisman-builder
+$DOCKER_CMD run --rm --volume "$(pwd)/review":/review talisman-builder bash -c ' \
     NODE_OPTIONS=--max_old_space_size=8192 USE_ONE_DIST_DIR=true pnpm build:extension:prod:firefox && \
     cp /talisman/apps/extension/dist/*.zip /review/ && \
     rm -rf /talisman/apps/extension/dist && \


### PR DESCRIPTION
Changesets is going to complain about missing one, but I think we can ignore it - I only made a small change to `tsconfig.json` to remove an error from vscode