### PR TITLE
feat: support more block explorers

### DIFF
--- a/.changeset/large-keys-help.md
+++ b/.changeset/large-keys-help.md
@@ -1,0 +1,5 @@
+---
+"@talismn/chaindata-provider": patch
+---
+
+fix taostats urls

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
@@ -1,6 +1,13 @@
 import { bind } from "@react-rxjs/core"
 import { Address, BalanceFormatter } from "@talismn/balances"
-import { EthNetworkId, isTokenInTypes, Network, Token, TokenId } from "@talismn/chaindata-provider"
+import {
+  EthNetworkId,
+  getBlockExplorerUrls,
+  isTokenInTypes,
+  Network,
+  Token,
+  TokenId,
+} from "@talismn/chaindata-provider"
 import {
   ChevronDownIcon,
   DiamondIcon,
@@ -159,10 +166,10 @@ const useBlockExplorerUrl = (token: Token | null) => {
 
   return useMemo(() => {
     if (isTokenInTypes(token, ["evm-erc20", "evm-uniswapv2"]) && network?.blockExplorerUrls[0])
-      return urlJoin(network.blockExplorerUrls[0], "token", token.contractAddress)
+      return getBlockExplorerUrls(network, { type: "address", address: token.contractAddress })[0]
 
     return null
-  }, [token, network?.blockExplorerUrls])
+  }, [token, network])
 }
 
 const useCoingeckoUrl = (token: Token | null) => {

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/AssetsDiscovery/AssetDiscoveryPage.tsx
@@ -165,8 +165,11 @@ const useBlockExplorerUrl = (token: Token | null) => {
   const network = useNetworkById(token?.networkId)
 
   return useMemo(() => {
-    if (isTokenInTypes(token, ["evm-erc20", "evm-uniswapv2"]) && network?.blockExplorerUrls[0])
-      return getBlockExplorerUrls(network, { type: "address", address: token.contractAddress })[0]
+    if (isTokenInTypes(token, ["evm-erc20", "evm-uniswapv2"]) && network)
+      return (
+        getBlockExplorerUrls(network, { type: "address", address: token.contractAddress })[0] ??
+        null
+      )
 
     return null
   }, [token, network])

--- a/apps/extension/src/ui/apps/popup/pages/Sign/substrate/MessageSiws.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Sign/substrate/MessageSiws.tsx
@@ -76,7 +76,7 @@ const ViewDetailsContent: FC<{
             "You are about to sign in via Substrate. Please ensure you trust the application before continuing.",
           )}
         </p>
-        <ViewDetailsAddress label={t("From")} address={account.address} />
+        <ViewDetailsAddress label={t("From")} address={account.address} network={null} />
         <ViewDetailsField label={t("Domain")}>{request.domain}</ViewDetailsField>
         <ViewDetailsField label={t("Statement")}>{request.statement}</ViewDetailsField>
         {request.chainId && (

--- a/apps/extension/src/ui/domains/Account/AddressLinkOrCopy.tsx
+++ b/apps/extension/src/ui/domains/Account/AddressLinkOrCopy.tsx
@@ -1,8 +1,7 @@
-import { NetworkId } from "@talismn/chaindata-provider"
+import { getBlockExplorerUrls, NetworkId } from "@talismn/chaindata-provider"
 import { CopyIcon, ExternalLinkIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
 import { FC, useCallback, useMemo } from "react"
-import urlJoin from "url-join"
 
 import { useAnyNetwork } from "@ui/state"
 import { copyAddress } from "@ui/util/copyAddress"
@@ -29,9 +28,9 @@ export const NetworkAddress: FC<NetworkAddressProps> = ({
   const network = useAnyNetwork(networkId)
 
   const blockExplorerUrl = useMemo(() => {
-    const baseUrl = network?.blockExplorerUrls?.[0] || null
-    return baseUrl ? urlJoin(baseUrl, "address", address) : null
-  }, [address, network?.blockExplorerUrls])
+    if (!network || !address) return null
+    return getBlockExplorerUrls(network, { type: "address", address })[0] ?? null
+  }, [address, network])
 
   const effectiveMode = useMemo(() => {
     // link must fallback to copy if no blockExplorerUrl

--- a/apps/extension/src/ui/domains/Erc20Tokens/CustomErc20TokenViewDetails.tsx
+++ b/apps/extension/src/ui/domains/Erc20Tokens/CustomErc20TokenViewDetails.tsx
@@ -32,7 +32,7 @@ export const CustomErc20TokenViewDetails = ({
             <ViewDetailsAddress
               label={t("Contract")}
               address={token.contractAddress}
-              blockExplorerUrl={network.blockExplorerUrls[0]}
+              network={network}
             />
           </div>
           <Button className="mt-12" onClick={close}>

--- a/apps/extension/src/ui/domains/Portfolio/DeFi/PositionContextMenu.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/DeFi/PositionContextMenu.tsx
@@ -1,3 +1,4 @@
+import { getBlockExplorerUrls } from "@talismn/chaindata-provider"
 import { MoreHorizontalIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
 import { DefiPosition } from "extension-core"
@@ -16,7 +17,9 @@ export const PositionContextMenu: FC<{ position: DefiPosition; className?: strin
 
   const blockExplorerUrl = useMemo(() => {
     if (!position.poolAddress || !network?.blockExplorerUrls.length) return null
-    return `${network.blockExplorerUrls[0]}/address/${position.poolAddress}`
+    return (
+      getBlockExplorerUrls(network, { type: "address", address: position.poolAddress })[0] ?? null
+    )
   }, [network, position.poolAddress])
 
   // dont display the menu if there is no action to provide

--- a/apps/extension/src/ui/domains/SendFunds/AddressDisplay.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/AddressDisplay.tsx
@@ -1,5 +1,5 @@
 import { Address as TAddress } from "@talismn/balances"
-import { NetworkId } from "@talismn/chaindata-provider"
+import { getBlockExplorerUrls, NetworkId } from "@talismn/chaindata-provider"
 import { encodeAddressSs58, encodeAnyAddress, normalizeAddress } from "@talismn/crypto"
 import { CopyIcon, ExternalLinkIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
@@ -7,7 +7,6 @@ import { getAccountGenesisHash, getAccountSignetUrl } from "extension-core"
 import { FC, useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
-import urlJoin from "url-join"
 
 import { shortenAddress } from "@talisman/util/shortenAddress"
 import { useOnChainId } from "@ui/hooks/useOnChainId"
@@ -33,8 +32,8 @@ const useBlockExplorerUrl = (
 
   return useMemo(() => {
     if (!resolvedAddress || !network?.blockExplorerUrls.length) return null
-    return urlJoin(network.blockExplorerUrls[0], "address", resolvedAddress)
-  }, [network?.blockExplorerUrls, resolvedAddress])
+    return getBlockExplorerUrls(network, { type: "address", address: resolvedAddress })[0] ?? null
+  }, [network, resolvedAddress])
 }
 
 const AddressTooltip: FC<{

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsProgress.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsProgress.tsx
@@ -17,8 +17,7 @@ import { useAnyNetwork, useNetworkById, useTransaction } from "@ui/state"
 import { TxReplaceDrawer, TxReplaceType } from "../Transactions"
 
 const getBlockExplorerUrl = (network: Network | undefined | null, hash: string) => {
-  const urls = getBlockExplorerUrls(network!, { type: "transaction", id: hash })
-  return urls[0]
+  return getBlockExplorerUrls(network!, { type: "transaction", id: hash })[0] ?? null
 }
 
 const TxReplaceActions: FC<{ tx: WalletTransaction }> = ({ tx }) => {

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsProgress.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsProgress.tsx
@@ -10,7 +10,6 @@ import {
 import { FC, useCallback, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { Button, PillButton, ProcessAnimation, ProcessAnimationStatus } from "talisman-ui"
-import urlJoin from "url-join"
 
 import { useSendFundsWizard } from "@ui/apps/popup/pages/SendFunds/context"
 import { useAnyNetwork, useNetworkById, useTransaction } from "@ui/state"
@@ -18,8 +17,8 @@ import { useAnyNetwork, useNetworkById, useTransaction } from "@ui/state"
 import { TxReplaceDrawer, TxReplaceType } from "../Transactions"
 
 const getBlockExplorerUrl = (network: Network | undefined | null, hash: string) => {
-  if (!network?.blockExplorerUrls.length) return undefined
-  return urlJoin(network.blockExplorerUrls[0], "tx", hash)
+  const urls = getBlockExplorerUrls(network!, { type: "transaction", id: hash })
+  return urls[0]
 }
 
 const TxReplaceActions: FC<{ tx: WalletTransaction }> = ({ tx }) => {

--- a/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessageSIWE.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessageSIWE.tsx
@@ -36,11 +36,7 @@ const ViewDetailsContent: FC<{
             "You are about to sign in via Ethereum. Please ensure you trust the application before continuing.",
           )}
         </p>
-        <ViewDetailsAddress
-          label={t("From")}
-          address={account.address}
-          blockExplorerUrl={evmNetwork?.blockExplorerUrls[0]}
-        />
+        <ViewDetailsAddress label={t("From")} address={account.address} network={evmNetwork} />
         <ViewDetailsField label={t("Domain")}>{siwe.domain}</ViewDetailsField>
         <ViewDetailsField label={t("Statement")}>{siwe.statement}</ViewDetailsField>
         <ViewDetailsField label={t("Network")}>

--- a/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsAddress.tsx
+++ b/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsAddress.tsx
@@ -1,3 +1,4 @@
+import { getBlockExplorerUrls, Network } from "@talismn/chaindata-provider"
 import { encodeAnyAddress } from "@talismn/crypto"
 import { CopyIcon, ExternalLinkIcon } from "@talismn/icons"
 import { FC, useCallback, useMemo } from "react"
@@ -13,17 +14,27 @@ import { ViewDetailsField, ViewDetailsFieldProps } from "./ViewDetailsField"
 
 export const ViewDetailsAddress: FC<
   ViewDetailsFieldProps & {
+    network: Network | null | undefined
     address?: string
-    blockExplorerUrl?: string | null
-    chainPrefix?: number | null
   }
-> = ({ address, blockExplorerUrl, chainPrefix, ...fieldProps }) => {
+> = ({ address, network, ...fieldProps }) => {
   const account = useAccountByAddress(address)
 
   const formatted = useMemo(
-    () => (address ? encodeAnyAddress(address, { ss58Format: chainPrefix ?? undefined }) : ""),
-    [address, chainPrefix],
+    () =>
+      address
+        ? encodeAnyAddress(address, {
+            ss58Format: network?.platform === "polkadot" ? network.prefix : undefined,
+          })
+        : "",
+    [address, network],
   )
+
+  const blockExplorerUrl = useMemo(() => {
+    if (!formatted || !network) return null
+    const urls = getBlockExplorerUrls(network, { type: "address", address: formatted })
+    return urls[0] ?? null
+  }, [formatted, network])
 
   const handleClick = useCallback(() => {
     if (!formatted) return

--- a/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsEth.tsx
+++ b/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsEth.tsx
@@ -133,16 +133,8 @@ const ViewDetailsContent: FC<ViewDetailsContentProps> = ({ onClose }) => {
               : t("Unknown")}
           </ViewDetailsField>
         )}
-        <ViewDetailsAddress
-          label={t("From")}
-          address={request.from}
-          blockExplorerUrl={network?.blockExplorerUrls[0]}
-        />
-        <ViewDetailsAddress
-          label={t("To")}
-          address={request.to ?? undefined}
-          blockExplorerUrl={network?.blockExplorerUrls[0]}
-        />
+        <ViewDetailsAddress label={t("From")} address={request.from} network={network} />
+        <ViewDetailsAddress label={t("To")} address={request.to ?? undefined} network={network} />
         <ViewDetailsField label={t("Value to be transferred")} breakAll>
           {formatEthValue(transaction?.value)}
         </ViewDetailsField>

--- a/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsSub.tsx
+++ b/apps/extension/src/ui/domains/Sign/ViewDetails/ViewDetailsSub.tsx
@@ -100,12 +100,7 @@ const ViewDetailsContent: FC<{
     <div className="bg-grey-850 flex max-h-[60rem] w-full flex-col gap-12 p-12">
       <div className="scrollable scrollable-700 flex-grow overflow-y-auto overflow-x-hidden pr-4 text-sm leading-[2rem]">
         <div className="text-body-secondary">{t("Details")}</div>
-        <ViewDetailsAddress
-          label={t("From")}
-          address={payload.address}
-          chainPrefix={chain?.prefix}
-          blockExplorerUrl={chain?.blockExplorerUrls[0]}
-        />
+        <ViewDetailsAddress label={t("From")} address={payload.address} network={chain} />
 
         {isExtrinsic ? (
           <>

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -7,7 +7,7 @@ import {
   RocketIcon,
   XOctagonIcon,
 } from "@talismn/icons"
-import { classNames, isNotNil, planckToTokens } from "@talismn/util"
+import { classNames, planckToTokens } from "@talismn/util"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { formatDistanceToNowStrict, Locale } from "date-fns"
 import {
@@ -23,7 +23,6 @@ import {
 } from "extension-core"
 import { IS_FIREFOX } from "extension-shared"
 import i18next from "i18next"
-import { uniq } from "lodash-es"
 import {
   FC,
   forwardRef,
@@ -320,7 +319,7 @@ const TxActionsEth: FC<{
 
   const blockExplorerUrls = useMemo(() => {
     if (!network) return []
-    return uniq(getBlockExplorerUrls(network, { type: "transaction", id: tx.id }).filter(isNotNil))
+    return getBlockExplorerUrls(network, { type: "transaction", id: tx.id })
   }, [network, tx])
 
   const { t } = useTranslation()
@@ -778,7 +777,7 @@ const TxActionsDefault: FC<{
 
   const blockExplorerUrls = useMemo(() => {
     if (!network) return []
-    return uniq(getBlockExplorerUrls(network, { type: "transaction", id: tx.id }).filter(isNotNil))
+    return getBlockExplorerUrls(network, { type: "transaction", id: tx.id })
   }, [network, tx])
 
   const { t } = useTranslation()

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -1,5 +1,5 @@
 import { BalanceFormatter } from "@talismn/balances"
-import { NetworkId } from "@talismn/chaindata-provider"
+import { getBlockExplorerLabel, getBlockExplorerUrls, NetworkId } from "@talismn/chaindata-provider"
 import {
   ArrowRightIcon,
   LoaderIcon,
@@ -7,7 +7,7 @@ import {
   RocketIcon,
   XOctagonIcon,
 } from "@talismn/icons"
-import { classNames, planckToTokens } from "@talismn/util"
+import { classNames, isNotNil, planckToTokens } from "@talismn/util"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { formatDistanceToNowStrict, Locale } from "date-fns"
 import {
@@ -23,6 +23,7 @@ import {
 } from "extension-core"
 import { IS_FIREFOX } from "extension-shared"
 import i18next from "i18next"
+import { uniq } from "lodash-es"
 import {
   FC,
   forwardRef,
@@ -43,7 +44,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "talisman-ui"
-import urlJoin from "url-join"
 
 import { useScrollContainer } from "@talisman/components/ScrollContainer"
 import { Fiat } from "@ui/domains/Asset/Fiat"
@@ -263,7 +263,7 @@ const ActionButton = forwardRef<
 ActionButton.displayName = "ActionButton"
 
 // this context menu prevents drawer animation to slide up correctly, render when it's finished
-const EvmTxActions: FC<{
+const TxActionsEth: FC<{
   tx: WalletTransactionEth
   enabled: boolean
   isOpen: boolean
@@ -276,6 +276,7 @@ const EvmTxActions: FC<{
   onContextMenuOpen,
   onContextMenuClose,
 }) => {
+  const network = useNetworkById(tx.networkId, "ethereum")
   const txInfo = tx.txInfo
   const canReplace = useCanReplaceTx(tx)
 
@@ -317,18 +318,10 @@ const EvmTxActions: FC<{
     if (IS_EMBEDDED_POPUP) window.close()
   }, [swapHref])
 
-  const hrefBlockExplorer = useMemo(
-    () =>
-      evmNetwork?.blockExplorerUrls[0]
-        ? urlJoin(evmNetwork.blockExplorerUrls[0], "tx", tx.hash)
-        : null,
-    [evmNetwork?.blockExplorerUrls, tx.hash],
-  )
-  const handleBlockExplorerClick = useCallback(() => {
-    if (!hrefBlockExplorer) return
-    window.open(hrefBlockExplorer, "_blank")
-    if (IS_EMBEDDED_POPUP) window.close()
-  }, [hrefBlockExplorer])
+  const blockExplorerUrls = useMemo(() => {
+    if (!network) return []
+    return uniq(getBlockExplorerUrls(network, { type: "transaction", id: tx.id }).filter(isNotNil))
+  }, [network, tx])
 
   const { t } = useTranslation()
 
@@ -415,15 +408,19 @@ const EvmTxActions: FC<{
                 {t("View swap status")}
               </button>
             )}
-            {hrefBlockExplorer && (
+            {blockExplorerUrls.map((url) => (
               <button
+                key={url}
                 type="button"
-                onClick={handleBlockExplorerClick}
+                onClick={() => {
+                  window.open(url, "_blank")
+                  if (IS_EMBEDDED_POPUP) window.close()
+                }}
                 className="hover:bg-grey-800 rounded-xs h-20 p-6 text-left"
               >
-                {t("View on block explorer")}
+                {t("View on {{label}}", { label: getBlockExplorerLabel(url) })}
               </button>
-            )}
+            ))}
             <button
               type="button"
               onClick={handleActionClick("dismiss")}
@@ -718,7 +715,7 @@ const TransactionRowEvm: FC<TransactionRowEthProps> = ({
         !!amount.fiat(currency) && <Fiat amount={amount} noCountUp isBalance />
       }
       actions={
-        <EvmTxActions
+        <TxActionsEth
           tx={tx}
           enabled={enabled}
           isOpen={isCtxMenuOpen}
@@ -779,16 +776,10 @@ const TxActionsDefault: FC<{
     if (IS_EMBEDDED_POPUP) window.close()
   }, [swapHref])
 
-  const hrefBlockExplorer = useMemo(
-    () =>
-      network?.blockExplorerUrls[0] ? urlJoin(network.blockExplorerUrls[0], "tx", tx.id) : null,
-    [network?.blockExplorerUrls, tx.id],
-  )
-  const handleBlockExplorerClick = useCallback(() => {
-    if (!hrefBlockExplorer) return
-    window.open(hrefBlockExplorer, "_blank")
-    if (IS_EMBEDDED_POPUP) window.close()
-  }, [hrefBlockExplorer])
+  const blockExplorerUrls = useMemo(() => {
+    if (!network) return []
+    return uniq(getBlockExplorerUrls(network, { type: "transaction", id: tx.id }).filter(isNotNil))
+  }, [network, tx])
 
   const { t } = useTranslation()
 
@@ -832,15 +823,19 @@ const TxActionsDefault: FC<{
                 {t("View swap status")}
               </button>
             )}
-            {hrefBlockExplorer && (
+            {blockExplorerUrls.map((url) => (
               <button
+                key={url}
                 type="button"
-                onClick={handleBlockExplorerClick}
+                onClick={() => {
+                  window.open(url, "_blank")
+                  if (IS_EMBEDDED_POPUP) window.close()
+                }}
                 className="hover:bg-grey-800 rounded-xs h-20 p-6 text-left"
               >
-                {t("View on block explorer")}
+                {t("View on {{label}}", { label: getBlockExplorerLabel(url) })}
               </button>
-            )}
+            ))}
             <button
               type="button"
               onClick={handleActionClick("dismiss")}

--- a/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
@@ -1,11 +1,10 @@
 import { HexString } from "@polkadot/util/types"
-import { Network } from "@talismn/chaindata-provider"
+import { getBlockExplorerUrls, Network } from "@talismn/chaindata-provider"
 import { ExternalLinkIcon, RocketIcon, XCircleIcon } from "@talismn/icons"
 import { WalletTransaction, WalletTransactionDot, WalletTransactionEth } from "extension-core"
 import { FC, useCallback, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { Button, PillButton, ProcessAnimation, ProcessAnimationStatus } from "talisman-ui"
-import urlJoin from "url-join"
 
 import { useSendFundsWizard } from "@ui/apps/popup/pages/SendFunds/context"
 import { useAnyNetwork, useNetworkById, useTransaction } from "@ui/state"
@@ -14,8 +13,10 @@ import { TxReplaceDrawer } from "./TxReplaceDrawer"
 import { TxReplaceType } from "./types"
 
 const getBlockExplorerUrl = (network: Network | undefined | null, hash: string) => {
-  const blockExplorerUrl = network?.blockExplorerUrls[0]
-  return blockExplorerUrl ? urlJoin(blockExplorerUrl, "tx", hash) : undefined
+  const blockExplorerUrls = network
+    ? getBlockExplorerUrls(network, { type: "transaction", id: hash })
+    : []
+  return blockExplorerUrls[0]
 }
 
 const TxReplaceActions: FC<{ tx: WalletTransaction }> = ({ tx }) => {

--- a/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
@@ -13,10 +13,8 @@ import { TxReplaceDrawer } from "./TxReplaceDrawer"
 import { TxReplaceType } from "./types"
 
 const getBlockExplorerUrl = (network: Network | undefined | null, hash: string) => {
-  const blockExplorerUrls = network
-    ? getBlockExplorerUrls(network, { type: "transaction", id: hash })
-    : []
-  return blockExplorerUrls[0]
+  if (!network) return null
+  return getBlockExplorerUrls(network, { type: "transaction", id: hash })[0] ?? null
 }
 
 const TxReplaceActions: FC<{ tx: WalletTransaction }> = ({ tx }) => {
@@ -140,7 +138,7 @@ type TxProgressBaseProps = {
   className?: string
   blockNumber?: string
   onClose?: () => void
-  href?: string
+  href?: string | null
 }
 
 const TxProgressBase: FC<TxProgressBaseProps> = ({ tx, blockNumber, href, onClose }) => {

--- a/apps/extension/src/ui/domains/ViewOnExplorer/ExplorerNetworkPicker.tsx
+++ b/apps/extension/src/ui/domains/ViewOnExplorer/ExplorerNetworkPicker.tsx
@@ -1,10 +1,9 @@
-import { Network } from "@talismn/chaindata-provider"
+import { getBlockExplorerUrls, Network } from "@talismn/chaindata-provider"
 import { ExternalLinkIcon, XIcon } from "@talismn/icons"
 import { isAccountCompatibleWithNetwork, isAddressCompatibleWithNetwork } from "extension-core"
 import { FC, useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { IconButton } from "talisman-ui"
-import urlJoin from "url-join"
 
 import { ScrollContainer } from "@talisman/components/ScrollContainer"
 import { SearchInput } from "@talisman/components/SearchInput"
@@ -80,8 +79,9 @@ export const ExplorerNetworkPicker: FC<{ address: string; onClose: () => void }>
 
   const handleNetworkClick = useCallback(
     (network: Network) => () => {
-      if (!network.blockExplorerUrls.length) return
-      window.open(urlJoin(network.blockExplorerUrls[0], "address", address), "_blank")
+      const urls = getBlockExplorerUrls(network, { type: "address", address })
+      if (!urls.length) return
+      window.open(urls[0], "_blank")
       onClose()
     },
     [address, onClose],

--- a/apps/extension/src/ui/domains/ViewOnExplorer/ExplorerNetworkPicker.tsx
+++ b/apps/extension/src/ui/domains/ViewOnExplorer/ExplorerNetworkPicker.tsx
@@ -79,9 +79,9 @@ export const ExplorerNetworkPicker: FC<{ address: string; onClose: () => void }>
 
   const handleNetworkClick = useCallback(
     (network: Network) => () => {
-      const urls = getBlockExplorerUrls(network, { type: "address", address })
-      if (!urls.length) return
-      window.open(urls[0], "_blank")
+      const url = getBlockExplorerUrls(network, { type: "address", address })[0]
+      if (!url) return
+      window.open(url, "_blank")
       onClose()
     },
     [address, onClose],

--- a/apps/extension/src/ui/domains/ViewOnExplorer/useViewOnExplorer.ts
+++ b/apps/extension/src/ui/domains/ViewOnExplorer/useViewOnExplorer.ts
@@ -1,5 +1,5 @@
+import { getBlockExplorerUrls } from "@talismn/chaindata-provider"
 import { useCallback, useMemo } from "react"
-import urlJoin from "url-join"
 
 import { useNetworkByGenesisHash, useNetworkById } from "@ui/state"
 
@@ -16,7 +16,11 @@ export const useViewOnExplorer = (address: string, networkIdOrHash?: string | nu
   const { open: openNetworkPickerModal } = useExplorerNetworkPickerModal()
   const network = useChainByIdOrGenesisHash(networkIdOrHash)
 
-  const blockExplorerUrl = useMemo(() => network?.blockExplorerUrls[0] || null, [network])
+  const blockExplorerUrl = useMemo(
+    () =>
+      network ? (getBlockExplorerUrls(network, { type: "address", address })[0] ?? null) : null,
+    [address, network],
+  )
 
   const canOpen = useMemo(
     () => !networkIdOrHash || blockExplorerUrl,
@@ -25,7 +29,7 @@ export const useViewOnExplorer = (address: string, networkIdOrHash?: string | nu
 
   const open = useCallback(() => {
     if (blockExplorerUrl) {
-      window.open(urlJoin(blockExplorerUrl, "address", address), "_blank")
+      window.open(blockExplorerUrl, "_blank")
     } else {
       openNetworkPickerModal({ address })
     }

--- a/packages/chaindata-provider/src/getBlockExplorerUrls.ts
+++ b/packages/chaindata-provider/src/getBlockExplorerUrls.ts
@@ -119,6 +119,8 @@ const getQueryPath = (query: BlockExplorerQuery, host: ExplorerHost): string | n
         case "statescan.io":
         case "subscan.io":
           return `/accounts/${query.address}`
+        case "taostats.io":
+          return `/account/${query.address}`
         default:
           return `/address/${query.address}`
       }

--- a/packages/chaindata-provider/src/getBlockExplorerUrls.ts
+++ b/packages/chaindata-provider/src/getBlockExplorerUrls.ts
@@ -1,4 +1,4 @@
-import { startCase } from "lodash-es"
+import { startCase, uniq } from "lodash-es"
 
 import { Network } from "./chaindata"
 
@@ -33,9 +33,11 @@ export type BlockExplorerQuery =
     }
 
 export const getBlockExplorerUrls = (network: Network, query: BlockExplorerQuery): string[] => {
-  return network.blockExplorerUrls
-    .map((explorerUrl) => getExplorerUrl(explorerUrl, query, network.rpcs?.[0]))
-    .filter(Boolean) as string[]
+  return uniq(
+    network.blockExplorerUrls
+      .map((explorerUrl) => getExplorerUrl(explorerUrl, query, network.rpcs?.[0]))
+      .filter(Boolean) as string[],
+  )
 }
 
 const getExplorerUrl = (

--- a/packages/chaindata-provider/src/getBlockExplorerUrls.ts
+++ b/packages/chaindata-provider/src/getBlockExplorerUrls.ts
@@ -2,7 +2,7 @@ import { startCase } from "lodash-es"
 
 import { Network } from "./chaindata"
 
-type ExplorerQuery =
+export type BlockExplorerQuery =
   | {
       type: "address"
       // to be used for contracts mainly, otherwise use "account"
@@ -32,7 +32,7 @@ type ExplorerQuery =
       hash: `0x${string}`
     }
 
-export const getBlockExplorerUrls = (network: Network, query: ExplorerQuery): string[] => {
+export const getBlockExplorerUrls = (network: Network, query: BlockExplorerQuery): string[] => {
   return network.blockExplorerUrls
     .map((explorerUrl) => getExplorerUrl(explorerUrl, query, network.rpcs?.[0]))
     .filter(Boolean) as string[]
@@ -40,7 +40,7 @@ export const getBlockExplorerUrls = (network: Network, query: ExplorerQuery): st
 
 const getExplorerUrl = (
   explorerUrl: string,
-  query: ExplorerQuery,
+  query: BlockExplorerQuery,
   rpcUrl?: string,
 ): string | null => {
   if (explorerUrl.includes("{RPC_URL}")) {
@@ -95,14 +95,17 @@ const getExplorerHost = (explorerUrl: URL): ExplorerHost => {
   return parts.length > 2 ? parts.slice(-2).join(".") : hostname
 }
 
-const getQueryPath = (query: ExplorerQuery, host: ExplorerHost): string | null => {
+const getQueryPath = (query: BlockExplorerQuery, host: ExplorerHost): string | null => {
   switch (query.type) {
     case "transaction":
       switch (host) {
         case "avail.so":
         case "polkadot.js":
-        case "statescan.io":
           return null
+        case "statescan.io":
+          return `/extrinsics/${query.id}`
+        case "taostats.io":
+          return `/hash/${query.id}`
         default:
           return `/tx/${query.id}`
       }

--- a/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
+++ b/packages/extension-core/src/domains/transactions/watchEthereumTransaction.ts
@@ -1,7 +1,6 @@
 import { assert } from "@polkadot/util"
-import { NetworkId } from "@talismn/chaindata-provider"
+import { getBlockExplorerUrls, NetworkId } from "@talismn/chaindata-provider"
 import { sleep, throwAfter } from "@talismn/util"
-import urlJoin from "url-join"
 import { Hex, TransactionReceipt, TransactionRequest } from "viem"
 
 import { sentry } from "../../config/sentry"
@@ -31,9 +30,11 @@ export const watchEthereumTransaction = async (
     if (!client) throw new Error(`No client for network ${evmNetworkId} (${ethereumNetwork.name})`)
 
     const networkName = ethereumNetwork.name ?? "unknown network"
-    const txUrl = ethereumNetwork.blockExplorerUrls[0]
-      ? urlJoin(ethereumNetwork.blockExplorerUrls[0], "tx", hash)
-      : chrome.runtime.getURL("dashboard.html#/tx-history")
+    const blockExplorerUrls = getBlockExplorerUrls(ethereumNetwork, {
+      type: "transaction",
+      id: hash,
+    })
+    const txUrl = blockExplorerUrls[0] ?? chrome.runtime.getURL("dashboard.html#/tx-history")
 
     // PENDING
     if (withNotifications) await createNotification("submitted", networkName, txUrl)

--- a/packages/extension-core/src/domains/transactions/watchSubstrateTransaction.ts
+++ b/packages/extension-core/src/domains/transactions/watchSubstrateTransaction.ts
@@ -4,10 +4,9 @@ import { assert } from "@polkadot/util"
 import { xxhashAsHex } from "@polkadot/util-crypto"
 import { HexString } from "@polkadot/util/types"
 import { SignerPayloadJSON } from "@substrate/txwrapper-core"
-import { DotNetwork, DotNetworkId } from "@talismn/chaindata-provider"
+import { DotNetwork, DotNetworkId, getBlockExplorerUrls } from "@talismn/chaindata-provider"
 import { log } from "extension-shared"
 import { Err, Ok, Result } from "ts-results"
-import urlJoin from "url-join"
 
 import { sentry } from "../../config/sentry"
 import { createNotification, NotificationType } from "../../notifications"
@@ -272,11 +271,10 @@ export const watchSubstrateTransaction = async (
       async (result, blockNumber, extIndex, finalized) => {
         const type: NotificationType = result === "included" ? "submitted" : result
 
-        const url = chain.blockExplorerUrls[0]
-          ? urlJoin(chain.blockExplorerUrls[0], "extrinsic", `${blockNumber}-${extIndex}`)
-          : chrome.runtime.getURL("dashboard.html#/tx-history")
+        const blockExplorerUrls = getBlockExplorerUrls(chain, { type: "transaction", id: hash })
+        const txUrl = blockExplorerUrls[0] ?? chrome.runtime.getURL("dashboard.html#/tx-history")
 
-        if (withNotifications) createNotification(type, chain.name ?? "chain", url)
+        if (withNotifications) createNotification(type, chain.name ?? "chain", txUrl)
 
         if (result !== "included")
           await updateTransactionStatus(hash, result, blockNumber, finalized)


### PR DESCRIPTION
Adds support for block explorer specific patterns.
This is mainly for substrate block explorers other than subscan.io.

Once this PR is merged, we will be able to add taostats.io, statescan.io and others in chaindata.

For testing the PR, add them manually in network settings