### PR TITLE
fix: allow add stake in a nom pool with less than the minJoinBond

### DIFF
--- a/apps/extension/src/ui/domains/Staking/hooks/nomPools/useGetNomPoolStakingPayload.ts
+++ b/apps/extension/src/ui/domains/Staking/hooks/nomPools/useGetNomPoolStakingPayload.ts
@@ -24,11 +24,14 @@ export const useGetNomPoolStakingPayload = ({
   minJoinBond,
 }: GetNomPoolStakingPayload) => {
   // use minJoinBond to get an accurate a 'fake fee estimate' if the amount is 0 or less than minJoinBond
-  const amount = useMemo(
-    () =>
-      typeof minJoinBond === "bigint" && plancks && plancks >= minJoinBond ? plancks : minJoinBond,
-    [minJoinBond, plancks],
-  )
+  const amount = useMemo(() => {
+    // no minimum if already in pool
+    if (plancks && hasJoinedNomPool) return plancks
+    // must at least stake minJoinBond
+    if (typeof minJoinBond === "bigint" && plancks && plancks >= minJoinBond) return plancks
+    // default to minJoinBond
+    return minJoinBond
+  }, [hasJoinedNomPool, minJoinBond, plancks])
 
   return useQuery({
     queryKey: [


### PR DESCRIPTION
if the user input value was less than the minJoinBond, the tx payload was crafted using the minJoinBond value instead.
when re-staking, a minimum value should not be enforced.