### PR TITLE
fix: portfolio stake button for TAO should not preselect netuid

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetRow.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/DashboardAssetRow.tsx
@@ -119,7 +119,11 @@ export const AssetRow: FC<{ balances: Balances; noCountUp?: boolean }> = ({
       {canBond && (
         <>
           <div className="absolute right-8 top-0 hidden h-[6.6rem] flex-col justify-center group-hover:flex">
-            <BondPillButton balances={balances} className="[>svg]:text-[2rem] text-base" />
+            <BondPillButton
+              balances={balances}
+              ignoreExistingSettings
+              className="[>svg]:text-[2rem] text-base"
+            />
           </div>
           <div className="absolute -right-5 -top-2 size-10 overflow-hidden rounded-full bg-black p-1">
             <div className="text-primary bg-primary/25 flex size-full items-center justify-center rounded-full text-xs">

--- a/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetsTable/PopupAssetsTable.tsx
@@ -175,7 +175,11 @@ const AssetRow: FC<{
       </button>
       {showStakingButton && (
         <div className="absolute right-4 top-0 hidden h-28 flex-col justify-center group-hover:flex">
-          <BondPillButton balances={balances} className="[>svg]:text-[2rem] text-base" />
+          <BondPillButton
+            balances={balances}
+            ignoreExistingSettings
+            className="[>svg]:text-[2rem] text-base"
+          />
         </div>
       )}
     </div>

--- a/apps/extension/src/ui/domains/Staking/Bond/BondPillButton.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bond/BondPillButton.tsx
@@ -8,10 +8,11 @@ import { useBondButton } from "./hooks/useBondButton"
 
 export const BondPillButton: FC<{
   balances: Balances
+  ignoreExistingSettings?: boolean
   className?: string
-}> = ({ balances, className }) => {
+}> = ({ balances, className, ignoreExistingSettings }) => {
   const { t } = useTranslation()
-  const { onClick } = useBondButton({ balances })
+  const { onClick } = useBondButton({ balances, ignoreExistingSettings })
 
   if (!onClick) return null
 

--- a/apps/extension/src/ui/domains/Staking/Bond/hooks/useBondButton.ts
+++ b/apps/extension/src/ui/domains/Staking/Bond/hooks/useBondButton.ts
@@ -12,7 +12,14 @@ import { useBittensorNetworkIds } from "@ui/state/bittensor"
 import { useBittensorBondModal } from "../../Bittensor/hooks/useBittensorBondModal"
 import { useBondModal } from "./useBondModal"
 
-export const useBondButton = ({ balances }: { balances: Balances | null | undefined }) => {
+export const useBondButton = ({
+  balances,
+  ignoreExistingSettings,
+}: {
+  balances: Balances | null | undefined
+  // for now only used for bittensor to prevent reusing existing netuid
+  ignoreExistingSettings?: boolean
+}) => {
   const { genericEvent } = useAnalytics()
   const ownedAccounts = useAccounts("owned")
 
@@ -57,7 +64,7 @@ export const useBondButton = ({ balances }: { balances: Balances | null | undefi
             address,
             networkId,
             hotkey,
-            netuid,
+            netuid: ignoreExistingSettings ? undefined : netuid,
           })
           break
         }
@@ -77,6 +84,7 @@ export const useBondButton = ({ balances }: { balances: Balances | null | undefi
       bestBondableBalance,
       genericEvent,
       handleOpenBittensorModal,
+      ignoreExistingSettings,
       remoteConfig.seek.webAppStakingPath,
       open,
     ],


### PR DESCRIPTION
at this time when clicking stake on TAO row, if user is already staking, the staking form will be prefilled with same setting, preventing the user to choose between root staking or dtao.
this PR makes it so that the existing netuid is ignored.