### PR TITLE
Feat/bittensor per subnet fee

### DIFF
--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
@@ -35,6 +35,8 @@ import { BittensorSelectButton } from "../BittensorSelectButton"
 import { BittensorSlippageDrawer } from "../Drawers/BittensorSlippageDrawer"
 import { BittensorWarningDrawer } from "../Drawers/BittensorWarningDrawer"
 
+const MAX_TOTAL_FEE_DISCOUNT = 1
+
 export const BittensorSubnetBondReview = () => {
   const [isDisabled, setIsDisabled] = useState(true)
   const [hideWarning] = useAppState("hideBittensorSubnetStakeWarning")
@@ -94,9 +96,9 @@ export const BittensorSubnetBondReview = () => {
   }, [subnetFee])
 
   const totalFeeDiscount = useMemo(() => {
-    if (subnetFeeDiscount === 1) {
+    if (subnetFeeDiscount === MAX_TOTAL_FEE_DISCOUNT) {
       // Discount cannot be greater than 100%
-      return 1
+      return MAX_TOTAL_FEE_DISCOUNT
     } else if (isSeekTaoDiscountEnabled) {
       // Calculate total discount, combining subnet fee discount and seek discount
       return tier.discount + subnetFeeDiscount
@@ -105,7 +107,11 @@ export const BittensorSubnetBondReview = () => {
     return subnetFeeDiscount
   }, [subnetFeeDiscount, isSeekTaoDiscountEnabled, tier.discount])
 
-  const totalDiscountPercent = `${totalFeeDiscount * 100}%`
+  const totalDiscountPercent = useMemo(() => `${totalFeeDiscount * 100}%`, [totalFeeDiscount])
+  const isSeekDrawerEnabled = useMemo(
+    () => isSeekTaoDiscountEnabled && totalFeeDiscount < MAX_TOTAL_FEE_DISCOUNT,
+    [isSeekTaoDiscountEnabled, totalFeeDiscount],
+  )
 
   const { isLoading } = useCombinedSubnetData()
 
@@ -277,9 +283,9 @@ export const BittensorSubnetBondReview = () => {
                   type="button"
                   className={classNames(
                     "rounded-[43px] bg-[#D5FF5C] bg-opacity-[0.1] px-3 py-1",
-                    !isSeekTaoDiscountEnabled && "cursor-default",
+                    !isSeekDrawerEnabled && "cursor-default",
                   )}
-                  onClick={isSeekTaoDiscountEnabled ? seekDiscountDrawer.open : undefined}
+                  onClick={isSeekDrawerEnabled ? seekDiscountDrawer.open : undefined}
                 >
                   <div className="text-[1rem] text-[#D5FF5C]">
                     {totalFeeDiscount > 0 ? (

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
@@ -87,11 +87,11 @@ export const BittensorSubnetBondReview = () => {
       return 0
     } else if (subnetFee === 0) {
       // 100% discount
-      return 1
+      return MAX_TOTAL_FEE_DISCOUNT
     } else {
       // Calculate discount percentage
       const discountDiff = TALISMAN_FEE_BITTENSOR - subnetFee
-      return (discountDiff * 1) / TALISMAN_FEE_BITTENSOR
+      return discountDiff / TALISMAN_FEE_BITTENSOR
     }
   }, [subnetFee])
 

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
@@ -1,6 +1,6 @@
 import { InfoIcon, SettingsIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
 
@@ -20,6 +20,7 @@ import { StakingFeeEstimate } from "../../../shared/StakingFeeEstimate"
 import { StakingUnbondingPeriod } from "../../../shared/StakingUnbondingPeriod"
 import { useBittensorBondModal } from "../../hooks/useBittensorBondModal"
 import { useBittensorBondWizard } from "../../hooks/useBittensorBondWizard"
+import { useGetSubnetFee } from "../../hooks/useGetSubnetFee"
 import {
   DEFAULT_USER_MAX_SLIPPAGE,
   DTAO_LOGO,
@@ -71,9 +72,40 @@ export const BittensorSubnetBondReview = () => {
   const { tier } = useGetSeekDiscount()
   const { seekDiscountDrawer } = useBittensorBondWizard()
   const { close } = useBittensorBondModal()
+  const subnetFee = useGetSubnetFee({
+    netuid: netuid ?? 0,
+    direction: stakeDirection === "bond" ? "taoToAlpha" : "alphaToTao",
+  })
 
   const { discount } = tier
-  const discountPercent = `${tier.discount * 100}%`
+
+  const subnetFeeDiscount = useMemo(() => {
+    if (subnetFee === TALISMAN_FEE_BITTENSOR) {
+      // No discount
+      return 0
+    } else if (subnetFee === 0) {
+      // 100% discount
+      return 1
+    } else {
+      // Calculate discount percentage
+      const discountDiff = TALISMAN_FEE_BITTENSOR - subnetFee
+      return (discountDiff * 1) / TALISMAN_FEE_BITTENSOR
+    }
+  }, [subnetFee])
+
+  const totalFeeDiscount = useMemo(() => {
+    if (subnetFeeDiscount === 1) {
+      // Discount cannot be greater than 100%
+      return 1
+    } else if (isSeekTaoDiscountEnabled) {
+      // Calculate total discount, combining subnet fee discount and seek discount
+      return tier.discount + subnetFeeDiscount
+    }
+    // subnet fee discount only
+    return subnetFeeDiscount
+  }, [subnetFeeDiscount, isSeekTaoDiscountEnabled, tier.discount])
+
+  const totalDiscountPercent = `${totalFeeDiscount * 100}%`
 
   const { isLoading } = useCombinedSubnetData()
 
@@ -234,20 +266,25 @@ export const BittensorSubnetBondReview = () => {
                 </TooltipTrigger>
                 <TooltipContent>
                   <span className="overflow-hidden text-ellipsis whitespace-nowrap">
-                    {t(`Talisman applies a ${TALISMAN_FEE_BITTENSOR}% fee to each transaction.`)}
+                    {subnetFee === 0
+                      ? t("Talisman doesn’t apply any fee to this transaction.")
+                      : t(`Talisman applies a ${TALISMAN_FEE_BITTENSOR}% fee to each transaction.`)}
                   </span>
                 </TooltipContent>
               </Tooltip>
-              {isSeekTaoDiscountEnabled && (
+              {totalFeeDiscount > 0 && (
                 <button
                   type="button"
-                  className="rounded-[43px] bg-[#D5FF5C] bg-opacity-[0.1] px-3 py-1"
-                  onClick={seekDiscountDrawer.open}
+                  className={classNames(
+                    "rounded-[43px] bg-[#D5FF5C] bg-opacity-[0.1] px-3 py-1",
+                    !isSeekTaoDiscountEnabled && "cursor-default",
+                  )}
+                  onClick={isSeekTaoDiscountEnabled ? seekDiscountDrawer.open : undefined}
                 >
                   <div className="text-[1rem] text-[#D5FF5C]">
-                    {discount ? (
+                    {totalFeeDiscount > 0 ? (
                       <>
-                        {discountPercent} {t("Off Fees")}
+                        {totalDiscountPercent} {t("Off Fees")}
                       </>
                     ) : (
                       t("Get Discount")

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/types.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/types.ts
@@ -1,0 +1,1 @@
+export type StakeDirection = "taoToAlpha" | "alphaToTao"

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useGetDynamicTaoStakeInfo.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useGetDynamicTaoStakeInfo.ts
@@ -3,12 +3,13 @@ import { useMemo } from "react"
 
 import { useSubnetDynamicInfo } from "../../hooks/bittensor/dTao/useGetSubnetMetagraphByNetuid"
 import { useGetSeekDiscount } from "../../Seek/hooks/useGetSeekDiscount"
-import { TALISMAN_FEE_BITTENSOR } from "../utils/constants"
+import { StakeDirection } from "./types"
+import { useGetSubnetFee } from "./useGetSubnetFee"
 
 type GetDynamicTaoStakeInfoProps = {
   netuid: number | null
   amount: bigint | null
-  direction: "taoToAlpha" | "alphaToTao"
+  direction: StakeDirection
   userMaxSlippage: number
   minJoinBond: bigint | null | undefined
 }
@@ -22,6 +23,7 @@ export const useGetDynamicTaoStakeInfo = ({
 }: GetDynamicTaoStakeInfoProps) => {
   const { data, isLoading, isError } = useSubnetDynamicInfo({ netuid })
   const { tier } = useGetSeekDiscount()
+  const subnetFee = useGetSubnetFee({ netuid: netuid ?? 0, direction })
 
   const isTaoToAlpha = useMemo(() => direction === "taoToAlpha", [direction])
 
@@ -46,8 +48,8 @@ export const useGetDynamicTaoStakeInfo = ({
   )
 
   const taoToAlphaTalismanFee = useMemo(
-    () => calculateFee({ amount, fee: TALISMAN_FEE_BITTENSOR, seekDiscount: tier.discount }),
-    [amount, tier.discount],
+    () => calculateFee({ amount, fee: subnetFee, seekDiscount: tier.discount }),
+    [amount, subnetFee, tier.discount],
   )
 
   // calculate the conversion rate of 1 Tao to alpha with zero slippage
@@ -85,10 +87,10 @@ export const useGetDynamicTaoStakeInfo = ({
     () =>
       calculateFee({
         amount: BigInt(Math.round(taoAmountFromAlpha)),
-        fee: TALISMAN_FEE_BITTENSOR,
+        fee: subnetFee,
         seekDiscount: tier.discount,
       }),
-    [taoAmountFromAlpha, tier.discount],
+    [subnetFee, taoAmountFromAlpha, tier.discount],
   )
 
   const alphaToTaoSlippage = useMemo(

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useGetSubnetFee.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useGetSubnetFee.ts
@@ -1,0 +1,24 @@
+import { useRemoteConfig } from "@ui/state/remoteConfig"
+
+import { TALISMAN_FEE_BITTENSOR } from "../utils/constants"
+import { StakeDirection } from "./types"
+
+export const useGetSubnetFee = ({
+  netuid,
+  direction,
+}: {
+  netuid: number
+  direction: StakeDirection
+}): number => {
+  const remoteConfig = useRemoteConfig()
+
+  const {
+    bittensor: { fee },
+  } = remoteConfig
+
+  if (direction === "alphaToTao") {
+    return fee.sell[netuid] ?? TALISMAN_FEE_BITTENSOR
+  }
+
+  return fee.buy[netuid] ?? TALISMAN_FEE_BITTENSOR
+}

--- a/packages/extension-core/src/domains/app/store.remoteConfig.ts
+++ b/packages/extension-core/src/domains/app/store.remoteConfig.ts
@@ -75,6 +75,12 @@ export const DEFAULT_REMOTE_CONFIG: RemoteConfigStoreData = {
       },
     ],
   },
+  bittensor: {
+    fee: {
+      buy: {},
+      sell: {},
+    },
+  },
 }
 
 const CONFIG_TIMEOUT = 30 * 60 * 1000 // 30 minutes

--- a/packages/extension-core/src/domains/app/types.ts
+++ b/packages/extension-core/src/domains/app/types.ts
@@ -50,6 +50,12 @@ export type RemoteConfigStoreData = {
       discount: number
     }>
   }
+  bittensor: {
+    fee: {
+      buy: Record<number, number>
+      sell: Record<number, number>
+    }
+  }
 }
 
 export interface RequestOnboardCreatePassword {


### PR DESCRIPTION
## Description

- Consumes fee by netuid and direction from remote config
- Display new fee discount

### 🧪 **Sample tx:**

- [No fees charged when buying SN 45](https://taostats.io/extrinsic/6864018-0013)
- [Fees charged when selling SN 45](https://taostats.io/extrinsic/6863951-0022)
- [Fees charged when buying other SN](https://taostats.io/extrinsic/6863959-0018)
- [Fees charged when selling other SN](https://taostats.io/extrinsic/6863966-0020)

### 🖼️ **Screenshots:**


https://github.com/user-attachments/assets/f4ad08fa-7a4c-4fad-ba3b-bc2e18f6dfd1

