### PR TITLE
fix: tokens/fiat inputs with send max

### DIFF
--- a/apps/extension/src/ui/domains/SendFunds/SendFundsAmountForm/AmountEdit.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsAmountForm/AmountEdit.tsx
@@ -58,8 +58,13 @@ const TokenInput = ({ onTokenClick }: { onTokenClick: () => void }) => {
   )
 
   const [value, setValue] = useState(formattedValue)
+  const refSkipSync = useRef(false)
 
   useEffect(() => {
+    if (refSkipSync.current) {
+      refSkipSync.current = false
+      return
+    }
     setValue(formattedValue)
   }, [formattedValue])
 
@@ -67,6 +72,7 @@ const TokenInput = ({ onTokenClick }: { onTokenClick: () => void }) => {
     (e) => {
       if (sendMax) set("sendMax", false)
       const nextValue = e.target.value ?? ""
+      refSkipSync.current = true
       setValue(nextValue)
       const num = Number(nextValue)
       if (token && nextValue.length && !isNaN(num))
@@ -129,8 +135,13 @@ const FiatInput = () => {
   )
 
   const [value, setValue] = useState(formattedValue)
+  const refSkipSync = useRef(false)
 
   useEffect(() => {
+    if (refSkipSync.current) {
+      refSkipSync.current = false
+      return
+    }
     setValue(formattedValue)
   }, [formattedValue])
 
@@ -138,6 +149,7 @@ const FiatInput = () => {
     (e) => {
       if (sendMax) set("sendMax", false)
       const nextValue = e.target.value ?? ""
+      refSkipSync.current = true
       setValue(nextValue)
       const num = Number(nextValue)
       const tokenRate = tokenRates?.[currency]

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsAmountForm/AmountEdit.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsAmountForm/AmountEdit.tsx
@@ -2,7 +2,6 @@ import { AlertCircleIcon, SwapIcon } from "@talismn/icons"
 import { classNames, tokensToPlanck } from "@talismn/util"
 import BigNumber from "bignumber.js"
 import { log } from "extension-shared"
-import debounce from "lodash-es/debounce"
 import {
   ChangeEventHandler,
   FC,
@@ -43,22 +42,13 @@ const normalizeStringNumber = (value?: string | number | null, decimals = 18) =>
 
 const TokenInput = ({ onTokenClick }: { onTokenClick: () => void }) => {
   const { set, remove } = useSendFundsWizard()
-  const { tokenId, token, transfer, maxAmount, isEstimatingMaxAmount, sendMax, amount } =
-    useSendFunds()
+  const { tokenId, token, transfer, maxAmount, isEstimatingMaxAmount, sendMax } = useSendFunds()
 
   const refTokensInput = useRef<HTMLInputElement>(null)
   useSendFundsInputNumber(refTokensInput, token?.decimals)
   useInputAutoWidth(refTokensInput)
 
-  useEffect(() => {
-    if (sendMax && refTokensInput.current && maxAmount?.tokens) {
-      const expectedInputValue = normalizeStringNumber(maxAmount.tokens, token?.decimals)
-      if (refTokensInput.current.value !== expectedInputValue)
-        refTokensInput.current.value = expectedInputValue
-    }
-  }, [amount, sendMax, token, maxAmount])
-
-  const defaultValue = useMemo(
+  const formattedValue = useMemo(
     () =>
       normalizeStringNumber(
         sendMax && maxAmount ? maxAmount.tokens : transfer?.tokens,
@@ -67,17 +57,22 @@ const TokenInput = ({ onTokenClick }: { onTokenClick: () => void }) => {
     [maxAmount, sendMax, token?.decimals, transfer?.tokens],
   )
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const [value, setValue] = useState(formattedValue)
+
+  useEffect(() => {
+    setValue(formattedValue)
+  }, [formattedValue])
+
   const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
-    debounce((e) => {
+    (e) => {
       if (sendMax) set("sendMax", false)
-
-      const text = e.target.value ?? ""
-      const num = Number(text)
-
-      if (token && text.length && !isNaN(num)) set("amount", tokensToPlanck(text, token.decimals))
+      const nextValue = e.target.value ?? ""
+      setValue(nextValue)
+      const num = Number(nextValue)
+      if (token && nextValue.length && !isNaN(num))
+        set("amount", tokensToPlanck(nextValue, token.decimals))
       else remove("amount")
-    }, 250),
+    },
     [remove, sendMax, set, token],
   )
 
@@ -101,7 +96,7 @@ const TokenInput = ({ onTokenClick }: { onTokenClick: () => void }) => {
         ref={refTokensInput}
         type="text"
         inputMode="decimal"
-        defaultValue={defaultValue}
+        value={value}
         placeholder="0"
         className={classNames(
           "text-body peer inline-block min-w-0 text-ellipsis bg-transparent text-xl",
@@ -124,15 +119,7 @@ const FiatInput = () => {
   useInputAutoWidth(refFiatInput)
   const currency = useSelectedCurrency()
 
-  useEffect(() => {
-    if (sendMax && refFiatInput.current && typeof maxAmount?.fiat(currency) === "number") {
-      const expectedInputValue = maxAmount?.fiat(currency)?.toString() ?? ""
-      if (refFiatInput.current.value !== expectedInputValue)
-        refFiatInput.current.value = expectedInputValue
-    }
-  }, [sendMax, currency, maxAmount])
-
-  const defaultValue = useMemo(
+  const formattedValue = useMemo(
     () =>
       normalizeStringNumber(
         sendMax && maxAmount ? maxAmount.fiat(currency) : transfer?.fiat(currency),
@@ -141,22 +128,27 @@ const FiatInput = () => {
     [currency, maxAmount, sendMax, transfer],
   )
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
-    debounce((e) => {
-      if (sendMax) set("sendMax", false)
+  const [value, setValue] = useState(formattedValue)
 
-      const text = e.target.value ?? ""
-      const num = Number(text)
+  useEffect(() => {
+    setValue(formattedValue)
+  }, [formattedValue])
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      if (sendMax) set("sendMax", false)
+      const nextValue = e.target.value ?? ""
+      setValue(nextValue)
+      const num = Number(nextValue)
       const tokenRate = tokenRates?.[currency]
 
-      if (token && tokenRate && text.length && !isNaN(num)) {
-        const fiat = parseFloat(text)
+      if (token && tokenRate && nextValue.length && !isNaN(num)) {
+        const fiat = parseFloat(nextValue)
         const tokens = (fiat / tokenRate.price).toFixed(Math.ceil(token.decimals / 3))
         set("amount", tokensToPlanck(tokens, token.decimals))
       } else remove("amount")
-    }, 250),
-    [remove, sendMax, set, token, tokenRates],
+    },
+    [currency, remove, sendMax, set, token, tokenRates],
   )
 
   if (!tokenRates) return null
@@ -173,7 +165,7 @@ const FiatInput = () => {
         key="fiatInput"
         ref={refFiatInput}
         type="text"
-        defaultValue={defaultValue}
+        value={value}
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={!sendMax && !transfer}
         placeholder={"0.00"}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/BittensorBondFormBase.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/BittensorBondFormBase.tsx
@@ -11,6 +11,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react"
 import { useTranslation } from "react-i18next"
 import { Button, PillButton } from "talisman-ui"
@@ -118,25 +119,37 @@ const TokenInput = () => {
     return nativeToken?.symbol
   }, [isSubnetUnbond, netuid, nativeToken?.symbol])
 
-  const defaultValue = useMemo(
+  const formattedValue = useMemo(
     () => (isSubnetUnbond ? (amountAlpha?.tokens ?? "") : (amountTao?.tokens ?? "")),
     [amountTao?.tokens, amountAlpha?.tokens, isSubnetUnbond],
   )
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const [value, setValue] = useState(formattedValue)
+  const refSkipSync = useRef(false)
+
+  useEffect(() => {
+    if (refSkipSync.current) {
+      refSkipSync.current = false
+      return
+    }
+    setValue(formattedValue)
+  }, [formattedValue])
+
   const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     (e) => {
-      if (nativeToken) {
-        try {
-          const plancks = tokensToPlanck(e.target.value, nativeToken.decimals)
+      refSkipSync.current = true
+      const nextValue = e.target.value
+      setValue(nextValue)
 
-          return setPlancks(BigInt(plancks))
-        } catch (err) {
-          // invalid input, ignore
-        }
+      if (!nativeToken || !nextValue.trim()) return setPlancks(null)
+
+      try {
+        const plancks = tokensToPlanck(nextValue, nativeToken.decimals)
+        setPlancks(BigInt(plancks))
+      } catch (err) {
+        // invalid input, ignore
+        setPlancks(null)
       }
-
-      return setPlancks(null)
     },
     [setPlancks, nativeToken],
   )
@@ -163,7 +176,7 @@ const TokenInput = () => {
         inputMode="decimal"
         placeholder="0"
         step="any"
-        defaultValue={defaultValue}
+        value={value}
         className={"text-body peer inline-block w-fit min-w-0 text-ellipsis bg-transparent text-xl"}
         onChange={handleChange}
       />
@@ -180,21 +193,36 @@ const FiatInput = () => {
     useBittensorBondWizard()
   const currency = useSelectedCurrency()
 
-  const defaultValue = useMemo(() => {
+  const formattedValue = useMemo(() => {
     const val = amountTao?.fiat(currency) ?? ""
     return val ? String(Number(val.toFixed(2))) : val
   }, [currency, amountTao])
 
+  const [value, setValue] = useState(formattedValue)
+  const refSkipSync = useRef(false)
+
+  useEffect(() => {
+    if (refSkipSync.current) {
+      refSkipSync.current = false
+      return
+    }
+    setValue(formattedValue)
+  }, [formattedValue])
+
   const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     (e) => {
+      refSkipSync.current = true
+      const nextValue = e.target.value
+      setValue(nextValue)
+
       if (
         nativeToken &&
         tokenRates?.[currency]?.price &&
-        e.target.value &&
+        nextValue &&
         typeof swapPrice === "bigint"
       ) {
         try {
-          const fiat = parseFloat(e.target.value)
+          const fiat = parseFloat(nextValue)
           let tokens: string = (fiat / tokenRates[currency].price).toFixed(
             Math.ceil(nativeToken.decimals / 3),
           )
@@ -244,7 +272,7 @@ const FiatInput = () => {
         ref={refFiatInput}
         type="number"
         inputMode="decimal"
-        defaultValue={defaultValue}
+        value={value}
         placeholder={"0.00"}
         className="text-body peer inline-block min-w-0 bg-transparent text-xl"
         onChange={handleChange}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorBondWizard.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorBondWizard.ts
@@ -321,21 +321,13 @@ const useBittensorBondWizardProvider = () => {
     if (stakeDirection === "unbond") {
       return totalStakedPlancks
     }
-    if (!nativeBalance || !existentialDeposit || !feeEstimate || typeof talismanFee !== "bigint")
-      return null
+    if (!nativeBalance || !existentialDeposit || !feeEstimate) return null
     if (existentialDeposit.planck + feeEstimate * 11n > nativeBalance.transferable.planck)
       return null
     const maxRootStake =
       nativeBalance.transferable.planck - existentialDeposit.planck - feeEstimate * 11n
     return maxRootStake
-  }, [
-    stakeDirection,
-    nativeBalance,
-    existentialDeposit,
-    feeEstimate,
-    talismanFee,
-    totalStakedPlancks,
-  ])
+  }, [stakeDirection, nativeBalance, existentialDeposit, feeEstimate, totalStakedPlancks])
 
   const newStakeTotal = useMemo(() => {
     if (stakeDirection === "unbond") {

--- a/apps/extension/src/ui/domains/Staking/Bond/BondForm.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bond/BondForm.tsx
@@ -12,6 +12,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react"
 import { useTranslation } from "react-i18next"
 import { Button, PillButton, Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
@@ -106,7 +107,18 @@ const TokenDisplay = () => {
 const TokenInput = () => {
   const { token, formatter, setPlancks } = useBondWizard()
 
-  const defaultValue = useMemo(() => formatter?.tokens ?? "", [formatter?.tokens])
+  const formattedValue = useMemo(() => formatter?.tokens ?? "", [formatter?.tokens])
+
+  const [value, setValue] = useState(formattedValue)
+  const refSkipSync = useRef(false)
+
+  useEffect(() => {
+    if (refSkipSync.current) {
+      refSkipSync.current = false
+      return
+    }
+    setValue(formattedValue)
+  }, [formattedValue])
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
@@ -114,12 +126,16 @@ const TokenInput = () => {
       if (token && e.target.value) {
         try {
           const plancks = tokensToPlanck(e.target.value, token.decimals)
+          refSkipSync.current = true
+          setValue(e.target.value)
           return setPlancks(BigInt(plancks))
         } catch (err) {
           // invalid input, ignore
         }
       }
 
+      refSkipSync.current = true
+      setValue(e.target.value)
       return setPlancks(null)
     },
     [setPlancks, token],
@@ -145,7 +161,7 @@ const TokenInput = () => {
         ref={refTokensInput}
         type="text"
         inputMode="decimal"
-        defaultValue={defaultValue}
+        value={value}
         placeholder="0"
         className={"text-body peer inline-block w-fit min-w-0 text-ellipsis bg-transparent text-xl"}
         onChange={handleChange}
@@ -162,10 +178,21 @@ const FiatInput = () => {
   const { token, tokenRates, formatter, setPlancks } = useBondWizard()
   const currency = useSelectedCurrency()
 
-  const defaultValue = useMemo(() => {
+  const formattedValue = useMemo(() => {
     const val = formatter?.fiat(currency) ?? ""
     return val ? String(Number(val.toFixed(2))) : val
   }, [currency, formatter])
+
+  const [value, setValue] = useState(formattedValue)
+  const refSkipSync = useRef(false)
+
+  useEffect(() => {
+    if (refSkipSync.current) {
+      refSkipSync.current = false
+      return
+    }
+    setValue(formattedValue)
+  }, [formattedValue])
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     (e) => {
@@ -174,12 +201,16 @@ const FiatInput = () => {
           const fiat = parseFloat(e.target.value)
           const tokens = (fiat / tokenRates[currency].price).toFixed(Math.ceil(token.decimals / 3))
           const plancks = tokensToPlanck(tokens, token.decimals)
+          refSkipSync.current = true
+          setValue(e.target.value)
           return setPlancks(BigInt(plancks))
         } catch (err) {
           // invalid input, ignore
         }
       }
 
+      refSkipSync.current = true
+      setValue(e.target.value)
       return setPlancks(null)
     },
 
@@ -210,7 +241,7 @@ const FiatInput = () => {
         key="fiatInput"
         ref={refFiatInput}
         type="text"
-        defaultValue={defaultValue}
+        value={value}
         placeholder={"0.00"}
         className="text-body peer inline-block min-w-0 bg-transparent text-xl"
         onChange={handleChange}


### PR DESCRIPTION
Fixed our input fields in the 3 forms:
- send funds
- nom pool staking
- dtao staking

those fields were uncontrolled, while they must be controlled to allow the send max button to change their value.