### PR TITLE
fix: simpleswap ksm asset hub

### DIFF
--- a/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
@@ -142,7 +142,7 @@ const specialAssets: Record<string, Omit<SwappableAssetBaseType, "context">> = {
     chainId: "polkadot-asset-hub",
     networkType: "substrate",
   },
-  ksm: {
+  ksmassethub: {
     id: subNativeTokenId("kusama-asset-hub"),
     name: "Kusama Asset Hub",
     symbol: "KSM",


### PR DESCRIPTION
Fixes KSM swaps for simpleswap (ticker is now `ksmassethub` not `ksm`)
Note: DOT (on asset hub) ticker is still `dot`.