### PR TITLE
fix: remove discount tiers from default remote config

### DIFF
--- a/packages/extension-core/src/domains/app/store.remoteConfig.ts
+++ b/packages/extension-core/src/domains/app/store.remoteConfig.ts
@@ -54,28 +54,7 @@ export const DEFAULT_REMOTE_CONFIG: RemoteConfigStoreData = {
     stakingContractAddress: "0x",
     webAppStakingPath: "",
     stakingEarlyRewardBoost: "",
-    discountTiers: [
-      {
-        tier: 0,
-        min: "0",
-        discount: 0,
-      },
-      {
-        tier: 1,
-        min: "100000000000000000000", // 100 * 10^18
-        discount: 0.01,
-      },
-      {
-        tier: 2,
-        min: "1000000000000000000000", // 1,000 * 10^18
-        discount: 0.02,
-      },
-      {
-        tier: 3,
-        min: "10000000000000000000000", // 10,000 * 10^18
-        discount: 0.03,
-      },
-    ],
+    discountTiers: [],
   },
   bittensor: {
     fee: {


### PR DESCRIPTION
# Description

- Fixes bug where 3% discount was being applied instead of 15%.

### 🗒️ **Notes:**

This issue only occurs for users staking 10k+ SEEK tokens.

The issue was caused because 'real' remove config values get merged with `DEFAULT_REMOTE_CONFIG` values, and I was under the assumption that the correct remote config would replace the default values.

I ended up writing quite a few tests to figure out what as going on and went the wrong way about it, it was not a bad math issue, simply loading the incorrect default values.