### PR TITLE
fix: fixed long network names blocking buttons

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/TokenBalancesList.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/TokenBalancesList.tsx
@@ -58,10 +58,10 @@ export const TokenBalancesList = ({
           <div className="shrink-0 p-8 pr-6 text-xl">
             <TokenLogo tokenId={tokenId} />
           </div>
-          <div className="flex grow flex-col justify-center gap-2 whitespace-nowrap">
+          <div className="flex grow flex-col justify-center gap-2 overflow-hidden">
             <div className="flex items-center gap-3">
-              <div className="text-body font-bold">{token.name}</div>
-              <div className="text-body flex items-center text-base font-bold">
+              <div className="text-body truncate font-bold">{token.name}</div>
+              <div className="text-body flex shrink-0 items-center text-base font-bold">
                 <CopyAddressButton networkId={chainOrNetworkId} />
                 <BittensorUnstakeButton balances={balances} />
                 <Suspense fallback={<SuspenseTracker name="ChainTokenBalances.Buttons" />}>


### PR DESCRIPTION
Fixed bug where long network names would stop user from clicking action buttons.

<img width="375" height="576" alt="Screenshot 2026-01-01 at 3 58 52 PM" src="https://github.com/user-attachments/assets/2dc7979b-7e4e-45d4-a0ed-d1140b28a65d" />
