### PR TITLE
fix: added details in history for Bittensor dTAO operations

### DIFF
--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorRootBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorRootBondReview.tsx
@@ -40,14 +40,12 @@ export const BittensorRootBondReview = () => {
     // Root staking: TAO -> TAO (no alpha token conversion)
     return {
       type: "bittensor-staking",
-      action: stakeDirection === "bond" ? "stake" : "unstake",
       fromTokenId: nativeToken.id,
       toTokenId: nativeToken.id,
       fromAmount: amountIn.toString(),
       toAmount: amountIn.toString(), // same amount for root staking
-      netuid: 0, // root staking
     }
-  }, [nativeToken?.id, amountIn, stakeDirection])
+  }, [nativeToken?.id, amountIn])
 
   useEffect(() => {
     // enable confirm button 0.5 second after the screen is open, to ensure the user doesnt accidentally click it (ex: double click from prev screen)

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorRootBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorRootBondReview.tsx
@@ -1,3 +1,4 @@
+import { subDTaoTokenId } from "@talismn/chaindata-provider"
 import { InfoIcon } from "@talismn/icons"
 import { WalletTransactionInfo } from "extension-core"
 import { useEffect, useMemo, useState } from "react"
@@ -35,17 +36,23 @@ export const BittensorRootBondReview = () => {
 
   const [isDisabled, setIsDisabled] = useState(true)
 
+  const rootAlphaTokenId = useMemo(
+    () => (nativeToken?.networkId ? subDTaoTokenId(nativeToken.networkId, 0) : null),
+    [nativeToken?.networkId],
+  )
+
   const txInfo: WalletTransactionInfo | undefined = useMemo(() => {
-    if (!nativeToken?.id || amountIn === null) return undefined
-    // Root staking: TAO -> TAO (no alpha token conversion)
+    if (!nativeToken?.id || !rootAlphaTokenId || amountIn === null) return undefined
+    // Root staking: TAO -> ALPHA (netuid 0) for stake, ALPHA -> TAO for unstake
+    const isStaking = stakeDirection === "bond"
     return {
       type: "bittensor-staking",
-      fromTokenId: nativeToken.id,
-      toTokenId: nativeToken.id,
+      fromTokenId: isStaking ? nativeToken.id : rootAlphaTokenId,
+      toTokenId: isStaking ? rootAlphaTokenId : nativeToken.id,
       fromAmount: amountIn.toString(),
-      toAmount: amountIn.toString(), // same amount for root staking
+      toAmount: amountIn.toString(), // same amount for root staking (1:1 ratio)
     }
-  }, [nativeToken?.id, amountIn])
+  }, [nativeToken?.id, rootAlphaTokenId, amountIn, stakeDirection])
 
   useEffect(() => {
     // enable confirm button 0.5 second after the screen is open, to ensure the user doesnt accidentally click it (ex: double click from prev screen)

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorRootBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorRootBondReview.tsx
@@ -37,10 +37,14 @@ export const BittensorRootBondReview = () => {
 
   const txInfo: WalletTransactionInfo | undefined = useMemo(() => {
     if (!nativeToken?.id || amountIn === null) return undefined
+    // Root staking: TAO -> TAO (no alpha token conversion)
     return {
-      type: stakeDirection === "bond" ? "bittensor-stake" : "bittensor-unstake",
-      tokenId: nativeToken.id,
-      amount: amountIn.toString(),
+      type: "bittensor-staking",
+      action: stakeDirection === "bond" ? "stake" : "unstake",
+      fromTokenId: nativeToken.id,
+      toTokenId: nativeToken.id,
+      fromAmount: amountIn.toString(),
+      toAmount: amountIn.toString(), // same amount for root staking
       netuid: 0, // root staking
     }
   }, [nativeToken?.id, amountIn, stakeDirection])

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorRootBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorRootBondReview.tsx
@@ -1,5 +1,6 @@
 import { InfoIcon } from "@talismn/icons"
-import { useEffect, useState } from "react"
+import { WalletTransactionInfo } from "extension-core"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
 
@@ -33,6 +34,16 @@ export const BittensorRootBondReview = () => {
   const { close } = useBittensorBondModal()
 
   const [isDisabled, setIsDisabled] = useState(true)
+
+  const txInfo: WalletTransactionInfo | undefined = useMemo(() => {
+    if (!nativeToken?.id || amountIn === null) return undefined
+    return {
+      type: stakeDirection === "bond" ? "bittensor-stake" : "bittensor-unstake",
+      tokenId: nativeToken.id,
+      amount: amountIn.toString(),
+      netuid: 0, // root staking
+    }
+  }, [nativeToken?.id, amountIn, stakeDirection])
 
   useEffect(() => {
     // enable confirm button 0.5 second after the screen is open, to ensure the user doesnt accidentally click it (ex: double click from prev screen)
@@ -124,6 +135,7 @@ export const BittensorRootBondReview = () => {
           payload={payload}
           onSubmitted={onSubmitted}
           txMetadata={txMetadata}
+          txInfo={txInfo}
           disabled={isDisabled}
         />
       )}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
@@ -119,18 +119,20 @@ export const BittensorSubnetBondReview = () => {
   )
 
   const txInfo: WalletTransactionInfo | undefined = useMemo(() => {
-    if (amountIn === null || netuid === null) return undefined
-    // For staking: use nativeToken (TAO) since that's what user is putting in
-    // For unstaking: use dtaoToken (alpha) since that's what user is unstaking
-    const tokenId = stakeDirection === "bond" ? nativeToken?.id : dtaoToken?.id
-    if (!tokenId) return undefined
+    if (amountIn === null || netuid === null || !nativeToken?.id || !dtaoToken?.id) return undefined
+    // For staking: TAO -> ALPHA (input TAO, receive ALPHA)
+    // For unstaking: ALPHA -> TAO (input ALPHA, receive TAO)
+    const isStaking = stakeDirection === "bond"
     return {
-      type: stakeDirection === "bond" ? "bittensor-stake" : "bittensor-unstake",
-      tokenId,
-      amount: amountIn.toString(),
+      type: "bittensor-staking",
+      action: isStaking ? "stake" : "unstake",
+      fromTokenId: isStaking ? nativeToken.id : dtaoToken.id,
+      toTokenId: isStaking ? dtaoToken.id : nativeToken.id,
+      fromAmount: amountIn.toString(),
+      toAmount: amountOut.toString(),
       netuid,
     }
-  }, [nativeToken?.id, dtaoToken?.id, amountIn, stakeDirection, netuid])
+  }, [nativeToken?.id, dtaoToken?.id, amountIn, amountOut, stakeDirection, netuid])
 
   const { isLoading } = useCombinedSubnetData(networkId)
 

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
@@ -119,20 +119,18 @@ export const BittensorSubnetBondReview = () => {
   )
 
   const txInfo: WalletTransactionInfo | undefined = useMemo(() => {
-    if (amountIn === null || netuid === null || !nativeToken?.id || !dtaoToken?.id) return undefined
+    if (amountIn === null || !nativeToken?.id || !dtaoToken?.id) return undefined
     // For staking: TAO -> ALPHA (input TAO, receive ALPHA)
     // For unstaking: ALPHA -> TAO (input ALPHA, receive TAO)
     const isStaking = stakeDirection === "bond"
     return {
       type: "bittensor-staking",
-      action: isStaking ? "stake" : "unstake",
       fromTokenId: isStaking ? nativeToken.id : dtaoToken.id,
       toTokenId: isStaking ? dtaoToken.id : nativeToken.id,
       fromAmount: amountIn.toString(),
       toAmount: amountOut.toString(),
-      netuid,
     }
-  }, [nativeToken?.id, dtaoToken?.id, amountIn, amountOut, stakeDirection, netuid])
+  }, [nativeToken?.id, dtaoToken?.id, amountIn, amountOut, stakeDirection])
 
   const { isLoading } = useCombinedSubnetData(networkId)
 

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorSubnetBondReview.tsx
@@ -1,5 +1,6 @@
 import { EditIcon, InfoIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
+import { WalletTransactionInfo } from "extension-core"
 import { FC, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
@@ -116,6 +117,20 @@ export const BittensorSubnetBondReview = () => {
     () => isSeekTaoDiscountEnabled && totalFeeDiscount < MAX_TOTAL_FEE_DISCOUNT,
     [isSeekTaoDiscountEnabled, totalFeeDiscount],
   )
+
+  const txInfo: WalletTransactionInfo | undefined = useMemo(() => {
+    if (amountIn === null || netuid === null) return undefined
+    // For staking: use nativeToken (TAO) since that's what user is putting in
+    // For unstaking: use dtaoToken (alpha) since that's what user is unstaking
+    const tokenId = stakeDirection === "bond" ? nativeToken?.id : dtaoToken?.id
+    if (!tokenId) return undefined
+    return {
+      type: stakeDirection === "bond" ? "bittensor-stake" : "bittensor-unstake",
+      tokenId,
+      amount: amountIn.toString(),
+      netuid,
+    }
+  }, [nativeToken?.id, dtaoToken?.id, amountIn, stakeDirection, netuid])
 
   const { isLoading } = useCombinedSubnetData(networkId)
 
@@ -343,6 +358,7 @@ export const BittensorSubnetBondReview = () => {
             payload={payload}
             onSubmitted={onSubmitted}
             txMetadata={txMetadata}
+            txInfo={txInfo}
             disabled={isDisabled}
             mode={withMevShield ? "bittensor-mev-shield" : "default"}
           />

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryDetails/TxHistoryDetailsTxInfo.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryDetails/TxHistoryDetailsTxInfo.tsx
@@ -184,36 +184,34 @@ const BittensorStakingTxInfo: FC<{
   // Stake: TAO (substrate-native) -> ALPHA, Unstake: ALPHA -> TAO
   const isStake = parseTokenId(txInfo.fromTokenId).type === "substrate-native"
 
+  const components = {
+    FromTokens: (
+      <TokensAndFiat
+        planck={txInfo.fromAmount}
+        tokenId={txInfo.fromTokenId}
+        withLogo
+        noFiat
+        className="text-body"
+      />
+    ),
+    ToTokens: (
+      <TokensAndFiat
+        planck={txInfo.toAmount}
+        tokenId={txInfo.toTokenId}
+        withLogo
+        noFiat
+        className="text-body"
+      />
+    ),
+  }
+
   return (
     <TxInfoCard>
-      <Trans
-        t={t}
-        defaults={
-          isStake
-            ? "Stake <FromTokens /> for <ToTokens />"
-            : "Unstake <FromTokens /> for <ToTokens />"
-        }
-        components={{
-          FromTokens: (
-            <TokensAndFiat
-              planck={txInfo.fromAmount}
-              tokenId={txInfo.fromTokenId}
-              withLogo
-              noFiat
-              className="text-body"
-            />
-          ),
-          ToTokens: (
-            <TokensAndFiat
-              planck={txInfo.toAmount}
-              tokenId={txInfo.toTokenId}
-              withLogo
-              noFiat
-              className="text-body"
-            />
-          ),
-        }}
-      />
+      {isStake ? (
+        <Trans t={t} defaults="Stake <FromTokens /> for <ToTokens />" components={components} />
+      ) : (
+        <Trans t={t} defaults="Unstake <FromTokens /> for <ToTokens />" components={components} />
+      )}
     </TxInfoCard>
   )
 }

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryDetails/TxHistoryDetailsTxInfo.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryDetails/TxHistoryDetailsTxInfo.tsx
@@ -26,6 +26,8 @@ export const TxHistoryDetailsTxInfo: FC<{
       return <SwapStealthExTxInfo txInfo={txInfo} networkId={tx.networkId} />
     case "swap-lifi":
       return <SwapLifiTxInfo txInfo={txInfo} networkId={tx.networkId} />
+    case "bittensor-staking":
+      return <BittensorStakingTxInfo txInfo={txInfo} />
     default:
       return <CodeBlock code={papiStringify(tx.txInfo, 2)} />
   }
@@ -174,3 +176,43 @@ const SwapLifiTxInfo: FC<{
 }> = ({ networkId, txInfo }) => (
   <SwapTxInfoCard networkId={networkId} txInfo={txInfo} protocolLabel={txInfo.protocolName} />
 )
+
+const BittensorStakingTxInfo: FC<{
+  txInfo: Extract<WalletTransaction["txInfo"], { type: "bittensor-staking" }>
+}> = ({ txInfo }) => {
+  const { t } = useTranslation()
+  const isStake = txInfo.action === "stake"
+
+  return (
+    <TxInfoCard>
+      <Trans
+        t={t}
+        defaults={
+          isStake
+            ? "Stake <FromTokens /> for <ToTokens />"
+            : "Unstake <FromTokens /> for <ToTokens />"
+        }
+        components={{
+          FromTokens: (
+            <TokensAndFiat
+              planck={txInfo.fromAmount}
+              tokenId={txInfo.fromTokenId}
+              withLogo
+              noFiat
+              className="text-body"
+            />
+          ),
+          ToTokens: (
+            <TokensAndFiat
+              planck={txInfo.toAmount}
+              tokenId={txInfo.toTokenId}
+              withLogo
+              noFiat
+              className="text-body"
+            />
+          ),
+        }}
+      />
+    </TxInfoCard>
+  )
+}

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryDetails/TxHistoryDetailsTxInfo.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryDetails/TxHistoryDetailsTxInfo.tsx
@@ -1,4 +1,4 @@
-import { NetworkId } from "@talismn/chaindata-provider"
+import { NetworkId, parseTokenId } from "@talismn/chaindata-provider"
 import { papiStringify } from "@talismn/scale"
 import { WalletTransaction } from "extension-core"
 import { FC, ReactNode } from "react"
@@ -181,7 +181,8 @@ const BittensorStakingTxInfo: FC<{
   txInfo: Extract<WalletTransaction["txInfo"], { type: "bittensor-staking" }>
 }> = ({ txInfo }) => {
   const { t } = useTranslation()
-  const isStake = txInfo.action === "stake"
+  // Stake: TAO (substrate-native) -> ALPHA, Unstake: ALPHA -> TAO
+  const isStake = parseTokenId(txInfo.fromTokenId).type === "substrate-native"
 
   return (
     <TxInfoCard>

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -480,7 +480,7 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
   const txSwap = isTxInfoSwap(tx.txInfo) ? tx.txInfo : undefined
   const txBittensorStaking = isTxInfoBittensorStaking(tx.txInfo) ? tx.txInfo : undefined
 
-  const tokenId = txTransfer?.tokenId || txSwap?.fromTokenId || txBittensorStaking?.tokenId
+  const tokenId = txTransfer?.tokenId || txSwap?.fromTokenId || txBittensorStaking?.fromTokenId
 
   const chain = useNetworkByGenesisHash(genesisHash)
   const token = useToken(tokenId)
@@ -499,13 +499,13 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
     }
   }, [token, tokenRates, txTransfer])
 
-  const bittensorStakingAmount = useMemo(() => {
-    if (!token || !txBittensorStaking) return null
-    return new BalanceFormatter(txBittensorStaking.amount, token.decimals, tokenRates)
-  }, [token, tokenRates, txBittensorStaking])
-
+  // Swap tokens
   const fromToken = useToken(txSwap?.fromTokenId)
   const toToken = useToken(txSwap?.toTokenId)
+
+  // Bittensor staking tokens (similar to swap)
+  const stakingFromToken = useToken(txBittensorStaking?.fromTokenId)
+  const stakingToToken = useToken(txBittensorStaking?.toTokenId)
 
   const handleRowClick = useCallback(() => onSelectTx(tx), [onSelectTx, tx])
 
@@ -526,10 +526,15 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
               <TokenLogo tokenId={toToken?.id} className="!h-16 !w-16" />
             </TxIconContainer>
           </div>
-        ) : txBittensorStaking && token ? (
-          <TxIconContainer tooltip={`${token?.symbol} on ${chain?.name}`} networkId={chain?.id}>
-            <TokenLogo tokenId={token.id} className="!h-16 !w-16" />
-          </TxIconContainer>
+        ) : txBittensorStaking && stakingFromToken && stakingToToken ? (
+          <div className="flex items-center">
+            <TxIconContainer networkId={stakingFromToken.networkId}>
+              <TokenLogo tokenId={stakingFromToken.id} className="!h-16 !w-16" />
+            </TxIconContainer>
+            <TxIconContainer className="-ml-4" networkId={stakingToToken.networkId}>
+              <TokenLogo tokenId={stakingToToken.id} className="!h-16 !w-16" />
+            </TxIconContainer>
+          </div>
         ) : isTransfer && token ? (
           <TxIconContainer tooltip={`${token?.symbol} on ${chain?.name}`} networkId={chain?.id}>
             <TokenLogo tokenId={token.id} className="!h-16 !w-16" />
@@ -576,16 +581,31 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
               isBalance
             />
           </div>
-        ) : txBittensorStaking && bittensorStakingAmount && token ? (
-          <Tokens
-            className="pointer-events-none"
-            amount={bittensorStakingAmount.tokens}
-            decimals={token.decimals}
-            noCountUp
-            noTooltip
-            symbol={token.symbol}
-            isBalance
-          />
+        ) : txBittensorStaking && stakingFromToken && stakingToToken ? (
+          // Bittensor staking: display like a swap (from -> to)
+          <div className="flex flex-col">
+            <div className="flex items-center justify-end gap-1">
+              <Tokens
+                className="pointer-events-none"
+                amount={planckToTokens(txBittensorStaking.fromAmount, stakingFromToken.decimals)}
+                decimals={stakingFromToken.decimals}
+                symbol={stakingFromToken.symbol}
+                noCountUp
+                noTooltip
+                isBalance
+              />
+              <ArrowRightIcon className="text-body-inactive" />
+            </div>
+            <Tokens
+              className="pointer-events-none"
+              amount={planckToTokens(txBittensorStaking.toAmount, stakingToToken.decimals)}
+              decimals={stakingToToken.decimals}
+              symbol={stakingToToken.symbol}
+              noCountUp
+              noTooltip
+              isBalance
+            />
+          </div>
         ) : (
           !!amount &&
           !!token && (
@@ -602,13 +622,9 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
         )
       }
       fiat={
-        txBittensorStaking && bittensorStakingAmount?.fiat(currency) ? (
-          <Fiat amount={bittensorStakingAmount} noCountUp isBalance />
-        ) : (
-          isTransfer &&
-          !!amount &&
-          !!amount.fiat(currency) && <Fiat amount={amount} noCountUp isBalance />
-        )
+        isTransfer &&
+        !!amount &&
+        !!amount.fiat(currency) && <Fiat amount={amount} noCountUp isBalance />
       }
     />
   )

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -1,21 +1,19 @@
-import { alphaToTao, BalanceFormatter, TAO_DECIMALS } from "@talismn/balances"
-import { isTokenSubDTao, NetworkId, subNativeTokenId } from "@talismn/chaindata-provider"
+import { BalanceFormatter } from "@talismn/balances"
+import { NetworkId } from "@talismn/chaindata-provider"
 import { ArrowRightIcon, LoaderIcon, XOctagonIcon } from "@talismn/icons"
 import { classNames, planckToTokens } from "@talismn/util"
-import { useQuery } from "@tanstack/react-query"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import {
   isTxInfoApproval,
   isTxInfoSwap,
   isTxInfoTransfer,
-  SignerPayloadJSON,
   TransactionStatus,
   WalletTransaction,
   WalletTransactionDot,
   WalletTransactionEth,
   WalletTransactionSol,
 } from "extension-core"
-import { IS_FIREFOX, log } from "extension-shared"
+import { IS_FIREFOX } from "extension-shared"
 import { FC, ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
@@ -25,17 +23,14 @@ import { Fiat } from "@ui/domains/Asset/Fiat"
 import { TokenLogo } from "@ui/domains/Asset/TokenLogo"
 import { Tokens } from "@ui/domains/Asset/Tokens"
 import { NetworkLogo } from "@ui/domains/Networks/NetworkLogo"
-import { isBatchCall } from "@ui/domains/Sign/Substrate/types"
 import { useSwapStatus } from "@ui/domains/Swap/hooks/useSwapStatus"
 import { useFaviconUrl } from "@ui/hooks/useFaviconUrl"
-import { useSubstratePayloadMetadata } from "@ui/hooks/useSubstratePayloadMetadata"
 import {
   useNetworkByGenesisHash,
   useNetworkById,
   useSelectedCurrency,
   useToken,
   useTokenRates,
-  useTokens,
 } from "@ui/state"
 import { IS_POPUP } from "@ui/util/constants"
 
@@ -302,217 +297,6 @@ const SwapTransactionStatusLabelFallback = () => {
   )
 }
 
-const BITTENSOR_GENESIS_HASHES = new Set([
-  "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03",
-  "0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105",
-])
-
-const BITTENSOR_STAKING_METHODS = new Set([
-  "add_stake",
-  "add_stake_limit",
-  "remove_stake",
-  "remove_stake_limit",
-])
-
-const isBittensorTransaction = (payload: SignerPayloadJSON) =>
-  BITTENSOR_GENESIS_HASHES.has(payload.genesisHash)
-
-const isBittensorStakingCall = (pallet: string, method: string) =>
-  pallet === "SubtensorModule" && BITTENSOR_STAKING_METHODS.has(method)
-
-const getStakingAmount = (
-  method: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  args: any,
-): { amount: bigint; isStake: boolean; netuid: number } | null => {
-  const netuid = args.netuid as number | undefined
-  if (netuid === undefined) return null
-
-  if (method === "add_stake" || method === "add_stake_limit") {
-    return args.amount_staked ? { amount: args.amount_staked, isStake: true, netuid } : null
-  }
-  if (method === "remove_stake" || method === "remove_stake_limit") {
-    return args.amount_unstaked ? { amount: args.amount_unstaked, isStake: false, netuid } : null
-  }
-  return null
-}
-
-const useBittensorStakingCalls = (payload: SignerPayloadJSON) => {
-  const { data } = useSubstratePayloadMetadata(payload)
-
-  return useMemo(() => {
-    if (!data?.sapi) return null
-
-    try {
-      const decodedCall = data.sapi.getDecodedCallFromPayload(payload)
-
-      if (isBatchCall(decodedCall)) {
-        const calls = decodedCall.args.calls as Array<{
-          type: string
-          value: { type: string; value: unknown }
-        }>
-        const filtered = calls
-          .map((call) => ({ pallet: call.type, method: call.value.type, args: call.value.value }))
-          .filter((call) => isBittensorStakingCall(call.pallet, call.method))
-        return filtered.length > 0 ? filtered : null
-      }
-
-      if (isBittensorStakingCall(decodedCall.pallet, decodedCall.method)) {
-        return [{ pallet: decodedCall.pallet, method: decodedCall.method, args: decodedCall.args }]
-      }
-
-      return null
-    } catch (err) {
-      log.error("Failed to decode bittensor staking call", { err })
-      return null
-    }
-  }, [data?.sapi, payload])
-}
-
-const useBittensorStakingAlphaPrices = (
-  payload: SignerPayloadJSON,
-  stakingCalls: Array<{ method: string; args: unknown }> | null,
-) => {
-  const { data } = useSubstratePayloadMetadata(payload)
-
-  const netuids = useMemo(() => {
-    if (!stakingCalls) return []
-    const uniqueNetuids = new Set<number>()
-    for (const call of stakingCalls) {
-      const info = getStakingAmount(call.method, call.args)
-      if (info && !info.isStake && info.netuid !== 0) {
-        uniqueNetuids.add(info.netuid)
-      }
-    }
-    return Array.from(uniqueNetuids)
-  }, [stakingCalls])
-
-  return useQuery({
-    queryKey: ["bittensorStakingAlphaPrices", data?.sapi?.id, netuids],
-    queryFn: async () => {
-      if (!data?.sapi || netuids.length === 0) return {}
-
-      const prices: Record<number, bigint> = {}
-      await Promise.all(
-        netuids.map(async (netuid) => {
-          try {
-            const price = await data.sapi!.getRuntimeCallValue<bigint>(
-              "SwapRuntimeApi",
-              "current_alpha_price",
-              [netuid],
-            )
-            prices[netuid] = price
-          } catch (err) {
-            log.error("Failed to fetch alpha price for netuid", { netuid, err })
-          }
-        }),
-      )
-      return prices
-    },
-    enabled: !!data?.sapi && netuids.length > 0,
-  })
-}
-
-const BittensorStakingTokens: FC<{ payload: SignerPayloadJSON }> = ({ payload }) => {
-  const stakingCalls = useBittensorStakingCalls(payload)
-  const network = useNetworkByGenesisHash(payload.genesisHash)
-  const allTokens = useTokens()
-
-  const subnetSymbols = useMemo(() => {
-    if (!network?.id) return {}
-    const symbols: Record<number, string> = {}
-    for (const token of allTokens) {
-      if (isTokenSubDTao(token) && token.networkId === network.id && !token.hotkey) {
-        symbols[token.netuid] = token.symbol
-      }
-    }
-    return symbols
-  }, [allTokens, network?.id])
-
-  if (!stakingCalls?.length) return null
-
-  const renderToken = (call: (typeof stakingCalls)[0], key?: number) => {
-    const info = getStakingAmount(call.method, call.args)
-    if (!info) return null
-
-    // For stakes, always use TAO. For unstakes, use subnet-specific symbol (or fallback to α)
-    const symbol = info.isStake ? "TAO" : (subnetSymbols[info.netuid] ?? "α")
-
-    return (
-      <Tokens
-        key={key}
-        className="pointer-events-none"
-        amount={planckToTokens(info.amount.toString(), Number(TAO_DECIMALS))}
-        symbol={symbol}
-        noCountUp
-        noTooltip
-        isBalance
-      />
-    )
-  }
-
-  if (stakingCalls.length > 1) {
-    return (
-      <div className="flex flex-col items-end">
-        {stakingCalls.map((call, i) => renderToken(call, i))}
-      </div>
-    )
-  }
-
-  return renderToken(stakingCalls[0])
-}
-
-const BittensorStakingTokensFallback = () => (
-  <div className="bg-grey-800 text-grey-800 rounded-xs animate-pulse text-sm">0.00 TAO</div>
-)
-
-const BittensorStakingFiat: FC<{ payload: SignerPayloadJSON }> = ({ payload }) => {
-  const stakingCalls = useBittensorStakingCalls(payload)
-  const network = useNetworkByGenesisHash(payload.genesisHash)
-  const taoTokenId = network?.id ? subNativeTokenId(network.id) : null
-  const taoRates = useTokenRates(taoTokenId)
-  const currency = useSelectedCurrency()
-  const { data: alphaPrices } = useBittensorStakingAlphaPrices(payload, stakingCalls)
-
-  const totalFiat = useMemo(() => {
-    if (!taoRates?.[currency]?.price) return null
-    if (!stakingCalls?.length) return null
-
-    let total = 0
-    for (const call of stakingCalls) {
-      const info = getStakingAmount(call.method, call.args)
-      if (!info) continue
-
-      let taoAmount: bigint
-      if (info.isStake) {
-        // Staking: amount is already in TAO
-        taoAmount = info.amount
-      } else if (info.netuid === 0) {
-        // Root subnet unstaking: amount is in TAO
-        taoAmount = info.amount
-      } else {
-        // Subnet unstaking: convert alpha to TAO using current price
-        const alphaPrice = alphaPrices?.[info.netuid]
-        if (!alphaPrice) continue
-        taoAmount = alphaToTao(info.amount, alphaPrice)
-      }
-
-      const tokens = Number(planckToTokens(taoAmount.toString(), Number(TAO_DECIMALS)))
-      total += tokens * taoRates[currency].price
-    }
-
-    return total > 0 ? total : null
-  }, [stakingCalls, taoRates, currency, alphaPrices])
-
-  if (!totalFiat) return null
-
-  return <Fiat amount={totalFiat} noCountUp isBalance />
-}
-
-const BittensorStakingFiatFallback = () => (
-  <div className="bg-grey-800 text-grey-800 rounded-xs animate-pulse text-xs">$0.00</div>
-)
-
 const TransactionRowBase: FC<{
   logo: ReactNode
   status: ReactNode
@@ -520,40 +304,44 @@ const TransactionRowBase: FC<{
   tokens: ReactNode
   fiat: ReactNode
   onClick?: () => void
-}> = ({ logo, status, wen, tokens, fiat, onClick }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    disabled={!onClick}
-    className={classNames(
-      "bg-grey-850 hover:bg-grey-800 relative z-0 flex w-full grow items-center rounded-sm text-left",
-      IS_POPUP ? "h-[5.2rem] gap-6 px-6" : "h-[5.8rem] gap-8 px-8",
-    )}
-  >
-    {logo}
-    <div className="leading-paragraph flex w-full grow justify-between">
-      <div className="flex flex-col items-start justify-center">
-        <div
-          className={classNames(
-            "text-body flex h-10 items-center gap-2 font-bold",
-            IS_POPUP ? "text-sm" : "text-base",
-          )}
-        >
-          {status}
+}> = ({ logo, status, wen, tokens, fiat, onClick }) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!onClick}
+      className={classNames(
+        "bg-grey-850 hover:bg-grey-800 relative z-0 flex w-full grow items-center rounded-sm text-left",
+        IS_POPUP ? "h-[5.2rem] gap-6 px-6" : "h-[5.8rem] gap-8 px-8",
+      )}
+    >
+      {logo}
+      <div className="leading-paragraph flex w-full grow justify-between">
+        <div className="flex flex-col items-start justify-center">
+          <div
+            className={classNames(
+              "text-body flex h-10 items-center gap-2 font-bold",
+              IS_POPUP ? "text-sm" : "text-base",
+            )}
+          >
+            {status}
+          </div>
+          <div className={classNames("text-body-disabled", IS_POPUP ? "text-xs" : "text-sm")}>
+            {wen}
+          </div>
         </div>
-        <div className={classNames("text-body-disabled", IS_POPUP ? "text-xs" : "text-sm")}>
-          {wen}
+        <div className="flex flex-col items-end justify-center text-right">
+          <div className={classNames("text-body", IS_POPUP ? "text-sm" : "text-base")}>
+            {tokens}
+          </div>
+          <div className={classNames("text-body-disabled", IS_POPUP ? "text-xs" : "text-sm")}>
+            {fiat}
+          </div>
         </div>
       </div>
-      <div className="flex flex-col items-end justify-center text-right">
-        <div className={classNames("text-body", IS_POPUP ? "text-sm" : "text-base")}>{tokens}</div>
-        <div className={classNames("text-body-disabled", IS_POPUP ? "text-xs" : "text-sm")}>
-          {fiat}
-        </div>
-      </div>
-    </div>
-  </button>
-)
+    </button>
+  )
+}
 
 const TransactionRowEvm: FC<TransactionRowEthProps> = ({ tx, onSelectTx }) => {
   const evmNetwork = useNetworkById(tx.networkId, "ethereum")
@@ -698,7 +486,9 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
   const currency = useSelectedCurrency()
 
   const { isTransfer, amount } = useMemo(() => {
+    // historically txInfo wasnt a property, transfer params were set on the tx object
     const isTransfer = token && txTransfer
+
     return {
       isTransfer,
       amount: isTransfer
@@ -712,9 +502,6 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
 
   const handleRowClick = useCallback(() => onSelectTx(tx), [onSelectTx, tx])
 
-  const isBittensorStaking =
-    isBittensorTransaction(tx.payload) && tx.label === "Transaction" && !tx.txInfo?.type
-
   return (
     <TransactionRowBase
       onClick={handleRowClick}
@@ -725,10 +512,10 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
           </TxIconContainer>
         ) : txSwap ? (
           <div className="flex items-center">
-            <TxIconContainer networkId={fromToken?.networkId}>
+            <TxIconContainer networkId={fromToken?.networkId ?? fromToken?.networkId}>
               <TokenLogo tokenId={fromToken?.id} className="!h-16 !w-16" />
             </TxIconContainer>
-            <TxIconContainer className="-ml-4" networkId={toToken?.networkId}>
+            <TxIconContainer className="-ml-4" networkId={toToken?.networkId ?? toToken?.networkId}>
               <TokenLogo tokenId={toToken?.id} className="!h-16 !w-16" />
             </TxIconContainer>
           </div>
@@ -743,21 +530,20 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
         )
       }
       status={
-        txSwap ? (
-          <Suspense fallback={<SwapTransactionStatusLabelFallback />}>
-            <SwapTransactionStatusLabel tx={tx} />
-          </Suspense>
-        ) : (
-          <TransactionStatusLabel status={tx.status} />
-        )
+        <>
+          {txSwap ? (
+            <Suspense fallback={<SwapTransactionStatusLabelFallback />}>
+              <SwapTransactionStatusLabel tx={tx} />
+            </Suspense>
+          ) : (
+            <TransactionStatusLabel status={tx.status} />
+          )}
+        </>
       }
       wen={<DistanceToNow timestamp={tx.timestamp} />}
       tokens={
-        isBittensorStaking ? (
-          <Suspense fallback={<BittensorStakingTokensFallback />}>
-            <BittensorStakingTokens payload={tx.payload} />
-          </Suspense>
-        ) : txSwap ? (
+        txSwap ? (
+          // tx is a swap deposit
           <div className="flex flex-col">
             <div className="flex items-center justify-end gap-1">
               <Tokens
@@ -797,15 +583,9 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
         )
       }
       fiat={
-        isBittensorStaking ? (
-          <Suspense fallback={<BittensorStakingFiatFallback />}>
-            <BittensorStakingFiat payload={tx.payload} />
-          </Suspense>
-        ) : (
-          isTransfer &&
-          !!amount &&
-          !!amount.fiat(currency) && <Fiat amount={amount} noCountUp isBalance />
-        )
+        isTransfer &&
+        !!amount &&
+        !!amount.fiat(currency) && <Fiat amount={amount} noCountUp isBalance />
       }
     />
   )

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -5,6 +5,7 @@ import { classNames, planckToTokens } from "@talismn/util"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import {
   isTxInfoApproval,
+  isTxInfoBittensorStaking,
   isTxInfoSwap,
   isTxInfoTransfer,
   TransactionStatus,
@@ -477,8 +478,9 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
 
   const txTransfer = isTxInfoTransfer(tx.txInfo) ? tx.txInfo : undefined
   const txSwap = isTxInfoSwap(tx.txInfo) ? tx.txInfo : undefined
+  const txBittensorStaking = isTxInfoBittensorStaking(tx.txInfo) ? tx.txInfo : undefined
 
-  const tokenId = txTransfer?.tokenId || txSwap?.fromTokenId
+  const tokenId = txTransfer?.tokenId || txSwap?.fromTokenId || txBittensorStaking?.tokenId
 
   const chain = useNetworkByGenesisHash(genesisHash)
   const token = useToken(tokenId)
@@ -497,6 +499,11 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
     }
   }, [token, tokenRates, txTransfer])
 
+  const bittensorStakingAmount = useMemo(() => {
+    if (!token || !txBittensorStaking) return null
+    return new BalanceFormatter(txBittensorStaking.amount, token.decimals, tokenRates)
+  }, [token, tokenRates, txBittensorStaking])
+
   const fromToken = useToken(txSwap?.fromTokenId)
   const toToken = useToken(txSwap?.toTokenId)
 
@@ -512,13 +519,17 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
           </TxIconContainer>
         ) : txSwap ? (
           <div className="flex items-center">
-            <TxIconContainer networkId={fromToken?.networkId ?? fromToken?.networkId}>
+            <TxIconContainer networkId={fromToken?.networkId}>
               <TokenLogo tokenId={fromToken?.id} className="!h-16 !w-16" />
             </TxIconContainer>
-            <TxIconContainer className="-ml-4" networkId={toToken?.networkId ?? toToken?.networkId}>
+            <TxIconContainer className="-ml-4" networkId={toToken?.networkId}>
               <TokenLogo tokenId={toToken?.id} className="!h-16 !w-16" />
             </TxIconContainer>
           </div>
+        ) : txBittensorStaking && token ? (
+          <TxIconContainer tooltip={`${token?.symbol} on ${chain?.name}`} networkId={chain?.id}>
+            <TokenLogo tokenId={token.id} className="!h-16 !w-16" />
+          </TxIconContainer>
         ) : isTransfer && token ? (
           <TxIconContainer tooltip={`${token?.symbol} on ${chain?.name}`} networkId={chain?.id}>
             <TokenLogo tokenId={token.id} className="!h-16 !w-16" />
@@ -530,15 +541,13 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
         )
       }
       status={
-        <>
-          {txSwap ? (
-            <Suspense fallback={<SwapTransactionStatusLabelFallback />}>
-              <SwapTransactionStatusLabel tx={tx} />
-            </Suspense>
-          ) : (
-            <TransactionStatusLabel status={tx.status} />
-          )}
-        </>
+        txSwap ? (
+          <Suspense fallback={<SwapTransactionStatusLabelFallback />}>
+            <SwapTransactionStatusLabel tx={tx} />
+          </Suspense>
+        ) : (
+          <TransactionStatusLabel status={tx.status} />
+        )
       }
       wen={<DistanceToNow timestamp={tx.timestamp} />}
       tokens={
@@ -567,6 +576,16 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
               isBalance
             />
           </div>
+        ) : txBittensorStaking && bittensorStakingAmount && token ? (
+          <Tokens
+            className="pointer-events-none"
+            amount={bittensorStakingAmount.tokens}
+            decimals={token.decimals}
+            noCountUp
+            noTooltip
+            symbol={token.symbol}
+            isBalance
+          />
         ) : (
           !!amount &&
           !!token && (
@@ -583,9 +602,13 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
         )
       }
       fiat={
-        isTransfer &&
-        !!amount &&
-        !!amount.fiat(currency) && <Fiat amount={amount} noCountUp isBalance />
+        txBittensorStaking && bittensorStakingAmount?.fiat(currency) ? (
+          <Fiat amount={bittensorStakingAmount} noCountUp isBalance />
+        ) : (
+          isTransfer &&
+          !!amount &&
+          !!amount.fiat(currency) && <Fiat amount={amount} noCountUp isBalance />
+        )
       }
     />
   )

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -5,7 +5,6 @@ import { classNames, planckToTokens } from "@talismn/util"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import {
   isTxInfoApproval,
-  isTxInfoBittensorStaking,
   isTxInfoSwap,
   isTxInfoTransfer,
   TransactionStatus,
@@ -478,9 +477,8 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
 
   const txTransfer = isTxInfoTransfer(tx.txInfo) ? tx.txInfo : undefined
   const txSwap = isTxInfoSwap(tx.txInfo) ? tx.txInfo : undefined
-  const txBittensorStaking = isTxInfoBittensorStaking(tx.txInfo) ? tx.txInfo : undefined
 
-  const tokenId = txTransfer?.tokenId || txSwap?.fromTokenId || txBittensorStaking?.fromTokenId
+  const tokenId = txTransfer?.tokenId || txSwap?.fromTokenId
 
   const chain = useNetworkByGenesisHash(genesisHash)
   const token = useToken(tokenId)
@@ -499,13 +497,11 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
     }
   }, [token, tokenRates, txTransfer])
 
-  // Swap tokens
   const fromToken = useToken(txSwap?.fromTokenId)
   const toToken = useToken(txSwap?.toTokenId)
 
-  // Bittensor staking tokens (similar to swap)
-  const stakingFromToken = useToken(txBittensorStaking?.fromTokenId)
-  const stakingToToken = useToken(txBittensorStaking?.toTokenId)
+  // Only use SwapTransactionStatusLabel for external swaps (not bittensor-staking)
+  const isExternalSwap = txSwap && txSwap.type !== "bittensor-staking"
 
   const handleRowClick = useCallback(() => onSelectTx(tx), [onSelectTx, tx])
 
@@ -517,22 +513,13 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
           <TxIconContainer tooltip={tx.siteUrl} networkId={chain?.id}>
             <Favicon siteUrl={tx.siteUrl} className="!h-16 !w-16" />
           </TxIconContainer>
-        ) : txSwap ? (
+        ) : txSwap && fromToken && toToken ? (
           <div className="flex items-center">
-            <TxIconContainer networkId={fromToken?.networkId}>
-              <TokenLogo tokenId={fromToken?.id} className="!h-16 !w-16" />
+            <TxIconContainer networkId={fromToken.networkId}>
+              <TokenLogo tokenId={fromToken.id} className="!h-16 !w-16" />
             </TxIconContainer>
-            <TxIconContainer className="-ml-4" networkId={toToken?.networkId}>
-              <TokenLogo tokenId={toToken?.id} className="!h-16 !w-16" />
-            </TxIconContainer>
-          </div>
-        ) : txBittensorStaking && stakingFromToken && stakingToToken ? (
-          <div className="flex items-center">
-            <TxIconContainer networkId={stakingFromToken.networkId}>
-              <TokenLogo tokenId={stakingFromToken.id} className="!h-16 !w-16" />
-            </TxIconContainer>
-            <TxIconContainer className="-ml-4" networkId={stakingToToken.networkId}>
-              <TokenLogo tokenId={stakingToToken.id} className="!h-16 !w-16" />
+            <TxIconContainer className="-ml-4" networkId={toToken.networkId}>
+              <TokenLogo tokenId={toToken.id} className="!h-16 !w-16" />
             </TxIconContainer>
           </div>
         ) : isTransfer && token ? (
@@ -546,7 +533,7 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
         )
       }
       status={
-        txSwap ? (
+        isExternalSwap ? (
           <Suspense fallback={<SwapTransactionStatusLabelFallback />}>
             <SwapTransactionStatusLabel tx={tx} />
           </Suspense>
@@ -556,15 +543,14 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
       }
       wen={<DistanceToNow timestamp={tx.timestamp} />}
       tokens={
-        txSwap ? (
-          // tx is a swap deposit
+        txSwap && fromToken && toToken ? (
           <div className="flex flex-col">
             <div className="flex items-center justify-end gap-1">
               <Tokens
                 className="pointer-events-none"
-                amount={planckToTokens(txSwap.fromAmount, fromToken?.decimals)}
-                decimals={fromToken?.decimals}
-                symbol={fromToken?.symbol}
+                amount={planckToTokens(txSwap.fromAmount, fromToken.decimals)}
+                decimals={fromToken.decimals}
+                symbol={fromToken.symbol}
                 noCountUp
                 noTooltip
                 isBalance
@@ -573,34 +559,9 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
             </div>
             <Tokens
               className="pointer-events-none"
-              amount={planckToTokens(txSwap.toAmount, toToken?.decimals)}
-              decimals={toToken?.decimals ?? 0}
-              symbol={toToken?.symbol}
-              noCountUp
-              noTooltip
-              isBalance
-            />
-          </div>
-        ) : txBittensorStaking && stakingFromToken && stakingToToken ? (
-          // Bittensor staking: display like a swap (from -> to)
-          <div className="flex flex-col">
-            <div className="flex items-center justify-end gap-1">
-              <Tokens
-                className="pointer-events-none"
-                amount={planckToTokens(txBittensorStaking.fromAmount, stakingFromToken.decimals)}
-                decimals={stakingFromToken.decimals}
-                symbol={stakingFromToken.symbol}
-                noCountUp
-                noTooltip
-                isBalance
-              />
-              <ArrowRightIcon className="text-body-inactive" />
-            </div>
-            <Tokens
-              className="pointer-events-none"
-              amount={planckToTokens(txBittensorStaking.toAmount, stakingToToken.decimals)}
-              decimals={stakingToToken.decimals}
-              symbol={stakingToToken.symbol}
+              amount={planckToTokens(txSwap.toAmount, toToken.decimals)}
+              decimals={toToken.decimals}
+              symbol={toToken.symbol}
               noCountUp
               noTooltip
               isBalance

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -1,19 +1,21 @@
-import { BalanceFormatter } from "@talismn/balances"
-import { NetworkId } from "@talismn/chaindata-provider"
+import { alphaToTao, BalanceFormatter, TAO_DECIMALS } from "@talismn/balances"
+import { isTokenSubDTao, NetworkId, subNativeTokenId } from "@talismn/chaindata-provider"
 import { ArrowRightIcon, LoaderIcon, XOctagonIcon } from "@talismn/icons"
 import { classNames, planckToTokens } from "@talismn/util"
+import { useQuery } from "@tanstack/react-query"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import {
   isTxInfoApproval,
   isTxInfoSwap,
   isTxInfoTransfer,
+  SignerPayloadJSON,
   TransactionStatus,
   WalletTransaction,
   WalletTransactionDot,
   WalletTransactionEth,
   WalletTransactionSol,
 } from "extension-core"
-import { IS_FIREFOX } from "extension-shared"
+import { IS_FIREFOX, log } from "extension-shared"
 import { FC, ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Tooltip, TooltipContent, TooltipTrigger } from "talisman-ui"
@@ -23,14 +25,17 @@ import { Fiat } from "@ui/domains/Asset/Fiat"
 import { TokenLogo } from "@ui/domains/Asset/TokenLogo"
 import { Tokens } from "@ui/domains/Asset/Tokens"
 import { NetworkLogo } from "@ui/domains/Networks/NetworkLogo"
+import { isBatchCall } from "@ui/domains/Sign/Substrate/types"
 import { useSwapStatus } from "@ui/domains/Swap/hooks/useSwapStatus"
 import { useFaviconUrl } from "@ui/hooks/useFaviconUrl"
+import { useSubstratePayloadMetadata } from "@ui/hooks/useSubstratePayloadMetadata"
 import {
   useNetworkByGenesisHash,
   useNetworkById,
   useSelectedCurrency,
   useToken,
   useTokenRates,
+  useTokens,
 } from "@ui/state"
 import { IS_POPUP } from "@ui/util/constants"
 
@@ -297,6 +302,217 @@ const SwapTransactionStatusLabelFallback = () => {
   )
 }
 
+const BITTENSOR_GENESIS_HASHES = new Set([
+  "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03",
+  "0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105",
+])
+
+const BITTENSOR_STAKING_METHODS = new Set([
+  "add_stake",
+  "add_stake_limit",
+  "remove_stake",
+  "remove_stake_limit",
+])
+
+const isBittensorTransaction = (payload: SignerPayloadJSON) =>
+  BITTENSOR_GENESIS_HASHES.has(payload.genesisHash)
+
+const isBittensorStakingCall = (pallet: string, method: string) =>
+  pallet === "SubtensorModule" && BITTENSOR_STAKING_METHODS.has(method)
+
+const getStakingAmount = (
+  method: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any,
+): { amount: bigint; isStake: boolean; netuid: number } | null => {
+  const netuid = args.netuid as number | undefined
+  if (netuid === undefined) return null
+
+  if (method === "add_stake" || method === "add_stake_limit") {
+    return args.amount_staked ? { amount: args.amount_staked, isStake: true, netuid } : null
+  }
+  if (method === "remove_stake" || method === "remove_stake_limit") {
+    return args.amount_unstaked ? { amount: args.amount_unstaked, isStake: false, netuid } : null
+  }
+  return null
+}
+
+const useBittensorStakingCalls = (payload: SignerPayloadJSON) => {
+  const { data } = useSubstratePayloadMetadata(payload)
+
+  return useMemo(() => {
+    if (!data?.sapi) return null
+
+    try {
+      const decodedCall = data.sapi.getDecodedCallFromPayload(payload)
+
+      if (isBatchCall(decodedCall)) {
+        const calls = decodedCall.args.calls as Array<{
+          type: string
+          value: { type: string; value: unknown }
+        }>
+        const filtered = calls
+          .map((call) => ({ pallet: call.type, method: call.value.type, args: call.value.value }))
+          .filter((call) => isBittensorStakingCall(call.pallet, call.method))
+        return filtered.length > 0 ? filtered : null
+      }
+
+      if (isBittensorStakingCall(decodedCall.pallet, decodedCall.method)) {
+        return [{ pallet: decodedCall.pallet, method: decodedCall.method, args: decodedCall.args }]
+      }
+
+      return null
+    } catch (err) {
+      log.error("Failed to decode bittensor staking call", { err })
+      return null
+    }
+  }, [data?.sapi, payload])
+}
+
+const useBittensorStakingAlphaPrices = (
+  payload: SignerPayloadJSON,
+  stakingCalls: Array<{ method: string; args: unknown }> | null,
+) => {
+  const { data } = useSubstratePayloadMetadata(payload)
+
+  const netuids = useMemo(() => {
+    if (!stakingCalls) return []
+    const uniqueNetuids = new Set<number>()
+    for (const call of stakingCalls) {
+      const info = getStakingAmount(call.method, call.args)
+      if (info && !info.isStake && info.netuid !== 0) {
+        uniqueNetuids.add(info.netuid)
+      }
+    }
+    return Array.from(uniqueNetuids)
+  }, [stakingCalls])
+
+  return useQuery({
+    queryKey: ["bittensorStakingAlphaPrices", data?.sapi?.id, netuids],
+    queryFn: async () => {
+      if (!data?.sapi || netuids.length === 0) return {}
+
+      const prices: Record<number, bigint> = {}
+      await Promise.all(
+        netuids.map(async (netuid) => {
+          try {
+            const price = await data.sapi!.getRuntimeCallValue<bigint>(
+              "SwapRuntimeApi",
+              "current_alpha_price",
+              [netuid],
+            )
+            prices[netuid] = price
+          } catch (err) {
+            log.error("Failed to fetch alpha price for netuid", { netuid, err })
+          }
+        }),
+      )
+      return prices
+    },
+    enabled: !!data?.sapi && netuids.length > 0,
+  })
+}
+
+const BittensorStakingTokens: FC<{ payload: SignerPayloadJSON }> = ({ payload }) => {
+  const stakingCalls = useBittensorStakingCalls(payload)
+  const network = useNetworkByGenesisHash(payload.genesisHash)
+  const allTokens = useTokens()
+
+  const subnetSymbols = useMemo(() => {
+    if (!network?.id) return {}
+    const symbols: Record<number, string> = {}
+    for (const token of allTokens) {
+      if (isTokenSubDTao(token) && token.networkId === network.id && !token.hotkey) {
+        symbols[token.netuid] = token.symbol
+      }
+    }
+    return symbols
+  }, [allTokens, network?.id])
+
+  if (!stakingCalls?.length) return null
+
+  const renderToken = (call: (typeof stakingCalls)[0], key?: number) => {
+    const info = getStakingAmount(call.method, call.args)
+    if (!info) return null
+
+    // For stakes, always use TAO. For unstakes, use subnet-specific symbol (or fallback to α)
+    const symbol = info.isStake ? "TAO" : (subnetSymbols[info.netuid] ?? "α")
+
+    return (
+      <Tokens
+        key={key}
+        className="pointer-events-none"
+        amount={planckToTokens(info.amount.toString(), Number(TAO_DECIMALS))}
+        symbol={symbol}
+        noCountUp
+        noTooltip
+        isBalance
+      />
+    )
+  }
+
+  if (stakingCalls.length > 1) {
+    return (
+      <div className="flex flex-col items-end">
+        {stakingCalls.map((call, i) => renderToken(call, i))}
+      </div>
+    )
+  }
+
+  return renderToken(stakingCalls[0])
+}
+
+const BittensorStakingTokensFallback = () => (
+  <div className="bg-grey-800 text-grey-800 rounded-xs animate-pulse text-sm">0.00 TAO</div>
+)
+
+const BittensorStakingFiat: FC<{ payload: SignerPayloadJSON }> = ({ payload }) => {
+  const stakingCalls = useBittensorStakingCalls(payload)
+  const network = useNetworkByGenesisHash(payload.genesisHash)
+  const taoTokenId = network?.id ? subNativeTokenId(network.id) : null
+  const taoRates = useTokenRates(taoTokenId)
+  const currency = useSelectedCurrency()
+  const { data: alphaPrices } = useBittensorStakingAlphaPrices(payload, stakingCalls)
+
+  const totalFiat = useMemo(() => {
+    if (!taoRates?.[currency]?.price) return null
+    if (!stakingCalls?.length) return null
+
+    let total = 0
+    for (const call of stakingCalls) {
+      const info = getStakingAmount(call.method, call.args)
+      if (!info) continue
+
+      let taoAmount: bigint
+      if (info.isStake) {
+        // Staking: amount is already in TAO
+        taoAmount = info.amount
+      } else if (info.netuid === 0) {
+        // Root subnet unstaking: amount is in TAO
+        taoAmount = info.amount
+      } else {
+        // Subnet unstaking: convert alpha to TAO using current price
+        const alphaPrice = alphaPrices?.[info.netuid]
+        if (!alphaPrice) continue
+        taoAmount = alphaToTao(info.amount, alphaPrice)
+      }
+
+      const tokens = Number(planckToTokens(taoAmount.toString(), Number(TAO_DECIMALS)))
+      total += tokens * taoRates[currency].price
+    }
+
+    return total > 0 ? total : null
+  }, [stakingCalls, taoRates, currency, alphaPrices])
+
+  if (!totalFiat) return null
+
+  return <Fiat amount={totalFiat} noCountUp isBalance />
+}
+
+const BittensorStakingFiatFallback = () => (
+  <div className="bg-grey-800 text-grey-800 rounded-xs animate-pulse text-xs">$0.00</div>
+)
+
 const TransactionRowBase: FC<{
   logo: ReactNode
   status: ReactNode
@@ -304,44 +520,40 @@ const TransactionRowBase: FC<{
   tokens: ReactNode
   fiat: ReactNode
   onClick?: () => void
-}> = ({ logo, status, wen, tokens, fiat, onClick }) => {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={!onClick}
-      className={classNames(
-        "bg-grey-850 hover:bg-grey-800 relative z-0 flex w-full grow items-center rounded-sm text-left",
-        IS_POPUP ? "h-[5.2rem] gap-6 px-6" : "h-[5.8rem] gap-8 px-8",
-      )}
-    >
-      {logo}
-      <div className="leading-paragraph flex w-full grow justify-between">
-        <div className="flex flex-col items-start justify-center">
-          <div
-            className={classNames(
-              "text-body flex h-10 items-center gap-2 font-bold",
-              IS_POPUP ? "text-sm" : "text-base",
-            )}
-          >
-            {status}
-          </div>
-          <div className={classNames("text-body-disabled", IS_POPUP ? "text-xs" : "text-sm")}>
-            {wen}
-          </div>
+}> = ({ logo, status, wen, tokens, fiat, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={!onClick}
+    className={classNames(
+      "bg-grey-850 hover:bg-grey-800 relative z-0 flex w-full grow items-center rounded-sm text-left",
+      IS_POPUP ? "h-[5.2rem] gap-6 px-6" : "h-[5.8rem] gap-8 px-8",
+    )}
+  >
+    {logo}
+    <div className="leading-paragraph flex w-full grow justify-between">
+      <div className="flex flex-col items-start justify-center">
+        <div
+          className={classNames(
+            "text-body flex h-10 items-center gap-2 font-bold",
+            IS_POPUP ? "text-sm" : "text-base",
+          )}
+        >
+          {status}
         </div>
-        <div className="flex flex-col items-end justify-center text-right">
-          <div className={classNames("text-body", IS_POPUP ? "text-sm" : "text-base")}>
-            {tokens}
-          </div>
-          <div className={classNames("text-body-disabled", IS_POPUP ? "text-xs" : "text-sm")}>
-            {fiat}
-          </div>
+        <div className={classNames("text-body-disabled", IS_POPUP ? "text-xs" : "text-sm")}>
+          {wen}
         </div>
       </div>
-    </button>
-  )
-}
+      <div className="flex flex-col items-end justify-center text-right">
+        <div className={classNames("text-body", IS_POPUP ? "text-sm" : "text-base")}>{tokens}</div>
+        <div className={classNames("text-body-disabled", IS_POPUP ? "text-xs" : "text-sm")}>
+          {fiat}
+        </div>
+      </div>
+    </div>
+  </button>
+)
 
 const TransactionRowEvm: FC<TransactionRowEthProps> = ({ tx, onSelectTx }) => {
   const evmNetwork = useNetworkById(tx.networkId, "ethereum")
@@ -486,9 +698,7 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
   const currency = useSelectedCurrency()
 
   const { isTransfer, amount } = useMemo(() => {
-    // historically txInfo wasnt a property, transfer params were set on the tx object
     const isTransfer = token && txTransfer
-
     return {
       isTransfer,
       amount: isTransfer
@@ -502,6 +712,9 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
 
   const handleRowClick = useCallback(() => onSelectTx(tx), [onSelectTx, tx])
 
+  const isBittensorStaking =
+    isBittensorTransaction(tx.payload) && tx.label === "Transaction" && !tx.txInfo?.type
+
   return (
     <TransactionRowBase
       onClick={handleRowClick}
@@ -512,10 +725,10 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
           </TxIconContainer>
         ) : txSwap ? (
           <div className="flex items-center">
-            <TxIconContainer networkId={fromToken?.networkId ?? fromToken?.networkId}>
+            <TxIconContainer networkId={fromToken?.networkId}>
               <TokenLogo tokenId={fromToken?.id} className="!h-16 !w-16" />
             </TxIconContainer>
-            <TxIconContainer className="-ml-4" networkId={toToken?.networkId ?? toToken?.networkId}>
+            <TxIconContainer className="-ml-4" networkId={toToken?.networkId}>
               <TokenLogo tokenId={toToken?.id} className="!h-16 !w-16" />
             </TxIconContainer>
           </div>
@@ -530,20 +743,21 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
         )
       }
       status={
-        <>
-          {txSwap ? (
-            <Suspense fallback={<SwapTransactionStatusLabelFallback />}>
-              <SwapTransactionStatusLabel tx={tx} />
-            </Suspense>
-          ) : (
-            <TransactionStatusLabel status={tx.status} />
-          )}
-        </>
+        txSwap ? (
+          <Suspense fallback={<SwapTransactionStatusLabelFallback />}>
+            <SwapTransactionStatusLabel tx={tx} />
+          </Suspense>
+        ) : (
+          <TransactionStatusLabel status={tx.status} />
+        )
       }
       wen={<DistanceToNow timestamp={tx.timestamp} />}
       tokens={
-        txSwap ? (
-          // tx is a swap deposit
+        isBittensorStaking ? (
+          <Suspense fallback={<BittensorStakingTokensFallback />}>
+            <BittensorStakingTokens payload={tx.payload} />
+          </Suspense>
+        ) : txSwap ? (
           <div className="flex flex-col">
             <div className="flex items-center justify-end gap-1">
               <Tokens
@@ -583,9 +797,15 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
         )
       }
       fiat={
-        isTransfer &&
-        !!amount &&
-        !!amount.fiat(currency) && <Fiat amount={amount} noCountUp isBalance />
+        isBittensorStaking ? (
+          <Suspense fallback={<BittensorStakingFiatFallback />}>
+            <BittensorStakingFiat payload={tx.payload} />
+          </Suspense>
+        ) : (
+          isTransfer &&
+          !!amount &&
+          !!amount.fiat(currency) && <Fiat amount={amount} noCountUp isBalance />
+        )
       }
     />
   )

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryList.tsx
@@ -213,9 +213,11 @@ const TxIconContainer = ({
         )}
       </div>
     </TooltipTrigger>
-    <TooltipContent className="bg-grey-700 rounded-xs z-20 p-3 text-xs shadow">
-      {tooltip}
-    </TooltipContent>
+    {!!tooltip && (
+      <TooltipContent className="bg-grey-700 rounded-xs z-20 p-3 text-xs shadow">
+        {tooltip}
+      </TooltipContent>
+    )}
   </Tooltip>
 )
 const TransactionStatusLabel: FC<{ status: TransactionStatus }> = ({ status }) => {
@@ -498,7 +500,9 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
   }, [token, tokenRates, txTransfer])
 
   const fromToken = useToken(txSwap?.fromTokenId)
+  const fromNetwork = useNetworkById(fromToken?.networkId)
   const toToken = useToken(txSwap?.toTokenId)
+  const toNetwork = useNetworkById(toToken?.networkId)
 
   // Only use SwapTransactionStatusLabel for external swaps (not bittensor-staking)
   const isExternalSwap = txSwap && txSwap.type !== "bittensor-staking"
@@ -515,10 +519,17 @@ const TransactionRowDot: FC<TransactionRowDotProps> = ({ tx, onSelectTx }) => {
           </TxIconContainer>
         ) : txSwap && fromToken && toToken ? (
           <div className="flex items-center">
-            <TxIconContainer networkId={fromToken.networkId}>
+            <TxIconContainer
+              tooltip={`${fromToken.name}${fromNetwork?.name ? ` on ${fromNetwork.name}` : ""}`}
+              networkId={fromToken.networkId}
+            >
               <TokenLogo tokenId={fromToken.id} className="!h-16 !w-16" />
             </TxIconContainer>
-            <TxIconContainer className="-ml-4" networkId={toToken.networkId}>
+            <TxIconContainer
+              className="-ml-4"
+              tooltip={`${toToken.name}${toNetwork?.name ? ` on ${toNetwork.name}` : ""}`}
+              networkId={toToken.networkId}
+            >
               <TokenLogo tokenId={toToken.id} className="!h-16 !w-16" />
             </TxIconContainer>
           </div>

--- a/packages/extension-core/src/domains/transactions/exports.ts
+++ b/packages/extension-core/src/domains/transactions/exports.ts
@@ -2,12 +2,7 @@ import { isAddressEqual } from "@talismn/crypto"
 
 import { WalletTransaction } from "./types"
 
-export {
-  isTxInfoSwap,
-  isTxInfoTransfer,
-  isTxInfoApproval,
-  isTxInfoBittensorStaking,
-} from "./helpers"
+export { isTxInfoSwap, isTxInfoTransfer, isTxInfoApproval } from "./helpers"
 
 export const filterIsSameNetworkAndAddressTx =
   (ref: WalletTransaction) => (tx: WalletTransaction) => {

--- a/packages/extension-core/src/domains/transactions/exports.ts
+++ b/packages/extension-core/src/domains/transactions/exports.ts
@@ -2,7 +2,12 @@ import { isAddressEqual } from "@talismn/crypto"
 
 import { WalletTransaction } from "./types"
 
-export { isTxInfoSwap, isTxInfoTransfer, isTxInfoApproval } from "./helpers"
+export {
+  isTxInfoSwap,
+  isTxInfoTransfer,
+  isTxInfoApproval,
+  isTxInfoBittensorStaking,
+} from "./helpers"
 
 export const filterIsSameNetworkAndAddressTx =
   (ref: WalletTransaction) => (tx: WalletTransaction) => {

--- a/packages/extension-core/src/domains/transactions/helpers.ts
+++ b/packages/extension-core/src/domains/transactions/helpers.ts
@@ -270,3 +270,6 @@ export const isTxInfoTransfer = (txInfo: WalletTransactionInfo | undefined | nul
 
 export const isTxInfoApproval = (txInfo: WalletTransactionInfo | undefined | null) =>
   isTxInfoOfType(txInfo, "approve-erc20")
+
+export const isTxInfoBittensorStaking = (txInfo: WalletTransactionInfo | undefined | null) =>
+  isTxInfoInTypes(txInfo, ["bittensor-stake", "bittensor-unstake"])

--- a/packages/extension-core/src/domains/transactions/helpers.ts
+++ b/packages/extension-core/src/domains/transactions/helpers.ts
@@ -272,4 +272,4 @@ export const isTxInfoApproval = (txInfo: WalletTransactionInfo | undefined | nul
   isTxInfoOfType(txInfo, "approve-erc20")
 
 export const isTxInfoBittensorStaking = (txInfo: WalletTransactionInfo | undefined | null) =>
-  isTxInfoInTypes(txInfo, ["bittensor-stake", "bittensor-unstake"])
+  isTxInfoOfType(txInfo, "bittensor-staking")

--- a/packages/extension-core/src/domains/transactions/helpers.ts
+++ b/packages/extension-core/src/domains/transactions/helpers.ts
@@ -263,13 +263,10 @@ export const isTxInfoInTypes = <T extends WalletTransactionInfo["type"]>(
 }
 
 export const isTxInfoSwap = (txInfo: WalletTransactionInfo | undefined | null) =>
-  isTxInfoInTypes(txInfo, ["swap-simpleswap", "swap-stealthex", "swap-lifi"])
+  isTxInfoInTypes(txInfo, ["swap-simpleswap", "swap-stealthex", "swap-lifi", "bittensor-staking"])
 
 export const isTxInfoTransfer = (txInfo: WalletTransactionInfo | undefined | null) =>
   isTxInfoOfType(txInfo, "transfer")
 
 export const isTxInfoApproval = (txInfo: WalletTransactionInfo | undefined | null) =>
   isTxInfoOfType(txInfo, "approve-erc20")
-
-export const isTxInfoBittensorStaking = (txInfo: WalletTransactionInfo | undefined | null) =>
-  isTxInfoOfType(txInfo, "bittensor-staking")

--- a/packages/extension-core/src/domains/transactions/types.ts
+++ b/packages/extension-core/src/domains/transactions/types.ts
@@ -60,12 +60,10 @@ export type WalletTransactionInfo =
     }
   | {
       type: "bittensor-staking"
-      action: "stake" | "unstake"
       fromTokenId: TokenId
       toTokenId: TokenId
       fromAmount: string
       toAmount: string
-      netuid: number
     }
 
 /** @deprecated */

--- a/packages/extension-core/src/domains/transactions/types.ts
+++ b/packages/extension-core/src/domains/transactions/types.ts
@@ -59,15 +59,12 @@ export type WalletTransactionInfo =
       to: Address
     }
   | {
-      type: "bittensor-stake"
-      tokenId: TokenId
-      amount: string
-      netuid: number
-    }
-  | {
-      type: "bittensor-unstake"
-      tokenId: TokenId
-      amount: string
+      type: "bittensor-staking"
+      action: "stake" | "unstake"
+      fromTokenId: TokenId
+      toTokenId: TokenId
+      fromAmount: string
+      toAmount: string
       netuid: number
     }
 

--- a/packages/extension-core/src/domains/transactions/types.ts
+++ b/packages/extension-core/src/domains/transactions/types.ts
@@ -58,6 +58,18 @@ export type WalletTransactionInfo =
       toAmount: string
       to: Address
     }
+  | {
+      type: "bittensor-stake"
+      tokenId: TokenId
+      amount: string
+      netuid: number
+    }
+  | {
+      type: "bittensor-unstake"
+      tokenId: TokenId
+      amount: string
+      netuid: number
+    }
 
 /** @deprecated */
 export type LegacyWalletTransactionBase = WalletTransactionTransferInfo & {


### PR DESCRIPTION
Added TAO/Alpha information for dTAO staking events (unstake/stake).
<img width="375" height="576" alt="Screenshot 2026-01-01 at 4 02 05 PM" src="https://github.com/user-attachments/assets/db2d9dba-a9da-485d-a965-a6a6fc2d9509" />

It seems like even for swap details (SimpleSwap), we still just say "Confirmed/Failed", so I didn't change the dTAO history items to stay "Stake/Unstake" (but this can easily be added if we want).