### PR TITLE
fix: typescript config for tests

### DIFF
--- a/.changeset/polite-rats-relate.md
+++ b/.changeset/polite-rats-relate.md
@@ -1,0 +1,20 @@
+---
+"@talismn/chaindata-provider": patch
+"@talismn/chain-connectors": patch
+"@talismn/connection-meta": patch
+"@talismn/balances-react": patch
+"@talismn/on-chain-id": patch
+"@talismn/token-rates": patch
+"@talismn/balances": patch
+"@talismn/keyring": patch
+"@talismn/tsconfig": patch
+"@talismn/crypto": patch
+"@talismn/solana": patch
+"@talismn/icons": patch
+"@talismn/scale": patch
+"@talismn/sapi": patch
+"@talismn/util": patch
+"@talismn/orb": patch
+---
+
+fix typescript config for tests

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 # Run Biome on staged files and auto-fix issues
 # Disable errexit for this block since we handle exit codes manually
 set +e
-output=$(pnpm biome check --staged --write --error-on-warnings 2>&1)
+output=$(pnpm biome check --staged --error-on-warnings 2>&1)
 exit_code=$?
 set -e
 echo "$output"

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -16,6 +16,13 @@
       "inject/*": ["./src/inject/*"]
     }
   },
-  "include": [".wxt/wxt.d.ts", "i18next-parser.config.cjs", "src", "entrypoints", "wxt.config.ts"],
-  "exclude": ["**/node_modules", "**/*.spec.ts", "**/*.test.ts"]
+  "include": [
+    ".wxt/wxt.d.ts",
+    "i18next-parser.config.cjs",
+    "src",
+    "entrypoints",
+    "wxt.config.ts",
+    "tests"
+  ],
+  "exclude": ["**/node_modules"]
 }

--- a/config/tsconfig/base.json
+++ b/config/tsconfig/base.json
@@ -18,5 +18,5 @@
     "skipLibCheck": true,
     "strict": true
   },
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/config/tsconfig/es6-node.json
+++ b/config/tsconfig/es6-node.json
@@ -13,5 +13,5 @@
     "noEmit": false,
     "customConditions": ["@talismn/source"]
   },
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/config/tsconfig/es6-react.json
+++ b/config/tsconfig/es6-react.json
@@ -14,5 +14,5 @@
     "jsx": "react-jsx",
     "customConditions": ["@talismn/source"]
   },
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/balances-react/tsconfig.json
+++ b/packages/balances-react/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-react.json",
   "include": ["src", "package.json"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/balances/tsconfig.json
+++ b/packages/balances/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src", "src/modules/abis/psp22.json", "package.json"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/chain-connectors/tsconfig.json
+++ b/packages/chain-connectors/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src", "package.json"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/chaindata-provider/tsconfig.json
+++ b/packages/chaindata-provider/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src", "src/state/initChaindata.json", "package.json"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/connection-meta/tsconfig.json
+++ b/packages/connection-meta/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/extension-core/tsconfig.json
+++ b/packages/extension-core/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@talismn/tsconfig/es6-react.json",
-  "include": ["src"],
-  "exclude": ["background", "**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "compilerOptions": {
+    "customConditions": ["@talismn/source"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["background", "**/node_modules", "**/.*/"]
 }

--- a/packages/extension-shared/tsconfig.json
+++ b/packages/extension-shared/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/keyring/tsconfig.json
+++ b/packages/keyring/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/on-chain-id/tsconfig.json
+++ b/packages/on-chain-id/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src", "package.json"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/orb/tsconfig.json
+++ b/packages/orb/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-react.json",
   "include": ["src"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/sapi/tsconfig.json
+++ b/packages/sapi/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src", "package.json"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/scale/tsconfig.json
+++ b/packages/scale/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src", "package.json"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/solana/tsconfig.json
+++ b/packages/solana/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src", "package.json"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/talisman-ui/tsconfig.json
+++ b/packages/talisman-ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-react.json",
   "include": ["src", "src/**/*.json"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/token-rates/tsconfig.json
+++ b/packages/token-rates/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "@talismn/tsconfig/es6-node.json",
   "include": ["src"],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "include": [],
-  "exclude": ["**/node_modules", "**/.*/", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["**/node_modules", "**/.*/"]
 }


### PR DESCRIPTION
follow-up to cristmas tooling PR.

- fixes imports from `@talisman/*` packages in test files.
- fixes precommit hook so biome doesnt apply any fixes automatically (which caused weird DX)