### PR TITLE
fix: button size of dtao swap history modal

### DIFF
--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryModal.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryModal.tsx
@@ -139,8 +139,8 @@ const TxHistoryActions: FC<TxHistoryActionsProps> = ({ tx }) => {
   }, [])
 
   const buttonsCount = useMemo(
-    () => (swapInfo ? 1 : 0) + (explorerLinks.length ? 1 : 0),
-    [explorerLinks.length, swapInfo]
+    () => (swapHref ? 1 : 0) + (explorerLinks.length ? 1 : 0),
+    [explorerLinks.length, swapHref]
   )
 
   if (!buttonsCount) return null


### PR DESCRIPTION
Alpha staking/swap tx history details will now display the "View on taostats" link with full width

Before:
<img width="407" height="611" alt="image" src="https://github.com/user-attachments/assets/dde89e22-584f-4b86-b980-773df5c09fbc" />

After: 
<img width="413" height="617" alt="Screenshot 2026-01-20 at 3 05 56 PM" src="https://github.com/user-attachments/assets/dc3fb1d0-c84b-447f-abe6-c5e5b4891b8e" />
