### PR TITLE
fix: json import for polkadot.js accounts (scalar validation error)

### DIFF
--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddJson/context.ts
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddJson/context.ts
@@ -2,15 +2,22 @@ import { createPair } from "@polkadot/keyring"
 import type { KeyringPair, KeyringPair$Json } from "@polkadot/keyring/types"
 import type { KeyringPairs$Json } from "@polkadot/ui-keyring/types"
 import { assert, hexToU8a, isHex, u8aToString } from "@polkadot/util"
-import { base64Decode, decodeAddress, encodeAddress, jsonDecrypt } from "@polkadot/util-crypto"
+import {
+  base64Decode,
+  base64Encode,
+  decodeAddress,
+  encodeAddress,
+  jsonDecrypt,
+} from "@polkadot/util-crypto"
 import type { EncryptedJson, KeypairType } from "@polkadot/util-crypto/types"
 import { provideContext } from "@talisman/util/provideContext"
 import { type Address, Balances } from "@talismn/balances"
-import { encodeAnyAddress, isAddressEqual, normalizeAddress } from "@talismn/crypto"
+import { deriveKeypair, encodeAnyAddress, isAddressEqual, normalizeAddress } from "@talismn/crypto"
 import { api } from "@ui/api"
 import { useAccountImportBalances } from "@ui/hooks/useAccountImportBalances"
 import { useAccounts, useNetworks } from "@ui/state"
 import type { Account, LegacyAccountOrigin } from "extension-core"
+import { getSecretKeyFromPjsJson } from "extension-core/domains/keyring/getSecretKeyFromPjsJson"
 import { log } from "extension-shared"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
@@ -41,13 +48,39 @@ const isMultiAccountJson = (json: EncryptedJson): json is KeyringPairs$Json => {
 const isSingleAccountJson = (json: EncryptedJson): json is KeyringPair$Json => {
   return (json as KeyringPair$Json).address !== undefined
 }
+// Add support for Polkadot.js array format: [{ address: "...", ... }]
+const isArrayAccountJson = (json: EncryptedJson): boolean => {
+  return Array.isArray(json) && json.length > 0 && json[0]?.address !== undefined
+}
 
-const createPairFromJson = ({ encoded, encoding, address, meta }: KeyringPair$Json) => {
+const createPairFromJson = (
+  { encoded, encoding, address, meta }: KeyringPair$Json,
+  password?: string
+) => {
   const cryptoType = Array.isArray(encoding.content) ? encoding.content[1] : "ed25519"
   const encType = Array.isArray(encoding.type) ? encoding.type : [encoding.type]
+
+  // Extract public key from encrypted data (not from address) to avoid scalar validation errors
+  let publicKey: Uint8Array
+  try {
+    if (password) {
+      // If we have password, get the correct public key from encrypted data
+      const json = { encoded, encoding, address, meta } as KeyringPair$Json
+      const keys = getSecretKeyFromPjsJson(json, password)
+      publicKey = keys.publicKey
+    } else {
+      // Fallback to address-derived public key
+      publicKey = decodeAddress(address, true)
+    }
+  } catch (error) {
+    log.error("Failed to extract keys from JSON:", error)
+    // If extraction fails, use address-derived public key as fallback
+    publicKey = decodeAddress(address, true)
+  }
+
   return createPair(
     { toSS58: encodeAddress, type: cryptoType as KeypairType },
-    { publicKey: decodeAddress(address, true) },
+    { publicKey },
     meta,
     isHex(encoded) ? hexToU8a(encoded) : base64Decode(encoded),
     encType
@@ -100,6 +133,12 @@ const useJsonAccountImportProvider = () => {
   // warning : array of mutable objects
   const [pairs, setPairs] = useState<KeyringPair[]>()
 
+  // Store original JSON data to send to backend (not re-exported)
+  const [originalJsons, setOriginalJsons] = useState<Map<string, KeyringPair$Json>>(new Map())
+
+  // Store the file password to use for key extraction during import
+  const [filePassword, setFilePassword] = useState<string>()
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: legacy
   useEffect(() => {
     setSelectedAccounts([])
@@ -111,6 +150,11 @@ const useJsonAccountImportProvider = () => {
 
     try {
       const content = JSON.parse(json) as EncryptedJson
+
+      // Handle Polkadot.js array format (extract first element)
+      if (isArrayAccountJson(content)) {
+        return { type: "single", content: (content as KeyringPair$Json[])[0] }
+      }
 
       if (isSingleAccountJson(content)) return { type: "single", content }
       if (isMultiAccountJson(content)) return { type: "multi", content }
@@ -127,15 +171,22 @@ const useJsonAccountImportProvider = () => {
     async (password: string) => {
       if (!file) return
 
+      // Store file password for later use during import
+      setFilePassword(password)
+
       // hangs UI, do asynchronously
       await new Promise<void>((resolve, reject) => {
         setTimeout(() => {
           try {
             if (file.type === "single") {
-              const pair = createPairFromJson(file.content)
+              // Pass password to get correct public key from encrypted data
+              const pair = createPairFromJson(file.content, password)
               pair.decodePkcs8(password)
 
               setPairs([pair])
+
+              // Store original JSON for backend import
+              setOriginalJsons(new Map([[pair.address, file.content]]))
 
               if (
                 !existingAccounts.some((a) => isAddressEqual(a.address, pair.address)) &&
@@ -146,9 +197,16 @@ const useJsonAccountImportProvider = () => {
             } else if (file.type === "multi") {
               const data = jsonDecrypt(file.content, password)
               const accounts = JSON.parse(u8aToString(data)) as KeyringPair$Json[]
-              const pairs = accounts.map(createPairFromJson)
+              const pairs = accounts.map((acc) => createPairFromJson(acc, password))
 
               setPairs(pairs)
+
+              // Store original JSONs for backend import
+              const jsonMap = new Map()
+              pairs.forEach((pair, i) => {
+                jsonMap.set(pair.address, accounts[i])
+              })
+              setOriginalJsons(jsonMap)
             } else throw new Error("Invalid file type")
 
             resolve()
@@ -277,6 +335,7 @@ const useJsonAccountImportProvider = () => {
   const importAccounts = useCallback(() => {
     assert(selectedAccounts.length, "No accounts selected")
     assert(pairs, "Pairs unavailable")
+    assert(filePassword, "File password not available")
 
     const pairsToImport = selectedAccounts.map(
       (address) => pairs.find((p) => p.address === address) as KeyringPair
@@ -287,10 +346,40 @@ const useJsonAccountImportProvider = () => {
       assert(!pair.isLocked, "Account is locked")
     }
 
-    const unlockedPairs = pairsToImport.map((p) => p.toJson())
+    // CRITICAL FIX: Convert Polkadot.js 64-byte format to Talisman format!
+    //
+    // Polkadot.js PKCS8 format: [32 bytes SEED] + [32 bytes PUBLIC KEY]
+    // Talisman sr25519 format: [32 bytes privateKey] + [32 bytes nonce] (from secretFromSeed)
+    //
+    // These are DIFFERENT! We must:
+    // 1. Extract seed (first 32 bytes) from Polkadot.js JSON
+    // 2. Derive proper secretKey using Talisman's deriveKeypair (like addAccountDerive does)
+    // 3. Use that derived secretKey (which has correct format)
+    const options = pairsToImport.map((pair) => {
+      const original = originalJsons.get(pair.address)
+      assert(original, `Original JSON not found for ${pair.address}`)
 
-    return api.accountCreateFromJson(unlockedPairs)
-  }, [pairs, selectedAccounts])
+      // Extract keys from Polkadot.js JSON
+      const keys = getSecretKeyFromPjsJson(original, filePassword)
+
+      // Extract SEED (first 32 bytes)
+      const seed = keys.secretKey.subarray(0, 32)
+
+      // Derive proper secretKey using Talisman's derivation (like addAccountDerive does)
+      const curve = Array.isArray(original.encoding.content)
+        ? original.encoding.content[1]
+        : "ed25519"
+      const derived = deriveKeypair(seed, "", curve) // Empty derivation path for base account
+
+      return {
+        name: pair.meta?.name || "Json Import",
+        curve,
+        secretKey: base64Encode(derived.secretKey), // Now in correct Talisman format!
+      }
+    })
+
+    return api.accountAddKeypair(options)
+  }, [pairs, selectedAccounts, originalJsons, filePassword])
 
   return {
     accounts,

--- a/packages/extension-core/src/domains/keyring/getSecretKeyFromPjsJson.ts
+++ b/packages/extension-core/src/domains/keyring/getSecretKeyFromPjsJson.ts
@@ -10,6 +10,7 @@ const PKCS8_HEADER = new Uint8Array([48, 83, 2, 1, 1, 48, 5, 6, 3, 43, 101, 112,
 const SEC_LENGTH = 64
 const SEED_LENGTH = 32
 const SEED_OFFSET = PKCS8_HEADER.length
+const PUB_LENGTH = 32
 
 // Function implementation inspired by these files:
 // - https://github.com/polkadot-js/common/blob/8b0f5bf46e3edf2f52001c499ccdd555d5bdf5c2/packages/keyring/src/pair/decode.ts#L13-L56
@@ -50,5 +51,9 @@ export const getSecretKeyFromPjsJson = (json: EncryptedJson, password: string) =
     if (!u8aEq(divider, PKCS8_DIVIDER)) throw new Error("Invalid Pkcs8 divider found in body")
   }
 
-  return privateKey
+  // Extract public key from encrypted data (like Polkadot.js decodePair)
+  const pubOffset = divOffset + PKCS8_DIVIDER.length
+  const publicKey = decrypted.subarray(pubOffset, pubOffset + PUB_LENGTH)
+
+  return { secretKey: privateKey, publicKey }
 }

--- a/packages/extension-core/src/domains/keyring/migrations/migrateFromPjsKeyring.ts
+++ b/packages/extension-core/src/domains/keyring/migrations/migrateFromPjsKeyring.ts
@@ -136,7 +136,7 @@ const executeMigrationFromPjsKeyring = async (password: string, reset = false) =
               await keyringStore.addAccountKeypair({
                 name,
                 curve,
-                secretKey: getSecretKeyFromPjsJson(oldPair.toJson(password), password),
+                secretKey: getSecretKeyFromPjsJson(oldPair.toJson(password), password).secretKey,
               })
             }
 


### PR DESCRIPTION
# Fix JSON Import for Polkadot.js Accounts

## Problem
Importing Polkadot.js JSON account backups into Talisman failed with: expected valid scalar error for sr25519/ed25519 accounts.

## Root Cause
Secret key format mismatch between Polkadot.js PKCS8 format ([seed + publicKey]) and Talisman's internal format ([privateKey + nonce]).

## Solution
Implemented format conversion by extracting seed from Polkadot.js JSON and deriving proper secretKey using Talisman's deriveKeypair function (same approach as addAccountDerive for mnemonic accounts).

## Changes
- apps/extension/src/ui/domains/Account/AccountAdd/AccountAddJson/context.ts: Added state preservation, JSON array format support, format conversion in importAccounts
- packages/extension-core/src/domains/keyring/getSecretKeyFromPjsJson.ts: Now returns {secretKey, publicKey} object
- packages/extension-core/src/domains/keyring/migrations/migrateFromPjsKeyring.ts: Updated to use .secretKey property

## Testing
- Tested with multiple Polkadot.js JSON exports (sr25519 and ed25519)
- Tested with both single JSON files and array format
- All imports succeed without scalar validation errors

## Impact
- Enables seamless migration from Polkadot.js Extension to Talisman
- Supports both legacy and modern JSON export formats
- No breaking changes