### PR TITLE
Feat/tao dashboard leaderboard

### DIFF
--- a/apps/extension/src/ui/domains/TaoDashboard/hooks/useSn45Api.ts
+++ b/apps/extension/src/ui/domains/TaoDashboard/hooks/useSn45Api.ts
@@ -3,8 +3,9 @@ import { Sn45Api } from "extension-core"
 import { useMemo } from "react"
 
 // Use local dev URL in development, otherwise use production
-const SN45_API_BASE_URL = "https://sn45api.talisman.xyz"
-// const SN45_API_BASE_URL = process.env.NODE_ENV === "development" ? "http://localhost:8787" : "https://sn45api.talisman.xyz"
+// const SN45_API_BASE_URL = "https://sn45api.talisman.xyz"
+const SN45_API_BASE_URL =
+  process.env.NODE_ENV === "development" ? "http://localhost:8787" : "https://sn45api.talisman.xyz"
 
 // Create a singleton API instance
 const sn45Api = new Sn45Api({ baseUrl: SN45_API_BASE_URL })
@@ -28,6 +29,19 @@ export const useSubnetEconomics = () => {
     queryKey: ["sn45", "subnetEconomics"],
     queryFn: async () => {
       const response = await sn45Api.v1.getSubnetEconomicsList()
+      return response.data
+    },
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  })
+}
+
+// Hook to get subnet leaderboard data
+export const useSubnetLeaderboard = (period: "1d" | "1w" | "1m" = "1d") => {
+  return useQuery({
+    queryKey: ["sn45", "subnetLeaderboard", period],
+    queryFn: async () => {
+      const response = await sn45Api.v1.getSubnetLeaderboard({ period })
       return response.data
     },
     refetchInterval: 60_000,

--- a/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardHeader.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardHeader.tsx
@@ -2,10 +2,53 @@ import { Balances } from "@talismn/balances"
 import { subNativeTokenId } from "@talismn/chaindata-provider"
 import { cn } from "@talismn/util"
 import { useBalances, useIsBalanceInitializing, useToken } from "@ui/state"
-import { useMemo } from "react"
+import { type FC, useMemo } from "react"
 import { useTranslation } from "react-i18next"
-import { TokensAndFiat } from "../../Asset/TokensAndFiat"
+import { useSubnetLeaderboard, useTaoPrice } from "../hooks/useSn45Api"
 import { BITTENSOR_NETWORK_ID } from "./constants"
+
+// Format large USD values
+const formatStatsUsd = (num: number) => {
+  if (num >= 1000000000) return `$${(num / 1000000000).toFixed(2)}B`
+  if (num >= 1000000) return `$${(num / 1000000).toFixed(2)}M`
+  if (num >= 1000) return `$${(num / 1000).toFixed(0)}K`
+  return `$${num.toFixed(2)}`
+}
+
+// Stat item for the header
+const StatItem: FC<{ label: string; value: string; change?: number }> = ({
+  label,
+  value,
+  change,
+}) => {
+  const isPositive = change !== undefined && change > 0
+  const isNegative = change !== undefined && change < 0
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-body-secondary text-sm">{label}</span>
+      <span className="font-bold text-body text-xl">{value}</span>
+      <span
+        className={cn(
+          "text-sm",
+          change === undefined && "invisible",
+          isPositive && "text-green",
+          isNegative && "text-red-500",
+          !isPositive && !isNegative && "text-body-secondary"
+        )}
+      >
+        {change !== undefined ? (
+          <>
+            {change > 0 ? "+" : ""}
+            {change.toFixed(2)}%
+          </>
+        ) : (
+          "—"
+        )}
+      </span>
+    </div>
+  )
+}
 
 export const PoweredBySn45 = () => (
   <a
@@ -24,6 +67,8 @@ export const TaoDashboardHeader = () => {
 
   const tao = useToken(subNativeTokenId(BITTENSOR_NETWORK_ID))
   const ownedBalances = useBalances("owned")
+  const { data: taoPrice } = useTaoPrice()
+  const { data: leaderboardData } = useSubnetLeaderboard("1d")
 
   const taoBalances = useMemo(() => {
     if (!tao) return new Balances([])
@@ -36,24 +81,62 @@ export const TaoDashboardHeader = () => {
     return isInitializing || taoBalances.each.some((b) => b.status === "cache")
   }, [isInitializing, taoBalances])
 
+  // Compute stats from TAO price and leaderboard data
+  const stats = useMemo(() => {
+    const taoUsd = taoPrice?.price ? parseFloat(taoPrice.price) : 0
+    const subnets = leaderboardData?.subnets ?? []
+
+    // TAO market cap from price feed
+    const marketCap = taoPrice?.marketCap ?? 0
+
+    // TAO price change
+    const priceChange24h = taoPrice?.priceChange24h ?? null
+
+    // Subnet volume from leaderboard (convert rao to TAO, then to USD)
+    const parseRao = (val: string | null | undefined) => (val ? Number(BigInt(val)) / 1e9 : 0)
+    const totalSubnetVolume = subnets.reduce((sum, s) => sum + parseRao(s.volume) * taoUsd, 0)
+
+    // Market cap change
+    const marketCapChange24h = taoPrice?.marketCapChange24h ?? null
+
+    return { marketCap, marketCapChange24h, totalSubnetVolume, taoUsd, priceChange24h }
+  }, [taoPrice, leaderboardData])
+
   return (
-    <div className="flex h-64 items-center justify-between rounded-[0.75rem] border border-grey-800 text-left text-base text-body-secondary">
-      <div className="flex flex-col gap-4 px-6 py-8">
+    <div className="flex h-auto min-h-64 items-stretch justify-between rounded-[0.75rem] border border-grey-800 text-left text-base text-body-secondary">
+      <div className="flex flex-col justify-center gap-4 px-6 py-8">
         <div className="text-body-secondary text-sm">{t("Available Tao Balance")}</div>
-        <div className="font-bold text-2xl text-body">
+        <div className={cn("font-bold text-2xl text-body", isLoading && "animate-pulse")}>
           {!taoBalances.sum.planck.transferable && isLoading ? (
-            <div className="animate-pulse rounded bg-grey-700 text-grey-700">$0.00</div>
+            <span className="rounded bg-grey-700 text-grey-700">0.00 τ</span>
           ) : (
-            <TokensAndFiat
-              tokenId={tao?.id}
-              planck={taoBalances.sum.planck.transferable}
-              className={cn(isLoading && "animate-pulse")}
-              fiatClassName="text-body-secondary"
-            />
+            <>
+              {/* TODO: remove placeholder */}
+              123,456.00 <span className="text-primary">τ</span>
+            </>
           )}
         </div>
       </div>
-      <div className="self-end px-6 py-4">
+
+      {/* Vertical divider */}
+      <div className="my-4 w-px bg-grey-800" />
+
+      {/* Stats */}
+      <div className="flex flex-1 items-center justify-around gap-8 px-6 py-8">
+        <StatItem
+          label={t("Total Market Cap")}
+          value={formatStatsUsd(stats.marketCap)}
+          change={stats.marketCapChange24h ?? undefined}
+        />
+        <StatItem label={t("24h Trading Volume")} value={formatStatsUsd(stats.totalSubnetVolume)} />
+        <StatItem
+          label={t("TAO Price")}
+          value={formatStatsUsd(stats.taoUsd)}
+          change={stats.priceChange24h ?? undefined}
+        />
+      </div>
+
+      <div className="flex items-end px-6 py-4">
         <PoweredBySn45 />
       </div>
     </div>

--- a/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardSubnetsTable.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardSubnetsTable.tsx
@@ -1,3 +1,4 @@
+import { InfoIcon } from "@talismn/icons"
 import { cn } from "@talismn/util"
 import { type FC, type PropsWithChildren, useCallback, useMemo, useState } from "react"
 import { Link } from "react-router-dom"
@@ -20,15 +21,16 @@ const DEFAULT_SORT_SETTING: SortSetting = { key: "netuid", order: "asc" }
 
 // Format number with appropriate precision
 const formatNumber = (num: number, decimals = 2) => {
-  if (num === 0) return "—"
+  if (num === 0) return "0"
+  if (Math.abs(num) >= 1000000000) return `${(num / 1000000000).toFixed(1)}B`
   if (Math.abs(num) >= 1000000) return `${(num / 1000000).toFixed(1)}M`
-  if (Math.abs(num) >= 1000) return `${(num / 1000).toFixed(1)}K`
+  if (Math.abs(num) >= 1000) return `${(num / 1000).toFixed(2)}k`
   return num.toFixed(decimals)
 }
 
 // Format price in TAO
 const formatTaoPrice = (price: number) => {
-  if (price === 0) return "—"
+  if (price === 0) return "0"
   if (price < 0.0001) return price.toFixed(6)
   if (price < 0.01) return price.toFixed(4)
   return price.toFixed(2)
@@ -36,9 +38,92 @@ const formatTaoPrice = (price: number) => {
 
 // Format USD price
 const formatUsdPrice = (price: number) => {
-  if (price === 0) return "—"
+  if (price === 0) return "$0"
+  if (price >= 1000000000) return `$ ${(price / 1000000000).toFixed(1)}B`
+  if (price >= 1000000) return `$ ${(price / 1000000).toFixed(1)}M`
   if (price < 0.01) return `$${price.toFixed(4)}`
   return `$${price.toFixed(2)}`
+}
+
+// Format large TAO amounts
+const formatTaoAmount = (num: number) => {
+  if (num === 0) return "0 τ"
+  if (num >= 1000000000) return `${(num / 1000000000).toFixed(1)}B τ`
+  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M τ`
+  if (num >= 1000) return `${(num / 1000).toFixed(1)}K τ`
+  return `${num.toFixed(0)} τ`
+}
+
+// Format balance with commas
+const formatBalance = (num: number) => {
+  if (num === 0) return "0"
+  return num.toLocaleString("en-US", { maximumFractionDigits: 0 })
+}
+
+// Mini sparkline chart component
+const SparklineChart: FC<{ data: number[]; isPositive: boolean }> = ({ data, isPositive }) => {
+  const min = Math.min(...data)
+  const max = Math.max(...data)
+  const range = max - min || 1
+
+  const points = data
+    .map((value, index) => {
+      const x = (index / (data.length - 1)) * 60
+      const y = 18 - ((value - min) / range) * 14
+      return `${x},${y}`
+    })
+    .join(" ")
+
+  return (
+    <svg width="60" height="20" className="overflow-visible">
+      <polyline
+        points={points}
+        fill="none"
+        stroke={isPositive ? "#22c55e" : "#ef4444"}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+// Sentiment badge component
+const SentimentBadge: FC<{ sentiment: "bullish" | "bearish" | null }> = ({ sentiment }) => {
+  if (!sentiment) return null
+
+  return (
+    <span
+      className={cn(
+        "ml-4 rounded px-4 py-1 text-[10px]",
+        sentiment === "bullish" && "bg-green/20 text-green",
+        sentiment === "bearish" && "bg-red-500/20 text-red-500"
+      )}
+    >
+      {sentiment === "bullish" ? "Bullish" : "Bearish"}
+    </span>
+  )
+}
+
+// Price change indicator
+const PriceChange: FC<{ change: number }> = ({ change }) => {
+  const isPositive = change > 0
+  const isNegative = change < 0
+
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-1 whitespace-nowrap",
+        isPositive && "text-green",
+        isNegative && "text-red-500",
+        !isPositive && !isNegative && "text-body-secondary"
+      )}
+    >
+      {change > 0 ? "+" : ""}
+      {change.toFixed(1)}%{isPositive && <span>↗</span>}
+      {isNegative && <span>↘</span>}
+    </span>
+  )
 }
 
 export const TaoDashboardSubnetsTable = () => {
@@ -71,7 +156,7 @@ export const TaoDashboardSubnetsTable = () => {
         <div className="flex w-full flex-col gap-px overflow-hidden bg-grey-750">
           {Array.from({ length: 8 }).map((_, i) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: static list
-            <div key={i} className="h-36 animate-pulse bg-grey-850" />
+            <div key={i} className="h-44 animate-pulse bg-grey-850" />
           ))}
         </div>
       </div>
@@ -94,6 +179,7 @@ const SortIndicator: FC<{ order?: SortOrder }> = ({ order }) => {
   return (
     <SortIcon
       className={cn(
+        "size-12 shrink-0",
         order === "asc" && "rotate-180 text-primary",
         order === "desc" && "text-primary"
       )}
@@ -102,18 +188,25 @@ const SortIndicator: FC<{ order?: SortOrder }> = ({ order }) => {
 }
 
 const HeaderCell: FC<
-  PropsWithChildren<{ sortOrder?: SortOrder; onSortOrderToggle?: () => void }>
-> = ({ children, sortOrder, onSortOrderToggle }) => {
+  PropsWithChildren<{
+    sortOrder?: SortOrder
+    onSortOrderToggle?: () => void
+    className?: string
+    showInfoIcon?: boolean
+  }>
+> = ({ children, sortOrder, onSortOrderToggle, className, showInfoIcon }) => {
   return (
     <button
       type="button"
       className={cn(
-        "flex max-h-24 gap-1 overflow-hidden uppercase",
-        onSortOrderToggle ? "cursor-pointer" : "cursor-default"
+        "flex items-center justify-start gap-1 text-left text-body-secondary text-xs uppercase",
+        onSortOrderToggle ? "cursor-pointer" : "cursor-default",
+        className
       )}
       onClick={onSortOrderToggle}
     >
-      <span className="truncate">{children}</span>
+      <span className="whitespace-nowrap">{children}</span>
+      {showInfoIcon && <InfoIcon className="size-12 shrink-0 text-body-disabled" />}
       {!!onSortOrderToggle && <SortIndicator order={sortOrder} />}
     </button>
   )
@@ -145,20 +238,36 @@ const HeaderRow: FC<{
   )
 
   return (
-    <div className="grid h-24 w-full grid-cols-[0.5fr,2fr,1fr,1fr,1fr,1fr,1fr] items-center gap-10 overflow-hidden bg-[#202020] px-10 text-body-inactive">
-      <HeaderCell>#</HeaderCell>
-      <HeaderCell>Subnet</HeaderCell>
+    <div className="grid h-36 w-full grid-cols-[minmax(120px,1.4fr),minmax(100px,1fr),minmax(100px,1fr),minmax(80px,0.7fr),minmax(90px,0.9fr),minmax(80px,0.8fr),minmax(70px,0.7fr),minmax(90px,0.8fr),minmax(70px,0.6fr)] items-center justify-items-start gap-4 bg-[#1a1a1a] px-8 text-body-inactive">
+      <HeaderCell
+        sortOrder={getSortOrder("netuid")}
+        onSortOrderToggle={handleSortToggle("netuid", "asc")}
+      >
+        Subnet
+      </HeaderCell>
       <HeaderCell
         sortOrder={getSortOrder("price")}
         onSortOrderToggle={handleSortToggle("price", "desc")}
       >
-        Price (τ)
+        Price
       </HeaderCell>
       <HeaderCell
-        sortOrder={getSortOrder("priceUsd")}
-        onSortOrderToggle={handleSortToggle("priceUsd", "desc")}
+        sortOrder={getSortOrder("balance")}
+        onSortOrderToggle={handleSortToggle("balance", "desc")}
       >
-        Price (USD)
+        My Balance
+      </HeaderCell>
+      <HeaderCell
+        sortOrder={getSortOrder("score")}
+        onSortOrderToggle={handleSortToggle("score", "desc")}
+      >
+        Score
+      </HeaderCell>
+      <HeaderCell
+        sortOrder={getSortOrder("stakedTao")}
+        onSortOrderToggle={handleSortToggle("stakedTao", "desc")}
+      >
+        Staked
       </HeaderCell>
       <HeaderCell
         sortOrder={getSortOrder("volume")}
@@ -167,71 +276,117 @@ const HeaderRow: FC<{
         Volume
       </HeaderCell>
       <HeaderCell
-        sortOrder={getSortOrder("netAlpha")}
-        onSortOrderToggle={handleSortToggle("netAlpha", "desc")}
+        sortOrder={getSortOrder("mcap")}
+        onSortOrderToggle={handleSortToggle("mcap", "desc")}
       >
-        24h Flow
+        MCap
       </HeaderCell>
       <HeaderCell
-        sortOrder={getSortOrder("score")}
-        onSortOrderToggle={handleSortToggle("score", "desc")}
+        sortOrder={getSortOrder("emission")}
+        onSortOrderToggle={handleSortToggle("emission", "desc")}
       >
-        Score
+        Emissions
       </HeaderCell>
+      <HeaderCell>Chart</HeaderCell>
     </div>
   )
 }
 
 const DataCell: FC<PropsWithChildren<{ className?: string }>> = ({ children, className }) => {
-  return <div className={cn("max-h-36 truncate", className)}>{children}</div>
-}
-
-// Flow direction badge component
-const FlowBadge: FC<{ netAlpha: number; flowDirection: string }> = ({
-  netAlpha,
-  flowDirection,
-}) => {
-  const isInflow = flowDirection === "inflow"
-  const isOutflow = flowDirection === "outflow"
-
   return (
-    <div
-      className={cn(
-        "inline-flex items-center gap-4 rounded-full px-8 py-2 font-medium text-xs",
-        isInflow && "bg-green/20 text-green",
-        isOutflow && "bg-red-500/20 text-red-500",
-        !isInflow && !isOutflow && "bg-grey-700 text-body-secondary"
-      )}
-    >
-      {isInflow && "↑"}
-      {isOutflow && "↓"}
-      {!isInflow && !isOutflow && "→"}
-      <span>
-        {netAlpha >= 0 ? "+" : ""}
-        {formatNumber(netAlpha, 1)}α
-      </span>
+    <div className={cn("flex flex-col items-start justify-center text-left", className)}>
+      {children}
     </div>
   )
 }
 
 const SubnetRow: FC<{ subnet: TaoDashboardSubnet }> = ({ subnet }) => {
+  // Compare last price to first price in 7d data to determine chart color
+  const firstPrice = subnet.chartData[0] ?? 0
+  const lastPrice = subnet.chartData[subnet.chartData.length - 1] ?? 0
+  const isChartPositive = lastPrice >= firstPrice
+  const sentiment =
+    subnet.sentiment === "bullish" || subnet.sentiment === "bearish" ? subnet.sentiment : null
+
   return (
     <Link
       to={`/bittensor/subnets/${subnet.netuid}`}
-      className="grid h-36 w-full grid-cols-[0.5fr,2fr,1fr,1fr,1fr,1fr,1fr] items-center gap-10 overflow-hidden bg-grey-850 px-10 text-left text-body hover:bg-grey-800"
+      className="grid h-44 w-full grid-cols-[minmax(120px,1.4fr),minmax(100px,1fr),minmax(100px,1fr),minmax(80px,0.7fr),minmax(90px,0.9fr),minmax(80px,0.8fr),minmax(70px,0.7fr),minmax(90px,0.8fr),minmax(70px,0.6fr)] items-center justify-items-start gap-4 bg-grey-900 px-8 text-left text-sm transition-colors hover:bg-grey-850"
     >
-      <DataCell>SN{subnet.netuid}</DataCell>
-      <DataCell className="flex items-center gap-6">
-        <TokenLogo tokenId={subnet.tokenId} className="size-20" />
-        <span className="font-bold">{subnet.name}</span>
+      {/* Subnet */}
+      <DataCell className="flex-row items-center gap-6">
+        <TokenLogo tokenId={subnet.tokenId} className="size-24 shrink-0" />
+        <div className="flex flex-col gap-0">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-white">{subnet.name}</span>
+            <span className="text-primary">{subnet.greekSymbol}</span>
+          </div>
+          <span className="text-body-secondary text-xs">SN{subnet.netuid}</span>
+        </div>
       </DataCell>
-      <DataCell>{formatTaoPrice(subnet.price)}τ</DataCell>
-      <DataCell>{formatUsdPrice(subnet.priceUsd)}</DataCell>
-      <DataCell>{formatNumber(subnet.volume, 0)}</DataCell>
+
+      {/* Price */}
       <DataCell>
-        <FlowBadge netAlpha={subnet.netAlpha} flowDirection={subnet.flowDirection} />
+        <div className="font-medium text-white">
+          {formatTaoPrice(subnet.price)} <span className="text-primary">τ</span>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-body-secondary">{formatUsdPrice(subnet.priceUsd)}</span>
+          <PriceChange change={subnet.priceChange} />
+        </div>
       </DataCell>
-      <DataCell>{formatNumber(subnet.score, 1)}</DataCell>
+
+      {/* My Balance */}
+      <DataCell>
+        {subnet.balance > 0 ? (
+          <>
+            <div className="text-green">
+              {formatBalance(subnet.balance)} {subnet.greekSymbol}
+            </div>
+            <div className="text-body-secondary text-xs">${formatBalance(subnet.balanceUsd)}</div>
+          </>
+        ) : (
+          <span className="text-body-secondary">0 {subnet.greekSymbol}</span>
+        )}
+      </DataCell>
+
+      {/* Score */}
+      <DataCell>
+        <div className="flex flex-wrap items-center">
+          <span className="font-medium text-white">{Math.round(subnet.score)}</span>
+          <SentimentBadge sentiment={sentiment} />
+        </div>
+      </DataCell>
+
+      {/* Staked */}
+      <DataCell>
+        <div className="text-white">
+          {formatNumber(subnet.stakedTao)} <span className="text-primary">τ</span>
+        </div>
+        <div className="text-body-secondary text-xs">
+          {formatNumber(subnet.stakedAlpha)} {subnet.greekSymbol}
+        </div>
+      </DataCell>
+
+      {/* Volume */}
+      <DataCell>
+        <span className="text-white">{formatTaoAmount(subnet.volume)}</span>
+      </DataCell>
+
+      {/* MCap */}
+      <DataCell>
+        <span className="text-white">{formatTaoAmount(subnet.mcap)}</span>
+      </DataCell>
+
+      {/* Emissions */}
+      <DataCell>
+        <span className="text-white">{subnet.emission.toFixed(2)}%</span>
+      </DataCell>
+
+      {/* Chart */}
+      <DataCell>
+        <SparklineChart data={subnet.chartData} isPositive={isChartPositive} />
+      </DataCell>
     </Link>
   )
 }

--- a/apps/extension/src/ui/domains/TaoDashboard/subnets/useTaoDashboardSubnets.ts
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnets/useTaoDashboardSubnets.ts
@@ -3,13 +3,90 @@ import { useTokens } from "@ui/state"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
-import { useSubnetEconomicsWithSentiment, useTaoPrice } from "../hooks/useSn45Api"
+import {
+  useSubnetEconomicsWithSentiment,
+  useSubnetLeaderboard,
+  useTaoPrice,
+} from "../hooks/useSn45Api"
 import { BITTENSOR_NETWORK_ID } from "./constants"
+
+type SubnetSentiment = "bullish" | "bearish" | null
+
+// Greek letter symbols for subnet tokens
+const SUBNET_SYMBOLS: Record<number, string> = {
+  1: "α",
+  2: "β",
+  3: "γ",
+  4: "δ",
+  5: "ε",
+  6: "ζ",
+  7: "η",
+  8: "θ",
+  9: "ι",
+  10: "κ",
+  11: "λ",
+  12: "μ",
+}
+
+// Placeholder data for user balance (needs wallet integration) and chart data
+const PLACEHOLDER_BALANCE: Record<
+  number,
+  {
+    balance: number
+    balanceUsd: number
+    sentiment: "bullish" | "bearish" | null
+    chartData: number[]
+  }
+> = {
+  1: {
+    balance: 12450,
+    balanceUsd: 5892,
+    sentiment: "bullish",
+    chartData: [60, 55, 50, 45, 50, 45, 40],
+  },
+  3: {
+    balance: 8200,
+    balanceUsd: 101598,
+    sentiment: null,
+    chartData: [40, 45, 50, 55, 60, 65, 70],
+  },
+  6: {
+    balance: 45000,
+    balanceUsd: 123750,
+    sentiment: null,
+    chartData: [40, 45, 50, 55, 50, 55, 60],
+  },
+  8: {
+    balance: 2100,
+    balanceUsd: 44226,
+    sentiment: "bearish",
+    chartData: [40, 45, 55, 60, 65, 70, 75],
+  },
+}
+
+// Default placeholder for balance/chart data
+const getPlaceholderBalance = (netuid: number) => {
+  return (
+    PLACEHOLDER_BALANCE[netuid] ?? {
+      balance: 0,
+      balanceUsd: 0,
+      sentiment: null,
+      chartData: Array.from({ length: 7 }, () => Math.random() * 100),
+    }
+  )
+}
+
+// Convert bigint string to number with decimals (values are in rao, 1e9)
+const parseRaoToNumber = (value: string | null | undefined): number => {
+  if (!value) return 0
+  return Number(BigInt(value)) / 1e9
+}
 
 export const useTaoDashboardSubnets = () => {
   const { t } = useTranslation()
   const allTokens = useTokens()
   const { data: economicsData, isLoading: _isEconomicsLoading } = useSubnetEconomicsWithSentiment()
+  const { data: leaderboardData, isLoading: _isLeaderboardLoading } = useSubnetLeaderboard("1d")
   const { data: taoPrice } = useTaoPrice()
 
   const subnetTokens = useMemo(() => {
@@ -27,32 +104,68 @@ export const useTaoDashboardSubnets = () => {
     return new Map(economicsData.map((e) => [e.netuid, e]))
   }, [economicsData])
 
+  // Index leaderboard by netuid
+  const leaderboardMap = useMemo(() => {
+    if (!leaderboardData?.subnets) return new Map()
+    return new Map(leaderboardData.subnets.map((s) => [s.netuid, s]))
+  }, [leaderboardData])
+
   const taoUsdPrice = taoPrice?.price ? parseFloat(taoPrice.price) : 0
 
   const subnets = useMemo(() => {
     return subnetTokens
       .map((token) => {
         const economics = economicsMap.get(token.netuid)
-        const priceInTao = economics?.price ?? 0
+        const leaderboard = leaderboardMap.get(token.netuid)
+        const placeholder = getPlaceholderBalance(token.netuid)
+
+        // Use leaderboard price if available, fallback to economics
+        const priceInTao = leaderboard?.currentPrice ?? economics?.price ?? 0
         const priceUsd = priceInTao * taoUsdPrice
+
+        // Use leaderboard data for price change, staked, mcap, volume
+        const priceChange = leaderboard?.priceChange ?? 0
+        const stakedAlpha = parseRaoToNumber(leaderboard?.stakedAlpha)
+        // mcap and volume from API are in TAO (rao units)
+        const mcap = parseRaoToNumber(leaderboard?.mcap)
+        const volume = leaderboard ? parseRaoToNumber(leaderboard.volume) : (economics?.volume ?? 0)
+
+        // Use emissionPct and score directly from the API
+        const emission = leaderboard?.emissionPct ?? 0
+        const score = leaderboard?.score ?? 0
+
+        // Determine sentiment based on score
+        const sentiment: SubnetSentiment = score >= 80 ? "bullish" : score <= 20 ? "bearish" : null
 
         return {
           tokenId: token.id,
           netuid: token.netuid,
           name: token.subnetName ?? t("Subnet {{netuid}}", { netuid: token.netuid }),
           symbol: token.symbol,
+          greekSymbol: SUBNET_SYMBOLS[token.netuid] ?? token.symbol,
           logo: token.logo,
           price: priceInTao,
           priceUsd,
-          score: economics?.economicScore ?? 0,
-          volume: economics?.volume ?? 0,
+          priceChange,
+          score,
+          sentiment,
+          volume,
           netAlpha: economics?.netAlpha ?? 0,
           flowDirection: economics?.flowDirection ?? ("neutral" as const),
           sentimentScore: economics?.sentimentScore ?? 0,
+          // Balance from placeholder (needs wallet integration)
+          balance: placeholder.balance,
+          balanceUsd: placeholder.balanceUsd,
+          // Real data from leaderboard
+          stakedTao: stakedAlpha * priceInTao, // Convert alpha to TAO equivalent
+          stakedAlpha,
+          mcap,
+          emission,
+          chartData: leaderboard?.priceHistory7d ?? placeholder.chartData,
         }
       })
       .sort((a, b) => a.netuid - b.netuid)
-  }, [subnetTokens, economicsMap, taoUsdPrice, t])
+  }, [subnetTokens, economicsMap, leaderboardMap, taoUsdPrice, t])
 
   return subnets
 }
@@ -61,6 +174,7 @@ export type TaoDashboardSubnet = ReturnType<typeof useTaoDashboardSubnets>[numbe
 
 // Hook for loading state
 export const useTaoDashboardSubnetsLoading = () => {
-  const { isLoading } = useSubnetEconomicsWithSentiment()
-  return isLoading
+  const { isLoading: economicsLoading } = useSubnetEconomicsWithSentiment()
+  const { isLoading: leaderboardLoading } = useSubnetLeaderboard("1d")
+  return economicsLoading || leaderboardLoading
 }

--- a/packages/extension-core/src/domains/bittensor/sn45/Sn45Api.ts
+++ b/packages/extension-core/src/domains/bittensor/sn45/Sn45Api.ts
@@ -354,6 +354,59 @@ export class Sn45Api<SecurityDataType> extends HttpClient<SecurityDataType> {
      * No description
      *
      * @tags Subnets
+     * @name GetSubnetLeaderboard
+     * @summary Subnet leaderboard with aggregated metrics
+     * @request GET:/v1/bittensor/subnets/leaderboard
+     */
+    getSubnetLeaderboard: (
+      query?: {
+        period?: "1d" | "1w" | "1m"
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<
+        {
+          period: "1d" | "1w" | "1m"
+          updatedAt: string
+          subnets: {
+            netuid: number
+            currentPrice: number | null
+            priceChange: number | null
+            stakedTao: string | null
+            stakedAlpha: string | null
+            volume: string
+            txCount: number
+            buyCount: number
+            sellCount: number
+            mcap: string | null
+            alphaOutEmission: string | null
+            alphaInEmission: string | null
+            taoInEmission: string | null
+            totalHolders: number
+            emaTaoFlow: string | null
+            emissionPct: number | null
+            priceHistory7d: number[] | null
+            score: number | null
+          }[]
+        },
+        {
+          error: {
+            code: string
+            message: string
+          }
+        }
+      >({
+        path: `/v1/bittensor/subnets/leaderboard`,
+        method: "GET",
+        query: query,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Subnets
      * @name GetSubnetStakeEvents
      * @summary Stake events for a specific subnet
      * @request GET:/v1/bittensor/subnets/{netuid}/stake-events

--- a/packages/extension-core/src/domains/bittensor/sn45/Sn45Api.ts
+++ b/packages/extension-core/src/domains/bittensor/sn45/Sn45Api.ts
@@ -262,6 +262,13 @@ export class Sn45Api<SecurityDataType> extends HttpClient<SecurityDataType> {
         {
           price: string | null
           timestamp: string | null
+          marketCap: number | null
+          volume24h: number | null
+          priceChange24h: number | null
+          priceChange7d: number | null
+          priceChange30d: number | null
+          marketCapChange24h: number | null
+          source: string | null
         },
         {
           error: {


### PR DESCRIPTION
## Summary

- Integrated the new **SN45 API leaderboard endpoint** into the Tao Dashboard.
- Added market statistics (market cap, volume, TAO price) to the dashboard header.
- Updated the subnets table to use real-time leaderboard data.

## Changes

### Dashboard Header

Added a market stats section displaying:

- **Total Market Cap** with 24h change indicator  
- **24h Trading Volume** (aggregated from all subnets)  
- **TAO Price** with 24h change indicator  

Additional improvements:

- Green/red indicators to reflect positive or negative changes  
- Improved layout with a vertical divider separating balance from stats  

### Subnets Leaderboard Table

- Now powered by the new leaderboard endpoint for real-time data  
- Displays:
  - Price and price change  
  - Staked amounts  
  - Volume  
  - Market cap  
  - Emissions  
- Added 7-day sparkline charts derived from price history data  

### New Hook

- Added `useSubnetLeaderboard` hook for fetching leaderboard data with a configurable period
