### PR TITLE
test: change passethub settings

### DIFF
--- a/playwright/e2e-tests/transfers.ts
+++ b/playwright/e2e-tests/transfers.ts
@@ -10,11 +10,11 @@ export const testAssets = [
   },
   {
     assetName: "PAS",
-    chain: "Paseo PassetHub",
+    chain: "PAsset Hub",
     needsEnabling: true,
-    chainType: "ethereum",
+    chainType: "polkadot",
     tokenType: "Native",
-    sendTo: "0x899F2F48D76771b1876165E5B4df1ad13021eb6d",
+    sendTo: "5DHyKJK9qY5nosXAvyGiSRTdnC76Z45RcuAMq5223T1Vrtbc",
     amount: "0.001",
   },
   {


### PR DESCRIPTION
Since the last chaindata change and some changes on Paseo testnet, passet hub is now part of Paseo Asset Hub. This PR changes the tesnet network/token used in the testnet transfer e2e test.