### PR TITLE
feat: added defi terms popup (after typing in amount)

### DIFF
--- a/apps/extension/src/ui/domains/Earn/yieldxyz/enter/steps/EarnDisclaimerDrawer.tsx
+++ b/apps/extension/src/ui/domains/Earn/yieldxyz/enter/steps/EarnDisclaimerDrawer.tsx
@@ -1,0 +1,59 @@
+import { useAppState } from "@ui/state"
+import { TERMS_OF_USE_URL } from "extension-shared"
+import type { FC, PropsWithChildren } from "react"
+import { Trans, useTranslation } from "react-i18next"
+import { Button, Drawer } from "talisman-ui"
+
+type EarnDisclaimerDrawerProps = {
+  isOpen: boolean
+  onAccept: () => void
+  onCancel: () => void
+}
+
+export const EarnDisclaimerDrawer: FC<EarnDisclaimerDrawerProps> = ({
+  isOpen,
+  onAccept,
+  onCancel,
+}) => {
+  const { t } = useTranslation()
+  const [, setHideDisclaimer] = useAppState("hideEarnDisclaimer")
+
+  return (
+    <Drawer anchor="bottom" isOpen={isOpen} containerId="earn-modal">
+      <div className="flex w-full flex-col items-center gap-8 rounded-t-xl bg-grey-850 p-12">
+        <div className="font-bold text-body">{t("Position Confirmation")}</div>
+        <p className="text-body-secondary text-sm">
+          <Trans
+            t={t}
+            defaults="You're about to open your first DeFi position with Talisman. All required information has been provided. Please accept the <Link>terms and conditions</Link>."
+            components={{
+              Link: <TermsLink />,
+            }}
+          />
+        </p>
+        <div className="grid w-full grid-cols-2 gap-8">
+          <Button onClick={onCancel}>{t("Cancel")}</Button>
+          <Button
+            primary
+            onClick={() => {
+              setHideDisclaimer(true)
+              onAccept()
+            }}
+          >
+            {t("Accept")}
+          </Button>
+        </div>
+      </div>
+    </Drawer>
+  )
+}
+
+const TermsLink: FC<PropsWithChildren> = ({ children }) => (
+  <button
+    type="button"
+    className="inline text-white underline"
+    onClick={() => window.open(TERMS_OF_USE_URL, "_blank", "noopener noreferrer")}
+  >
+    {children}
+  </button>
+)

--- a/apps/extension/src/ui/domains/Earn/yieldxyz/enter/steps/YieldxyzEnterStepAmount.tsx
+++ b/apps/extension/src/ui/domains/Earn/yieldxyz/enter/steps/YieldxyzEnterStepAmount.tsx
@@ -6,17 +6,19 @@ import { YieldxyzProviderDisplay } from "@ui/domains/Earn/yieldxyz/components/Yi
 import { NetworkLogo } from "@ui/domains/Networks/NetworkLogo"
 import { NetworkName } from "@ui/domains/Networks/NetworkName"
 import { useDateFnsLocale } from "@ui/hooks/useDateFnsLocale"
+import { useAppState } from "@ui/state"
 import { formatDuration, intervalToDuration } from "date-fns"
 import type { TimePeriodDto } from "extension-core"
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Button, WizardModalDialog } from "talisman-ui"
+import { Button, useOpenClose, WizardModalDialog } from "talisman-ui"
 
 import { FormFieldSet, FormFieldSetRow } from "../../../shared/FormFieldSet"
 import { YieldxyzProductTitleDisplay } from "../../components/YieldxyzProductTitleDisplay"
 import { YieldxyzProductYieldDisplay } from "../../components/YieldxyzProductYieldDisplay"
 import { useYieldxyzEnterModal } from "../useYieldxyzEnterModal"
 import { useYieldxyzEnterWizard } from "../useYieldxyzEnterWizard"
+import { EarnDisclaimerDrawer } from "./EarnDisclaimerDrawer"
 
 export const YieldxyzEnterStepAmount = () => {
   const { t } = useTranslation()
@@ -24,8 +26,11 @@ export const YieldxyzEnterStepAmount = () => {
   const { address, goTo, canCreateAction, createAction, product } = useYieldxyzEnterWizard()
 
   const [processing, setProcessing] = useState(false)
+  const [hideDisclaimer] = useAppState("hideEarnDisclaimer")
+  const [hasAckDisclaimer, setHasAckDisclaimer] = useState(hideDisclaimer || false)
+  const disclaimerDrawer = useOpenClose()
 
-  const handleSubmit = async () => {
+  const proceedToReview = useCallback(async () => {
     setProcessing(true)
     try {
       await createAction()
@@ -33,6 +38,14 @@ export const YieldxyzEnterStepAmount = () => {
     } finally {
       setProcessing(false)
     }
+  }, [createAction, goTo])
+
+  const handleSubmit = async () => {
+    if (!hasAckDisclaimer) {
+      disclaimerDrawer.open()
+      return
+    }
+    await proceedToReview()
   }
 
   if (!product) return null
@@ -105,6 +118,15 @@ export const YieldxyzEnterStepAmount = () => {
           {t("Review")}
         </Button>
       </div>
+      <EarnDisclaimerDrawer
+        isOpen={disclaimerDrawer.isOpen}
+        onAccept={() => {
+          setHasAckDisclaimer(true)
+          disclaimerDrawer.close()
+          proceedToReview()
+        }}
+        onCancel={disclaimerDrawer.close}
+      />
     </WizardModalDialog>
   )
 }

--- a/packages/extension-core/src/domains/app/store.app.ts
+++ b/packages/extension-core/src/domains/app/store.app.ts
@@ -40,6 +40,9 @@ export type AppStoreData = {
   hideBittensorSubnetStakeWarning?: boolean
   hideGetStarted?: boolean
 
+  // dismissed earn disclaimer
+  hideEarnDisclaimer?: boolean
+
   // dismissed banners
   hideUnifiedAddressBanner?: boolean
   hideAutonomysQuestBanner?: boolean
@@ -123,6 +126,7 @@ if (DEBUG) {
       hideManageAccountsWelcome: false,
       hideBittensorSubnetStakeWarning: false,
       hideGetStarted: false,
+      hideEarnDisclaimer: false,
       hideUnifiedAddressBanner: false,
       hideAutonomysQuestBanner: false,
       hideSeekBenefitsBanner: false,


### PR DESCRIPTION
First time user goes to 'Earn' page and adds position, they'll receive a pop-up to let them know to read terms and conditions etc.

https://github.com/user-attachments/assets/930a05fe-83ea-4f65-88f1-b78bb6e8f59b

