### PR TITLE
feat: added SS58 search into wallet and settings page

### DIFF
--- a/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAccounts.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Portfolio/PortfolioAccounts.tsx
@@ -2,6 +2,7 @@ import { isEthereumAddress } from "@polkadot/util-crypto"
 import { bind } from "@react-rxjs/core"
 import { SearchInput } from "@talisman/components/SearchInput"
 import { SuspenseTracker } from "@talisman/components/SuspenseTracker"
+import { isSs58Address, normalizeAddress } from "@talismn/crypto"
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -378,10 +379,23 @@ export const PortfolioAccounts = () => {
             ? accounts.find((account) => account.address === item.address)
             : undefined
 
-        const getSearchContent = (account?: Account) =>
-          [account?.name, account?.address, account?.type?.replaceAll(/talisman/gi, "")]
+        const getSearchContent = (account?: Account) => {
+          const normalizedAddress = (() => {
+            try {
+              return account?.address ? normalizeAddress(account.address) : undefined
+            } catch {
+              return undefined
+            }
+          })()
+          return [
+            account?.name,
+            account?.address,
+            normalizedAddress,
+            account?.type?.replaceAll(/talisman/gi, ""),
+          ]
             .join(" ")
             .toLowerCase()
+        }
 
         return item.type === "account"
           ? {
@@ -421,7 +435,18 @@ export const PortfolioAccounts = () => {
     ]
   }, [folder, treeName, catalog.portfolio, catalog.watched, accounts, t, balanceTotals])
 
-  const ls = useMemo(() => search.toLowerCase(), [search])
+  const ls = useMemo(() => {
+    const lower = search.toLowerCase()
+    // if full search input is a valid SS58 address, normalize it for comparison
+    if (search && isSs58Address(search)) {
+      try {
+        return normalizeAddress(search).toLowerCase()
+      } catch {
+        return lower
+      }
+    }
+    return lower
+  }, [search])
 
   const searchFilter = useCallback(
     (option: AccountOption): boolean => {

--- a/apps/extension/src/ui/domains/Account/ManageAccounts/ManageAccountsLists.tsx
+++ b/apps/extension/src/ui/domains/Account/ManageAccounts/ManageAccountsLists.tsx
@@ -1,3 +1,4 @@
+import { isSs58Address, normalizeAddress } from "@talismn/crypto"
 import { EyeIcon, TalismanHandIcon } from "@talismn/icons"
 import { classNames } from "@talismn/util"
 import { usePortfolioAccounts } from "@ui/hooks/usePortfolioAccounts"
@@ -29,7 +30,15 @@ export const ManageAccountsLists: FC<{ className?: string }> = ({ className }) =
   )
 
   const [portfolioTree, watchedTree] = useMemo(() => {
-    const lowerSearch = search.toLowerCase()
+    // if full search input is a valid SS58 address, normalize it for comparison
+    let lowerSearch = search.toLowerCase()
+    if (search && isSs58Address(search)) {
+      try {
+        lowerSearch = normalizeAddress(search).toLowerCase()
+      } catch {
+        // keep original lowerSearch
+      }
+    }
     return [
       searchTree(portfolioUiTree, lowerSearch, accountsMap),
       searchTree(watchedUiTree, lowerSearch, accountsMap),
@@ -70,9 +79,17 @@ const searchTree = (
 
   const setAccountVisibility = (item: UiTreeAccount) => {
     const account = accountsMap[item.address] as Account | undefined // may be undefined for a moment right after deletion
+    const normalizedAddress = (() => {
+      try {
+        return account?.address ? normalizeAddress(account.address).toLowerCase() : undefined
+      } catch {
+        return undefined
+      }
+    })()
     item.isVisible =
-      account?.name?.toLowerCase().includes(lowerSearch) ??
-      account?.address?.toLowerCase().includes(lowerSearch) ??
+      account?.name?.toLowerCase().includes(lowerSearch) ||
+      account?.address?.toLowerCase().includes(lowerSearch) ||
+      normalizedAddress?.includes(lowerSearch) ||
       false
   }
 


### PR DESCRIPTION
Added SS58 searching capabilities to PortfolioAccounts.tsx and ManageAccountsList.tsx.

Does partial string search if address is incomplete, but if address is filled out, it normalizes it and compares.

For example, for one of our test accounts, Talisman wallet stores as `5CcU6DRpocLUWYJHuNLjB4gGyHJrkWuruQD5XFbRYffCfSAP` (prefix 42). Now, you can search for it with `5CcU6DRpocL` (partial search or the entire address `5CcU6DRpocLUWYJHuNLjB4gGyHJrkWuruQD5XFbRYffCfSAP`). Or you can search for it with the complete address with a different prefix i.e. `1YmEYgtfPbwx5Jos1PjKDWRpuJWSpTzytwZgYan6kgiquNS` (polkadot format, prefix-0).
<img width="1312" height="935" alt="Screenshot 2026-02-19 at 4 26 55 PM" src="https://github.com/user-attachments/assets/ae1a0d07-ff55-4e06-ab27-b2f26ca6316c" />
<img width="386" height="590" alt="Screenshot 2026-02-19 at 4 26 39 PM" src="https://github.com/user-attachments/assets/3a41a086-0acc-4fa0-9d72-58f48e266245" />

