### PR TITLE
feat: improve paraverse protector

### DIFF
--- a/packages/extension-core/package.json
+++ b/packages/extension-core/package.json
@@ -59,7 +59,6 @@
     "extension-shared": "workspace:*",
     "i18next": "^25.5.2",
     "lodash-es": "4.17.21",
-    "lz-string": "^1.5.0",
     "p-queue": "8.1.0",
     "pako": "^2.1.0",
     "rxjs": "^7.8.1",

--- a/packages/extension-core/src/db/blobs.ts
+++ b/packages/extension-core/src/db/blobs.ts
@@ -14,6 +14,8 @@ export type DbBlobId =
   | "yieldxyz-providers"
   | "dynamic-tokens"
   | "bittensor-validators"
+  | "phishing-metamask"
+  | "phishing-polkadot"
 
 export type DbBlobItem = { id: DbBlobId; data: Uint8Array }
 

--- a/packages/extension-core/src/db/db.ts
+++ b/packages/extension-core/src/db/db.ts
@@ -1,9 +1,5 @@
 import { Dexie } from "dexie"
 
-import type {
-  ProtectorSources,
-  ProtectorStorage,
-} from "../domains/app/protector/ParaverseProtector"
 import type { DiscoveredBalance } from "../domains/assetDiscovery/types"
 import type { TalismanMetadataDef } from "../domains/substrate/types"
 import type { LegacyWalletTransaction, WalletTransaction } from "../domains/transactions/types"
@@ -15,7 +11,6 @@ export const MIGRATION_ERROR_MSG = "Talisman Dexie Migration Error"
 class TalismanDatabase extends Dexie {
   assetDiscovery!: Dexie.Table<DiscoveredBalance, string>
   metadata!: Dexie.Table<TalismanMetadataDef, string>
-  phishing!: Dexie.Table<ProtectorStorage, ProtectorSources>
   transactions!: Dexie.Table<LegacyWalletTransaction, string>
   transactionsV2!: Dexie.Table<WalletTransaction, string>
   blobs!: Dexie.Table<DbBlobItem, DbBlobId>
@@ -55,6 +50,11 @@ class TalismanDatabase extends Dexie {
       // migration is handled by the MigrationRunner, to ensure it's executed after other migrations
       transactionsV2: "id, status, timestamp",
       tokenRates: null,
+    })
+
+    // v12: migrate phishing data from dedicated table to compressed blob store
+    this.version(12).stores({
+      phishing: null,
     })
   }
 }

--- a/packages/extension-core/src/domains/app/handler.ts
+++ b/packages/extension-core/src/domains/app/handler.ts
@@ -11,7 +11,7 @@ import type { MessageTypes, RequestTypes, ResponseType } from "../../types"
 import type { Port } from "../../types/base"
 import { authenticateLegacyMethod } from "../accounts/legacy"
 import { keyringStore } from "../keyring/store"
-import { protector } from "./protector"
+import { addException } from "./protector"
 import type { PasswordStoreData } from "./store.password"
 import type {
   AnalyticsCaptureRequest,
@@ -296,9 +296,7 @@ export default class AppHandler extends ExtensionHandler {
       }
 
       case "pri(app.phishing.addException)": {
-        return protector.addException(
-          (request as RequestTypes["pri(app.phishing.addException)"]).url
-        )
+        return addException((request as RequestTypes["pri(app.phishing.addException)"]).url)
       }
 
       case "pri(app.resetWallet)":

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
@@ -1,21 +1,37 @@
-import { afterAll, expect, it, vi } from "vitest"
+import { afterAll, beforeAll, expect, it, vi } from "vitest"
 
 import { db } from "../../../db"
 import ParaverseProtector from "./ParaverseProtector"
 
-const mockGetCommitSha = vi.fn(async () => "newCommit")
-const mockGetPolkadotData = vi.fn(async () => ({
-  deny: ["badsite.com", "an.other-badsite.io"],
-  allow: ["goodsite.com", "polkadot.js.org"],
-}))
-const mockGetMetamaskData = vi.fn(() => require("eth-phishing-detect/src/config.json"))
+const mockMetamaskConfig = require("eth-phishing-detect/src/config.json")
 
-vi.spyOn(ParaverseProtector.prototype, "getCommitSha").mockImplementation(mockGetCommitSha)
-vi.spyOn(ParaverseProtector.prototype, "getPolkadotData").mockImplementation(mockGetPolkadotData)
-vi.spyOn(ParaverseProtector.prototype, "getMetamaskData").mockImplementation(mockGetMetamaskData)
+const mockFetchWithEtag = vi.fn(async (url: string) => {
+  if (url.includes("MetaMask")) {
+    return { data: mockMetamaskConfig, etag: "mm-etag-1" }
+  }
+  if (url.includes("polkadot")) {
+    return {
+      data: {
+        deny: ["badsite.com", "an.other-badsite.io"],
+        allow: ["goodsite.com", "polkadot.js.org"],
+      },
+      etag: "pd-etag-1",
+    }
+  }
+  return null
+})
+
+vi.spyOn(ParaverseProtector.prototype, "fetchWithEtag").mockImplementation(mockFetchWithEtag)
 const protector = new ParaverseProtector()
 // mock fire the ready event on the database
 db.on.ready.fire(db)
+
+// Explicitly trigger a refresh so both lists are loaded before assertions.
+// In production this happens 30 s after construction via setTimeout.
+beforeAll(async () => {
+  await protector.isInitialised()
+  await protector.setRefreshTimer()
+})
 
 it("Checks phishing sites", async () => {
   // in allow lists
@@ -26,13 +42,13 @@ it("Checks phishing sites", async () => {
   // not listed at all
   expect(await protector.isPhishingSite("https://something.else")).toBeFalsy()
   // in deny list
-  expect(await protector.isPhishingSite("https://badsite.com"))
-  expect(await protector.isPhishingSite("ws://badsite.com"))
-  expect(await protector.isPhishingSite("https://an.other-badsite.io"))
+  expect(await protector.isPhishingSite("https://badsite.com")).toBeTruthy()
+  expect(await protector.isPhishingSite("ws://badsite.com")).toBeTruthy()
+  expect(await protector.isPhishingSite("https://an.other-badsite.io")).toBeTruthy()
   // unlisted subdomain of domain with another subdomain in deny list
   expect(await protector.isPhishingSite("https://safe.other-badsite.io")).toBeFalsy()
   // unlisted subdomain of domain in deny list
-  expect(await protector.isPhishingSite("https://not-in-list.badsite.io"))
+  expect(await protector.isPhishingSite("https://not-in-list.badsite.com")).toBeTruthy()
 
   // not a url
   expect(await protector.isPhishingSite("some garbage")).toBeFalsy()
@@ -40,9 +56,40 @@ it("Checks phishing sites", async () => {
 
 it("Can add an exception to phishing sites", async () => {
   const badsite = "https://badsite.com"
-  expect(await protector.isPhishingSite(badsite))
+  expect(await protector.isPhishingSite(badsite)).toBeTruthy()
   protector.addException(badsite)
   expect(await protector.isPhishingSite(badsite)).toBeFalsy()
+})
+
+it("Skips update when fetchWithEtag returns null (304)", async () => {
+  mockFetchWithEtag.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+  // Should not throw, and lists should remain unchanged
+  await protector.setRefreshTimer()
+  expect(await protector.isPhishingSite("https://badsite.com")).toBeFalsy() // was excepted above
+})
+
+it("Rejects invalid MetaMask config gracefully", async () => {
+  mockFetchWithEtag.mockImplementation(async (url: string) => {
+    if (url.includes("MetaMask")) {
+      return { data: { broken: true }, etag: "bad-etag" }
+    }
+    return null
+  })
+  // Should not throw — invalid data is logged and skipped
+  await protector.refreshMetamaskList()
+  // Protector should still work with previous data
+  expect(await protector.isPhishingSite("https://something.else")).toBeFalsy()
+})
+
+it("Rejects invalid Polkadot list gracefully", async () => {
+  mockFetchWithEtag.mockImplementation(async (url: string) => {
+    if (url.includes("polkadot")) {
+      return { data: "not-an-object", etag: "bad-etag" }
+    }
+    return null
+  })
+  await protector.refreshPolkadotList()
+  expect(await protector.isPhishingSite("https://something.else")).toBeFalsy()
 })
 
 afterAll(() => {

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
@@ -44,14 +44,10 @@ function setDefaultFetchResponses() {
 
 setDefaultFetchResponses()
 
-import { db } from "../../../db"
 import { addException, isPhishingSite, refreshPhishingLists } from "./ParaverseProtector"
 
-// mock fire the ready event on the database
-db.on.ready.fire(db)
-
 // Explicitly trigger a refresh so both lists are loaded before assertions.
-// In production this happens 30 s after module load via timer().
+// In production this happens 30 s after module load via setTimeout.
 beforeAll(async () => {
   await refreshPhishingLists()
 })

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
@@ -82,11 +82,8 @@ it("Skips update when fetchWithEtag returns null (304)", async () => {
 })
 
 it("Rejects invalid MetaMask config gracefully", async () => {
-  mockFetchWithEtag.mockImplementation(async (url: string) => {
-    if (url.includes("MetaMask")) {
-      return { data: { broken: true }, etag: "bad-etag" }
-    }
-    return null
+  mockFetchWithEtag.mockImplementationOnce(async () => {
+    return { data: { broken: true }, etag: "bad-etag" }
   })
   // Should not throw — invalid data is logged and skipped
   await protector.refreshMetamaskList()
@@ -95,11 +92,8 @@ it("Rejects invalid MetaMask config gracefully", async () => {
 })
 
 it("Rejects invalid Polkadot list gracefully", async () => {
-  mockFetchWithEtag.mockImplementation(async (url: string) => {
-    if (url.includes("polkadot")) {
-      return { data: "not-an-object", etag: "bad-etag" }
-    }
-    return null
+  mockFetchWithEtag.mockImplementationOnce(async () => {
+    return { data: "not-an-object", etag: "bad-etag" }
   })
   await protector.refreshPolkadotList()
   expect(await protector.isPhishingSite("https://something.else")).toBeFalsy()

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
@@ -1,11 +1,8 @@
-import { afterAll, beforeAll, expect, it, vi } from "vitest"
-
-import { db } from "../../../db"
-import ParaverseProtector from "./ParaverseProtector"
+import { afterAll, afterEach, beforeAll, expect, it, vi } from "vitest"
 
 const mockMetamaskConfig = require("eth-phishing-detect/src/config.json")
 
-// Mock the blob store so no real IndexedDB is needed
+// Mock the blob store so no real IndexedDB is needed (hoisted before imports)
 vi.mock("../../../db/blobs", () => {
   const stores = new Map<string, unknown>()
   return {
@@ -18,87 +15,118 @@ vi.mock("../../../db/blobs", () => {
   }
 })
 
-const mockFetchWithEtag = vi.fn(async (url: string) => {
-  if (url.includes("MetaMask")) {
-    return { data: mockMetamaskConfig, etag: "mm-etag-1" }
-  }
-  if (url.includes("polkadot")) {
-    return {
-      data: {
-        deny: ["badsite.com", "an.other-badsite.io"],
-        allow: ["goodsite.com", "polkadot.js.org"],
-      },
-      etag: "pd-etag-1",
-    }
-  }
-  return null
-})
+// Mock fetch globally
+const mockFetch = vi.fn<typeof fetch>()
+vi.stubGlobal("fetch", mockFetch)
 
-vi.spyOn(ParaverseProtector.prototype, "fetchWithEtag").mockImplementation(mockFetchWithEtag)
-const protector = new ParaverseProtector()
+function setDefaultFetchResponses() {
+  mockFetch.mockImplementation(async (input) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    if (url.includes("MetaMask")) {
+      return new Response(JSON.stringify(mockMetamaskConfig), {
+        status: 200,
+        headers: { etag: "mm-etag-1" },
+      })
+    }
+    if (url.includes("polkadot")) {
+      return new Response(
+        JSON.stringify({
+          deny: ["badsite.com", "an.other-badsite.io"],
+          allow: ["goodsite.com", "polkadot.js.org"],
+        }),
+        { status: 200, headers: { etag: "pd-etag-1" } }
+      )
+    }
+    return new Response("", { status: 404 })
+  })
+}
+
+setDefaultFetchResponses()
+
+import { db } from "../../../db"
+import { addException, isPhishingSite, refreshPhishingLists } from "./ParaverseProtector"
+
 // mock fire the ready event on the database
 db.on.ready.fire(db)
 
 // Explicitly trigger a refresh so both lists are loaded before assertions.
-// In production this happens 30 s after construction via setTimeout.
+// In production this happens 30 s after module load via timer().
 beforeAll(async () => {
-  await protector.isInitialised()
-  await protector.setRefreshTimer()
+  await refreshPhishingLists()
+})
+
+afterEach(() => {
+  setDefaultFetchResponses()
 })
 
 it("Checks phishing sites", async () => {
   // in allow lists
-  expect(await protector.isPhishingSite("https://www.goodsite.com")).toBeFalsy()
-  expect(await protector.isPhishingSite("https://app.talisman.xyz")).toBeFalsy()
+  expect(await isPhishingSite("https://www.goodsite.com")).toBeFalsy()
+  expect(await isPhishingSite("https://app.talisman.xyz")).toBeFalsy()
   // unlisted subdomain of domain in allow list
-  expect(await protector.isPhishingSite("https://fake.talisman.xyz")).toBeFalsy()
+  expect(await isPhishingSite("https://fake.talisman.xyz")).toBeFalsy()
   // not listed at all
-  expect(await protector.isPhishingSite("https://something.else")).toBeFalsy()
+  expect(await isPhishingSite("https://something.else")).toBeFalsy()
   // in deny list
-  expect(await protector.isPhishingSite("https://badsite.com")).toBeTruthy()
-  expect(await protector.isPhishingSite("ws://badsite.com")).toBeTruthy()
-  expect(await protector.isPhishingSite("https://an.other-badsite.io")).toBeTruthy()
+  expect(await isPhishingSite("https://badsite.com")).toBeTruthy()
+  expect(await isPhishingSite("ws://badsite.com")).toBeTruthy()
+  expect(await isPhishingSite("https://an.other-badsite.io")).toBeTruthy()
   // unlisted subdomain of domain with another subdomain in deny list
-  expect(await protector.isPhishingSite("https://safe.other-badsite.io")).toBeFalsy()
+  expect(await isPhishingSite("https://safe.other-badsite.io")).toBeFalsy()
   // unlisted subdomain of domain in deny list
-  expect(await protector.isPhishingSite("https://not-in-list.badsite.com")).toBeTruthy()
+  expect(await isPhishingSite("https://not-in-list.badsite.com")).toBeTruthy()
 
   // not a url
-  expect(await protector.isPhishingSite("some garbage")).toBeFalsy()
+  expect(await isPhishingSite("some garbage")).toBeFalsy()
 })
 
 it("Can add an exception to phishing sites", async () => {
   const badsite = "https://badsite.com"
-  expect(await protector.isPhishingSite(badsite)).toBeTruthy()
-  protector.addException(badsite)
-  expect(await protector.isPhishingSite(badsite)).toBeFalsy()
+  expect(await isPhishingSite(badsite)).toBeTruthy()
+  addException(badsite)
+  expect(await isPhishingSite(badsite)).toBeFalsy()
 })
 
-it("Skips update when fetchWithEtag returns null (304)", async () => {
-  mockFetchWithEtag.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
-  // Should not throw, and lists should remain unchanged
-  await protector.setRefreshTimer()
-  expect(await protector.isPhishingSite("https://badsite.com")).toBeFalsy() // was excepted above
+it("Skips update when fetch returns 304", async () => {
+  mockFetch.mockResolvedValue(new Response(null, { status: 304 }))
+  await refreshPhishingLists()
+  // badsite.com was excepted above — should remain so
+  expect(await isPhishingSite("https://badsite.com")).toBeFalsy()
 })
 
 it("Rejects invalid MetaMask config gracefully", async () => {
-  mockFetchWithEtag.mockImplementationOnce(async () => {
-    return { data: { broken: true }, etag: "bad-etag" }
+  mockFetch.mockImplementation(async (input) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    if (url.includes("MetaMask")) {
+      return new Response(JSON.stringify({ broken: true }), {
+        status: 200,
+        headers: { etag: "bad-etag" },
+      })
+    }
+    return new Response(null, { status: 304 })
   })
-  // Should not throw — invalid data is logged and skipped
-  await protector.refreshMetamaskList()
-  // Protector should still work with previous data
-  expect(await protector.isPhishingSite("https://something.else")).toBeFalsy()
+  await refreshPhishingLists()
+  expect(await isPhishingSite("https://something.else")).toBeFalsy()
 })
 
 it("Rejects invalid Polkadot list gracefully", async () => {
-  mockFetchWithEtag.mockImplementationOnce(async () => {
-    return { data: "not-an-object", etag: "bad-etag" }
+  mockFetch.mockImplementation(async (input) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    if (url.includes("polkadot")) {
+      return new Response(JSON.stringify("not-an-object"), {
+        status: 200,
+        headers: { etag: "bad-etag" },
+      })
+    }
+    return new Response(null, { status: 304 })
   })
-  await protector.refreshPolkadotList()
-  expect(await protector.isPhishingSite("https://something.else")).toBeFalsy()
+  await refreshPhishingLists()
+  expect(await isPhishingSite("https://something.else")).toBeFalsy()
 })
 
 afterAll(() => {
-  vi.clearAllMocks()
+  vi.restoreAllMocks()
 })

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
@@ -5,6 +5,19 @@ import ParaverseProtector from "./ParaverseProtector"
 
 const mockMetamaskConfig = require("eth-phishing-detect/src/config.json")
 
+// Mock the blob store so no real IndexedDB is needed
+vi.mock("../../../db/blobs", () => {
+  const stores = new Map<string, unknown>()
+  return {
+    getBlobStore: vi.fn((id: string) => ({
+      set: vi.fn(async (data: unknown) => {
+        stores.set(id, data)
+      }),
+      get: vi.fn(async () => stores.get(id) ?? null),
+    })),
+  }
+})
+
 const mockFetchWithEtag = vi.fn(async (url: string) => {
   if (url.includes("MetaMask")) {
     return { data: mockMetamaskConfig, etag: "mm-etag-1" }

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.spec.ts
@@ -44,10 +44,10 @@ function setDefaultFetchResponses() {
 
 setDefaultFetchResponses()
 
-import { addException, isPhishingSite, refreshPhishingLists } from "./ParaverseProtector"
+import { addException, dispose, isPhishingSite, refreshPhishingLists } from "./ParaverseProtector"
 
 // Explicitly trigger a refresh so both lists are loaded before assertions.
-// In production this happens 30 s after module load via setTimeout.
+// In production this happens 30 s after first use via lazy init + setTimeout.
 beforeAll(async () => {
   await refreshPhishingLists()
 })
@@ -124,5 +124,6 @@ it("Rejects invalid Polkadot list gracefully", async () => {
 })
 
 afterAll(() => {
+  dispose()
   vi.restoreAllMocks()
 })

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
@@ -169,10 +169,9 @@ export default class ParaverseProtector {
       this.#metamaskDetector = new MetamaskDetector(result.data)
       this.#etags.metamask = result.etag
       await metamaskBlobStore.set({ etag: result.etag, data: result.data }).catch((cause) => {
-        if (
-          !(cause instanceof Dexie.DatabaseClosedError) &&
-          !(cause.name !== Dexie.errnames.DatabaseClosed)
-        ) {
+        const isDbClosed =
+          cause instanceof Dexie.DatabaseClosedError || cause.name === Dexie.errnames.DatabaseClosed
+        if (!isDbClosed) {
           sentry.captureException(new Error("Failed to persist MetaMask phishing list", { cause }))
         }
       })
@@ -193,10 +192,9 @@ export default class ParaverseProtector {
       this.lists.polkadot = result.data
       this.#etags.polkadot = result.etag
       await polkadotBlobStore.set({ etag: result.etag, data: result.data }).catch((cause) => {
-        if (
-          !(cause instanceof Dexie.DatabaseClosedError) &&
-          !(cause.name !== Dexie.errnames.DatabaseClosed)
-        ) {
+        const isDbClosed =
+          cause instanceof Dexie.DatabaseClosedError || cause.name === Dexie.errnames.DatabaseClosed
+        if (!isDbClosed) {
           sentry.captureException(new Error("Failed to persist Polkadot phishing list", { cause }))
         }
       })

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
@@ -3,10 +3,8 @@ import { Dexie } from "dexie"
 import metamaskInitialData from "eth-phishing-detect/src/config.json"
 import MetamaskDetector from "eth-phishing-detect/src/detector"
 import { log, TALISMAN_WEB_APP_DOMAIN } from "extension-shared"
-import { catchError, exhaustMap, firstValueFrom, Observable, of, shareReplay, timer } from "rxjs"
 
 import { sentry } from "../../../config/sentry"
-import { db } from "../../../db"
 import { getBlobStore } from "../../../db/blobs"
 import { getHostName } from "../helpers"
 
@@ -146,50 +144,35 @@ async function refreshPolkadotList() {
   }
 }
 
-// ─── Initialisation observable ──────────────────────────────────────────────
+// ─── Initialisation ─────────────────────────────────────────────────────────
 
-/** Emits once when the DB is ready and cached phishing data has been restored. */
-const initialised$ = new Observable<true>((subscriber) => {
-  db.on(
-    "ready",
-    async () => {
-      try {
-        const [mmBlob, pdBlob] = await Promise.all([
-          metamaskBlobStore.get(),
-          polkadotBlobStore.get(),
-        ])
+/** Restore cached phishing data from the blob store. Dexie auto-opens the DB on first query. */
+const initialised = restoreFromBlobStore()
 
-        if (mmBlob && isValidMetamaskConfig(mmBlob.data)) {
-          metamaskDetector = new MetamaskDetector(mmBlob.data)
-          etags.metamask = mmBlob.etag
-        }
-        if (pdBlob && isValidPolkadotList(pdBlob.data)) {
-          polkadotList = pdBlob.data
-          etags.polkadot = pdBlob.etag
-        }
-      } catch (err) {
-        log.error("Error restoring phishing data", { err })
-      }
-      subscriber.next(true)
-      subscriber.complete()
-    },
-    false
-  )
-}).pipe(
-  catchError((err) => {
+async function restoreFromBlobStore() {
+  try {
+    const [mmBlob, pdBlob] = await Promise.all([metamaskBlobStore.get(), polkadotBlobStore.get()])
+
+    if (mmBlob && isValidMetamaskConfig(mmBlob.data)) {
+      metamaskDetector = new MetamaskDetector(mmBlob.data)
+      etags.metamask = mmBlob.etag
+    }
+    if (pdBlob && isValidPolkadotList(pdBlob.data)) {
+      polkadotList = pdBlob.data
+      etags.polkadot = pdBlob.etag
+    }
+  } catch (err) {
     // on any error the user is only unprotected until the first refresh (30 s)
-    log.error(err)
-    return of(true as const)
-  }),
-  shareReplay(1)
-)
+    log.error("Error restoring phishing data", { err })
+  }
+}
 
-// Kick off: register the DB-ready listener and start the periodic refresh timer.
-// exhaustMap prevents overlapping refreshes if a cycle takes longer than the interval.
-initialised$.subscribe()
-timer(30_000, REFRESH_INTERVAL_MIN * 60 * 1000)
-  .pipe(exhaustMap(() => refreshPhishingLists()))
-  .subscribe()
+// Periodic refresh: recursive setTimeout naturally prevents overlapping fetches.
+async function scheduleRefresh() {
+  await refreshPhishingLists()
+  setTimeout(scheduleRefresh, REFRESH_INTERVAL_MIN * 60 * 1000)
+}
+setTimeout(scheduleRefresh, 30_000)
 
 // ─── Public API ─────────────────────────────────────────────────────────────
 
@@ -200,7 +183,7 @@ export async function refreshPhishingLists(): Promise<void> {
 
 /** Check whether a URL is on a known phishing list. Waits for DB initialisation on first call. */
 export async function isPhishingSite(url: string): Promise<boolean> {
-  await firstValueFrom(initialised$)
+  await initialised
 
   const { val: host, ok } = getHostName(url)
   if (!ok) return false

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
@@ -1,13 +1,12 @@
 import { checkHost } from "@polkadot/phishing"
-import { isNotNil } from "@talismn/util"
 import { Dexie } from "dexie"
 import metamaskInitialData from "eth-phishing-detect/src/config.json"
 import MetamaskDetector from "eth-phishing-detect/src/detector"
 import { log, TALISMAN_WEB_APP_DOMAIN } from "extension-shared"
-import { decompressFromUTF16 } from "lz-string"
 
 import { sentry } from "../../../config/sentry"
 import { db } from "../../../db"
+import { getBlobStore } from "../../../db/blobs"
 import { getHostName } from "../helpers"
 
 // Fetch directly from CDN-backed raw URLs — no GitHub API rate limits (60 req/hr),
@@ -36,18 +35,13 @@ type MetaMaskDetectorConfig = {
   whitelist: string[]
 }
 
-export type ProtectorData = Record<"talisman" | "polkadot", HostList>
+type ProtectorData = Record<"talisman" | "polkadot", HostList>
 
-export type ProtectorSources = "polkadot" | "metamask" // don't persist Talisman
+/** Shape stored in the blob store: data + ETag for conditional fetching. */
+type PhishingBlob<T> = { etag: string; data: T }
 
-// Note: the `commitSha` field is reused to store HTTP ETags for cache validation.
-// Keeping the field name avoids a Dexie schema migration for what is just a transient cache.
-export type ProtectorStorage = {
-  source: ProtectorSources
-  commitSha: string // stores ETag (or legacy commit SHA — both are opaque cache keys)
-  compressedHostList?: string // legacy compressed format, kept for migration
-  hostList?: HostList | MetaMaskDetectorConfig
-}
+const metamaskBlobStore = getBlobStore<PhishingBlob<MetaMaskDetectorConfig>>("phishing-metamask")
+const polkadotBlobStore = getBlobStore<PhishingBlob<HostList>>("phishing-polkadot")
 
 function isValidMetamaskConfig(data: unknown): data is MetaMaskDetectorConfig {
   if (!data || typeof data !== "object") return false
@@ -80,7 +74,6 @@ export default class ParaverseProtector {
   }
   #refreshTimer?: ReturnType<typeof setInterval>
   #metamaskDetector = new MetamaskDetector(metamaskInitialData)
-  #persistQueue?: Record<ProtectorSources, ProtectorStorage>
 
   constructor() {
     this.setRefreshTimer = this.setRefreshTimer.bind(this)
@@ -91,38 +84,17 @@ export default class ParaverseProtector {
   }
 
   async initialise() {
-    // restore persisted data
+    // restore persisted data from blob store
     return new Promise<boolean>((resolve) => {
       db.on(
         "ready",
-        () => {
-          db.phishing.bulkGet(["polkadot", "metamask"]).then((persisted) => {
-            ;(persisted.filter(isNotNil) as ProtectorStorage[]).forEach(
-              ({ source, compressedHostList, hostList, commitSha }) => {
-                const fullData = hostList
-                  ? hostList
-                  : JSON.parse(
-                      // Legacy: decompress old format (safe to remove in a future release)
-                      (compressedHostList && decompressFromUTF16(compressedHostList)) || "{}"
-                    )
-
-                if (!fullData) return
-
-                // Restore cached ETag (or legacy commit SHA — either works as a cache key,
-                // a mismatch just causes one extra full fetch which is harmless)
-                this.#etags[source] = commitSha
-
-                if (source === "metamask") {
-                  if (isValidMetamaskConfig(fullData)) {
-                    this.#metamaskDetector = new MetamaskDetector(fullData)
-                  }
-                } else if (isValidPolkadotList(fullData)) {
-                  this.lists[source] = fullData
-                }
-              }
-            )
-            resolve(true)
-          })
+        async () => {
+          try {
+            await this.restoreFromBlobStore()
+          } catch (err) {
+            log.error("Error restoring phishing data", { err })
+          }
+          resolve(true)
         },
         false
       )
@@ -133,45 +105,27 @@ export default class ParaverseProtector {
     })
   }
 
+  /** Restore cached phishing data from the compressed blob store. */
+  private async restoreFromBlobStore() {
+    const [mmBlob, pdBlob] = await Promise.all([metamaskBlobStore.get(), polkadotBlobStore.get()])
+
+    if (mmBlob && isValidMetamaskConfig(mmBlob.data)) {
+      this.#metamaskDetector = new MetamaskDetector(mmBlob.data)
+      this.#etags.metamask = mmBlob.etag
+    }
+
+    if (pdBlob && isValidPolkadotList(pdBlob.data)) {
+      this.lists.polkadot = pdBlob.data
+      this.#etags.polkadot = pdBlob.etag
+    }
+  }
+
   isInitialised() {
     return this.#initialised
   }
 
   async setRefreshTimer() {
     await Promise.all([this.refreshMetamaskList(), this.refreshPolkadotList()])
-    await this.persistAllData()
-  }
-
-  async persistAllData() {
-    if (this.#persistQueue && Object.values(this.#persistQueue).length > 0) {
-      const data = this.#persistQueue
-      this.#persistQueue = {} as Record<ProtectorSources, ProtectorStorage>
-
-      await db.phishing.bulkPut(Object.values(data)).catch((cause) => {
-        // put it back
-        this.#persistQueue = data
-        // we can't do much about DatabaseClosedError errors
-        if (
-          !(cause instanceof Dexie.DatabaseClosedError) &&
-          !(cause.name !== Dexie.errnames.DatabaseClosed)
-        ) {
-          const error = new Error("Failed to persist phishing list", { cause })
-          sentry.captureException(error)
-        }
-      })
-    }
-  }
-
-  private persistData(source: "metamask", etag: string, data: MetaMaskDetectorConfig): void
-  private persistData(source: "polkadot", etag: string, data: HostList): void
-  private persistData(
-    source: "polkadot" | "metamask",
-    etag: string,
-    data: HostList | MetaMaskDetectorConfig
-  ): void {
-    if (!this.#persistQueue) this.#persistQueue = {} as Record<ProtectorSources, ProtectorStorage>
-    // Store ETag in the commitSha field to avoid a Dexie schema migration
-    this.#persistQueue[source] = { source, commitSha: etag, hostList: data }
   }
 
   /**
@@ -214,7 +168,14 @@ export default class ParaverseProtector {
 
       this.#metamaskDetector = new MetamaskDetector(result.data)
       this.#etags.metamask = result.etag
-      this.persistData("metamask", result.etag, result.data)
+      await metamaskBlobStore.set({ etag: result.etag, data: result.data }).catch((cause) => {
+        if (
+          !(cause instanceof Dexie.DatabaseClosedError) &&
+          !(cause.name !== Dexie.errnames.DatabaseClosed)
+        ) {
+          sentry.captureException(new Error("Failed to persist MetaMask phishing list", { cause }))
+        }
+      })
     } catch (error) {
       log.error("Error refreshing MetaMask phishing list", { error })
     }
@@ -231,7 +192,14 @@ export default class ParaverseProtector {
 
       this.lists.polkadot = result.data
       this.#etags.polkadot = result.etag
-      this.persistData("polkadot", result.etag, result.data)
+      await polkadotBlobStore.set({ etag: result.etag, data: result.data }).catch((cause) => {
+        if (
+          !(cause instanceof Dexie.DatabaseClosedError) &&
+          !(cause.name !== Dexie.errnames.DatabaseClosed)
+        ) {
+          sentry.captureException(new Error("Failed to persist Polkadot phishing list", { cause }))
+        }
+      })
     } catch (error) {
       log.error("Error refreshing Polkadot phishing list", { error })
     }

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
@@ -10,12 +10,12 @@ import { sentry } from "../../../config/sentry"
 import { db } from "../../../db"
 import { getHostName } from "../helpers"
 
-const METAMASK_REPO = "https://api.github.com/repos/MetaMask/eth-phishing-detect"
-const METAMASK_CONTENT_URL = `${METAMASK_REPO}/contents/src/config.json`
-const POLKADOT_REPO = "https://api.github.com/repos/polkadot-js/phishing"
-const POLKADOT_CONTENT_URL = "https://polkadot.js.org/phishing/all.json"
-const METAMASK_COMMIT_PATH = "/commits/main"
-const POLKADOT_COMMIT_PATH = "/commits/master"
+// Fetch directly from CDN-backed raw URLs — no GitHub API rate limits (60 req/hr),
+// no base64 decoding, no branch-name fragility. ETag-based conditional requests
+// return 304 when the list hasn't changed, avoiding re-downloading ~7 MB every cycle.
+const METAMASK_CONFIG_URL =
+  "https://raw.githubusercontent.com/MetaMask/eth-phishing-detect/main/src/config.json"
+const POLKADOT_CONFIG_URL = "https://polkadot.js.org/phishing/all.json"
 
 const REFRESH_INTERVAL_MIN = 20
 
@@ -40,16 +40,37 @@ export type ProtectorData = Record<"talisman" | "polkadot", HostList>
 
 export type ProtectorSources = "polkadot" | "metamask" // don't persist Talisman
 
+// Note: the `commitSha` field is reused to store HTTP ETags for cache validation.
+// Keeping the field name avoids a Dexie schema migration for what is just a transient cache.
 export type ProtectorStorage = {
   source: ProtectorSources
-  commitSha: string
-  compressedHostList?: string
+  commitSha: string // stores ETag (or legacy commit SHA — both are opaque cache keys)
+  compressedHostList?: string // legacy compressed format, kept for migration
   hostList?: HostList | MetaMaskDetectorConfig
+}
+
+function isValidMetamaskConfig(data: unknown): data is MetaMaskDetectorConfig {
+  if (!data || typeof data !== "object") return false
+  const obj = data as Record<string, unknown>
+  return (
+    Array.isArray(obj.blacklist) &&
+    obj.blacklist.length > 0 &&
+    Array.isArray(obj.fuzzylist) &&
+    Array.isArray(obj.whitelist) &&
+    typeof obj.tolerance === "number" &&
+    typeof obj.version === "number"
+  )
+}
+
+function isValidPolkadotList(data: unknown): data is HostList {
+  if (!data || typeof data !== "object") return false
+  const obj = data as Record<string, unknown>
+  return Array.isArray(obj.deny) && Array.isArray(obj.allow)
 }
 
 export default class ParaverseProtector {
   #initialised: Promise<boolean>
-  #commits = {
+  #etags = {
     polkadot: "",
     metamask: "",
   }
@@ -81,17 +102,23 @@ export default class ParaverseProtector {
                 const fullData = hostList
                   ? hostList
                   : JSON.parse(
-                      // todo remove decompressFromUTF16 in next release
+                      // Legacy: decompress old format (safe to remove in a future release)
                       (compressedHostList && decompressFromUTF16(compressedHostList)) || "{}"
                     )
 
                 if (!fullData) return
 
-                this.#commits[source] = commitSha
+                // Restore cached ETag (or legacy commit SHA — either works as a cache key,
+                // a mismatch just causes one extra full fetch which is harmless)
+                this.#etags[source] = commitSha
 
                 if (source === "metamask") {
-                  this.#metamaskDetector = new MetamaskDetector(fullData as MetaMaskDetectorConfig)
-                } else this.lists[source] = fullData
+                  if (isValidMetamaskConfig(fullData)) {
+                    this.#metamaskDetector = new MetamaskDetector(fullData)
+                  }
+                } else if (isValidPolkadotList(fullData)) {
+                  this.lists[source] = fullData
+                }
               }
             )
             resolve(true)
@@ -111,7 +138,7 @@ export default class ParaverseProtector {
   }
 
   async setRefreshTimer() {
-    await Promise.all([this.getMetamaskCommit(), this.getPolkadotCommit()])
+    await Promise.all([this.refreshMetamaskList(), this.refreshPolkadotList()])
     await this.persistAllData()
   }
 
@@ -135,68 +162,79 @@ export default class ParaverseProtector {
     }
   }
 
-  private persistData(source: "metamask", commitSha: string, data: MetaMaskDetectorConfig): void
-  private persistData(source: "polkadot", commitSha: string, data: HostList): void
+  private persistData(source: "metamask", etag: string, data: MetaMaskDetectorConfig): void
+  private persistData(source: "polkadot", etag: string, data: HostList): void
   private persistData(
     source: "polkadot" | "metamask",
-    commitSha: string,
+    etag: string,
     data: HostList | MetaMaskDetectorConfig
   ): void {
     if (!this.#persistQueue) this.#persistQueue = {} as Record<ProtectorSources, ProtectorStorage>
-    this.#persistQueue[source] = { source, commitSha, hostList: data }
+    // Store ETag in the commitSha field to avoid a Dexie schema migration
+    this.#persistQueue[source] = { source, commitSha: etag, hostList: data }
   }
 
-  async getCommitSha(url: string) {
-    const sha = await fetch(url, {
-      headers: [["Accept", "application/vnd.github.VERSION.sha"]],
-    })
-    return await sha.text()
+  /**
+   * Fetch a URL with ETag-based conditional caching.
+   * Returns parsed JSON + new ETag when data changed, or null on 304 Not Modified.
+   * Throws on network/HTTP errors so callers can keep existing data.
+   */
+  async fetchWithEtag(
+    url: string,
+    currentEtag: string
+  ): Promise<{ data: unknown; etag: string } | null> {
+    const headers: HeadersInit = {}
+    if (currentEtag) {
+      headers["If-None-Match"] = currentEtag
+    }
+
+    const response = await fetch(url, { headers })
+
+    // 304: content unchanged since last fetch — keep current data
+    if (response.status === 304) return null
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} fetching ${url}`)
+    }
+
+    const data: unknown = await response.json()
+    const etag = response.headers.get("etag") ?? ""
+
+    return { data, etag }
   }
 
-  async getMetamaskCommit() {
+  async refreshMetamaskList() {
     try {
-      const sha = await this.getCommitSha(`${METAMASK_REPO}${METAMASK_COMMIT_PATH}`)
-      if (sha !== this.#commits.metamask) {
-        const mmConfig = await this.getMetamaskData()
-        this.#metamaskDetector = new MetamaskDetector(mmConfig)
-        this.#commits.metamask = sha
-        this.persistData("metamask", sha, mmConfig)
+      const result = await this.fetchWithEtag(METAMASK_CONFIG_URL, this.#etags.metamask)
+      if (!result) return // 304 — no changes
+
+      if (!isValidMetamaskConfig(result.data)) {
+        throw new Error("Invalid MetaMask phishing config structure")
       }
+
+      this.#metamaskDetector = new MetamaskDetector(result.data)
+      this.#etags.metamask = result.etag
+      this.persistData("metamask", result.etag, result.data)
     } catch (error) {
-      log.error("Error getting metamask phishing commit and data", { error })
+      log.error("Error refreshing MetaMask phishing list", { error })
     }
   }
 
-  async getPolkadotCommit() {
+  async refreshPolkadotList() {
     try {
-      const sha = await this.getCommitSha(`${POLKADOT_REPO}${POLKADOT_COMMIT_PATH}`)
-      if (sha !== this.#commits.polkadot) {
-        this.lists.polkadot = await this.getPolkadotData()
-        this.#commits.polkadot = sha
-        this.persistData("polkadot", sha, this.lists.polkadot)
+      const result = await this.fetchWithEtag(POLKADOT_CONFIG_URL, this.#etags.polkadot)
+      if (!result) return // 304 — no changes
+
+      if (!isValidPolkadotList(result.data)) {
+        throw new Error("Invalid Polkadot phishing list structure")
       }
+
+      this.lists.polkadot = result.data
+      this.#etags.polkadot = result.etag
+      this.persistData("polkadot", result.etag, result.data)
     } catch (error) {
-      log.error("Error getting polkadot phishing commit and data", { error })
+      log.error("Error refreshing Polkadot phishing list", { error })
     }
-  }
-
-  async getPolkadotData() {
-    return await this.getData(POLKADOT_CONTENT_URL)
-  }
-
-  private async getData(url: string) {
-    const response = await fetch(url)
-    if (response.ok) {
-      return await response.json()
-    }
-    throw new Error(`Error fetching data from ${url}`)
-  }
-
-  async getMetamaskData(): Promise<MetaMaskDetectorConfig> {
-    const json = await this.getData(METAMASK_CONTENT_URL)
-    if (json.content === "" && json.download_url) return await this.getData(json.download_url)
-    if (!json.content) throw new Error("Unable to get content for Metamask phishing list")
-    return JSON.parse(Buffer.from(json.content, "base64").toString())
   }
 
   async isPhishingSite(url: string) {
@@ -208,7 +246,7 @@ export default class ParaverseProtector {
     if (this.lists.talisman.allow.includes(host)) return false
     if (this.lists.talisman.deny.includes(host)) return true
 
-    // then check polkadot, phishFort, and metamask lists
+    // then check polkadot and metamask lists
     const pdResult = checkHost(this.lists.polkadot.deny, host)
     if (pdResult) {
       log.warn(`Phishing site listed on Polkadot list: ${host}`)

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
@@ -14,7 +14,8 @@ const METAMASK_REPO = "https://api.github.com/repos/MetaMask/eth-phishing-detect
 const METAMASK_CONTENT_URL = `${METAMASK_REPO}/contents/src/config.json`
 const POLKADOT_REPO = "https://api.github.com/repos/polkadot-js/phishing"
 const POLKADOT_CONTENT_URL = "https://polkadot.js.org/phishing/all.json"
-const COMMIT_PATH = "/commits/master"
+const METAMASK_COMMIT_PATH = "/commits/main"
+const POLKADOT_COMMIT_PATH = "/commits/master"
 
 const REFRESH_INTERVAL_MIN = 20
 
@@ -154,7 +155,7 @@ export default class ParaverseProtector {
 
   async getMetamaskCommit() {
     try {
-      const sha = await this.getCommitSha(`${METAMASK_REPO}${COMMIT_PATH}`)
+      const sha = await this.getCommitSha(`${METAMASK_REPO}${METAMASK_COMMIT_PATH}`)
       if (sha !== this.#commits.metamask) {
         const mmConfig = await this.getMetamaskData()
         this.#metamaskDetector = new MetamaskDetector(mmConfig)
@@ -168,7 +169,7 @@ export default class ParaverseProtector {
 
   async getPolkadotCommit() {
     try {
-      const sha = await this.getCommitSha(`${POLKADOT_REPO}${COMMIT_PATH}`)
+      const sha = await this.getCommitSha(`${POLKADOT_REPO}${POLKADOT_COMMIT_PATH}`)
       if (sha !== this.#commits.polkadot) {
         this.lists.polkadot = await this.getPolkadotData()
         this.#commits.polkadot = sha

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
@@ -16,7 +16,7 @@ const METAMASK_CONFIG_URL =
   "https://raw.githubusercontent.com/MetaMask/eth-phishing-detect/main/src/config.json"
 const POLKADOT_CONFIG_URL = "https://polkadot.js.org/phishing/all.json"
 
-const REFRESH_INTERVAL_MIN = 20
+const REFRESH_INTERVAL_MIN = 5
 
 const DEFAULT_ALLOW = [
   TALISMAN_WEB_APP_DOMAIN, // app.talisman.xyz

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
@@ -68,6 +68,9 @@ let polkadotList: HostList = { allow: [], deny: [] }
 const talismanAllow = new Set<string>(DEFAULT_ALLOW)
 const etags = { polkadot: "", metamask: "" }
 
+/** Controller for in-flight fetch requests; aborted on dispose or new refresh cycle. */
+let fetchController: AbortController | null = null
+
 // ─── Data fetching ──────────────────────────────────────────────────────────
 
 /**
@@ -77,12 +80,13 @@ const etags = { polkadot: "", metamask: "" }
  */
 async function fetchWithEtag(
   url: string,
-  currentEtag: string
+  currentEtag: string,
+  signal?: AbortSignal
 ): Promise<{ data: unknown; etag: string } | null> {
   const headers: HeadersInit = {}
   if (currentEtag) headers["If-None-Match"] = currentEtag
 
-  const response = await fetch(url, { headers })
+  const response = await fetch(url, { headers, signal })
   if (response.status === 304) return null
   if (!response.ok) throw new Error(`HTTP ${response.status} fetching ${url}`)
 
@@ -102,9 +106,9 @@ function persistBlob<T>(store: ReturnType<typeof getBlobStore<T>>, data: T, labe
   })
 }
 
-async function refreshMetamaskList() {
+async function refreshMetamaskList(signal?: AbortSignal) {
   try {
-    const result = await fetchWithEtag(METAMASK_CONFIG_URL, etags.metamask)
+    const result = await fetchWithEtag(METAMASK_CONFIG_URL, etags.metamask, signal)
     if (!result) return
 
     if (!isValidMetamaskConfig(result.data)) {
@@ -119,13 +123,14 @@ async function refreshMetamaskList() {
       "MetaMask phishing list"
     )
   } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") return
     log.error("Error refreshing MetaMask phishing list", { error })
   }
 }
 
-async function refreshPolkadotList() {
+async function refreshPolkadotList(signal?: AbortSignal) {
   try {
-    const result = await fetchWithEtag(POLKADOT_CONFIG_URL, etags.polkadot)
+    const result = await fetchWithEtag(POLKADOT_CONFIG_URL, etags.polkadot, signal)
     if (!result) return
 
     if (!isValidPolkadotList(result.data)) {
@@ -140,15 +145,27 @@ async function refreshPolkadotList() {
       "Polkadot phishing list"
     )
   } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") return
     log.error("Error refreshing Polkadot phishing list", { error })
   }
 }
 
 // ─── Initialisation ─────────────────────────────────────────────────────────
 
-/** Restore cached phishing data from the blob store. Dexie auto-opens the DB on first query. */
-const initialised = restoreFromBlobStore()
+/** Lazy-init: DB restore + periodic refresh are started on first use, not at import time. */
+let initialised: Promise<void> | null = null
 
+function ensureInitialised(): Promise<void> {
+  if (!initialised) {
+    initialised = restoreFromBlobStore().then(() => {
+      // start periodic refresh 30 s after first use
+      refreshTimer = setTimeout(scheduleRefresh, 30_000)
+    })
+  }
+  return initialised
+}
+
+/** Restore cached phishing data from the blob store. Dexie auto-opens the DB on first query. */
 async function restoreFromBlobStore() {
   try {
     const [mmBlob, pdBlob] = await Promise.all([metamaskBlobStore.get(), polkadotBlobStore.get()])
@@ -168,22 +185,31 @@ async function restoreFromBlobStore() {
 }
 
 // Periodic refresh: recursive setTimeout naturally prevents overlapping fetches.
+let refreshTimer: ReturnType<typeof setTimeout> | null = null
+
 async function scheduleRefresh() {
   await refreshPhishingLists()
-  setTimeout(scheduleRefresh, REFRESH_INTERVAL_MIN * 60 * 1000)
+  refreshTimer = setTimeout(scheduleRefresh, REFRESH_INTERVAL_MIN * 60 * 1000)
 }
-setTimeout(scheduleRefresh, 30_000)
 
 // ─── Public API ─────────────────────────────────────────────────────────────
 
 /** Force-refresh both phishing lists. Exposed for manual triggers and testing. */
 export async function refreshPhishingLists(): Promise<void> {
-  await Promise.all([refreshMetamaskList(), refreshPolkadotList()])
+  // Abort any in-flight fetches from a previous refresh cycle
+  fetchController?.abort()
+  const controller = new AbortController()
+  fetchController = controller
+
+  await Promise.all([
+    refreshMetamaskList(controller.signal),
+    refreshPolkadotList(controller.signal),
+  ])
 }
 
-/** Check whether a URL is on a known phishing list. Waits for DB initialisation on first call. */
+/** Check whether a URL is on a known phishing list. Lazily initialises on first call. */
 export async function isPhishingSite(url: string): Promise<boolean> {
-  await initialised
+  await ensureInitialised()
 
   const { val: host, ok } = getHostName(url)
   if (!ok) return false
@@ -214,4 +240,15 @@ export function addException(url: string): boolean {
 
   talismanAllow.add(host)
   return true
+}
+
+/** Tear down timers and abort in-flight fetches. Useful for clean shutdown and testing. */
+export function dispose(): void {
+  fetchController?.abort()
+  fetchController = null
+  if (refreshTimer) {
+    clearTimeout(refreshTimer)
+    refreshTimer = null
+  }
+  initialised = null
 }

--- a/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
+++ b/packages/extension-core/src/domains/app/protector/ParaverseProtector.ts
@@ -3,14 +3,15 @@ import { Dexie } from "dexie"
 import metamaskInitialData from "eth-phishing-detect/src/config.json"
 import MetamaskDetector from "eth-phishing-detect/src/detector"
 import { log, TALISMAN_WEB_APP_DOMAIN } from "extension-shared"
+import { catchError, exhaustMap, firstValueFrom, Observable, of, shareReplay, timer } from "rxjs"
 
 import { sentry } from "../../../config/sentry"
 import { db } from "../../../db"
 import { getBlobStore } from "../../../db/blobs"
 import { getHostName } from "../helpers"
 
-// Fetch directly from CDN-backed raw URLs — no GitHub API rate limits (60 req/hr),
-// no base64 decoding, no branch-name fragility. ETag-based conditional requests
+// Fetch directly from CDN-backed raw URLs with no rate limits
+// Supports ETag-based conditional requests
 // return 304 when the list hasn't changed, avoiding re-downloading ~7 MB every cycle.
 const METAMASK_CONFIG_URL =
   "https://raw.githubusercontent.com/MetaMask/eth-phishing-detect/main/src/config.json"
@@ -18,7 +19,7 @@ const POLKADOT_CONFIG_URL = "https://polkadot.js.org/phishing/all.json"
 
 const REFRESH_INTERVAL_MIN = 5
 
-const DEFAULT_ALLOW = [
+const DEFAULT_ALLOW: ReadonlyArray<string> = [
   TALISMAN_WEB_APP_DOMAIN, // app.talisman.xyz
   TALISMAN_WEB_APP_DOMAIN.split(".")
     .slice(1)
@@ -35,13 +36,13 @@ type MetaMaskDetectorConfig = {
   whitelist: string[]
 }
 
-type ProtectorData = Record<"talisman" | "polkadot", HostList>
-
 /** Shape stored in the blob store: data + ETag for conditional fetching. */
 type PhishingBlob<T> = { etag: string; data: T }
 
 const metamaskBlobStore = getBlobStore<PhishingBlob<MetaMaskDetectorConfig>>("phishing-metamask")
 const polkadotBlobStore = getBlobStore<PhishingBlob<HostList>>("phishing-polkadot")
+
+// ─── Validators ─────────────────────────────────────────────────────────────
 
 function isValidMetamaskConfig(data: unknown): data is MetaMaskDetectorConfig {
   if (!data || typeof data !== "object") return false
@@ -59,179 +60,175 @@ function isValidMetamaskConfig(data: unknown): data is MetaMaskDetectorConfig {
 function isValidPolkadotList(data: unknown): data is HostList {
   if (!data || typeof data !== "object") return false
   const obj = data as Record<string, unknown>
-  return Array.isArray(obj.deny) && Array.isArray(obj.allow)
+  return Array.isArray(obj.deny) && obj.deny.length > 0 && Array.isArray(obj.allow)
 }
 
-export default class ParaverseProtector {
-  #initialised: Promise<boolean>
-  #etags = {
-    polkadot: "",
-    metamask: "",
-  }
-  lists: ProtectorData = {
-    talisman: { allow: DEFAULT_ALLOW, deny: [] },
-    polkadot: { allow: [], deny: [] },
-  }
-  #refreshTimer?: ReturnType<typeof setInterval>
-  #metamaskDetector = new MetamaskDetector(metamaskInitialData)
+// ─── Module state ───────────────────────────────────────────────────────────
 
-  constructor() {
-    this.setRefreshTimer = this.setRefreshTimer.bind(this)
-    this.#refreshTimer = setInterval(this.setRefreshTimer, REFRESH_INTERVAL_MIN * 60 * 1000)
-    // do the first check once after 30 seconds
-    setTimeout(this.setRefreshTimer, 30_000)
-    this.#initialised = this.initialise()
-  }
+let metamaskDetector = new MetamaskDetector(metamaskInitialData)
+let polkadotList: HostList = { allow: [], deny: [] }
+const talismanAllow = new Set<string>(DEFAULT_ALLOW)
+const etags = { polkadot: "", metamask: "" }
 
-  async initialise() {
-    // restore persisted data from blob store
-    return new Promise<boolean>((resolve) => {
-      db.on(
-        "ready",
-        async () => {
-          try {
-            await this.restoreFromBlobStore()
-          } catch (err) {
-            log.error("Error restoring phishing data", { err })
-          }
-          resolve(true)
-        },
-        false
-      )
-    }).catch((err) => {
-      // in the case of any error, the user should only be unprotected until the first update runs (30 seconds)
-      log.error(err)
-      return true
-    })
-  }
+// ─── Data fetching ──────────────────────────────────────────────────────────
 
-  /** Restore cached phishing data from the compressed blob store. */
-  private async restoreFromBlobStore() {
-    const [mmBlob, pdBlob] = await Promise.all([metamaskBlobStore.get(), polkadotBlobStore.get()])
+/**
+ * Fetch a URL with ETag-based conditional caching.
+ * Returns parsed JSON + new ETag when data changed, or null on 304 Not Modified.
+ * Throws on network/HTTP errors so callers can keep existing data.
+ */
+async function fetchWithEtag(
+  url: string,
+  currentEtag: string
+): Promise<{ data: unknown; etag: string } | null> {
+  const headers: HeadersInit = {}
+  if (currentEtag) headers["If-None-Match"] = currentEtag
 
-    if (mmBlob && isValidMetamaskConfig(mmBlob.data)) {
-      this.#metamaskDetector = new MetamaskDetector(mmBlob.data)
-      this.#etags.metamask = mmBlob.etag
+  const response = await fetch(url, { headers })
+  if (response.status === 304) return null
+  if (!response.ok) throw new Error(`HTTP ${response.status} fetching ${url}`)
+
+  const data: unknown = await response.json()
+  const etag = response.headers.get("etag") ?? ""
+  return { data, etag }
+}
+
+/** Persist a blob, swallowing DatabaseClosedError (extension shutting down). */
+function persistBlob<T>(store: ReturnType<typeof getBlobStore<T>>, data: T, label: string): void {
+  store.set(data).catch((cause) => {
+    const isDbClosed =
+      cause instanceof Dexie.DatabaseClosedError || cause.name === Dexie.errnames.DatabaseClosed
+    if (!isDbClosed) {
+      sentry.captureException(new Error(`Failed to persist ${label}`, { cause }))
+    }
+  })
+}
+
+async function refreshMetamaskList() {
+  try {
+    const result = await fetchWithEtag(METAMASK_CONFIG_URL, etags.metamask)
+    if (!result) return
+
+    if (!isValidMetamaskConfig(result.data)) {
+      throw new Error("Invalid MetaMask phishing config structure")
     }
 
-    if (pdBlob && isValidPolkadotList(pdBlob.data)) {
-      this.lists.polkadot = pdBlob.data
-      this.#etags.polkadot = pdBlob.etag
-    }
+    metamaskDetector = new MetamaskDetector(result.data)
+    etags.metamask = result.etag
+    persistBlob(
+      metamaskBlobStore,
+      { etag: result.etag, data: result.data },
+      "MetaMask phishing list"
+    )
+  } catch (error) {
+    log.error("Error refreshing MetaMask phishing list", { error })
   }
+}
 
-  isInitialised() {
-    return this.#initialised
-  }
+async function refreshPolkadotList() {
+  try {
+    const result = await fetchWithEtag(POLKADOT_CONFIG_URL, etags.polkadot)
+    if (!result) return
 
-  async setRefreshTimer() {
-    await Promise.all([this.refreshMetamaskList(), this.refreshPolkadotList()])
-  }
-
-  /**
-   * Fetch a URL with ETag-based conditional caching.
-   * Returns parsed JSON + new ETag when data changed, or null on 304 Not Modified.
-   * Throws on network/HTTP errors so callers can keep existing data.
-   */
-  async fetchWithEtag(
-    url: string,
-    currentEtag: string
-  ): Promise<{ data: unknown; etag: string } | null> {
-    const headers: HeadersInit = {}
-    if (currentEtag) {
-      headers["If-None-Match"] = currentEtag
+    if (!isValidPolkadotList(result.data)) {
+      throw new Error("Invalid Polkadot phishing list structure")
     }
 
-    const response = await fetch(url, { headers })
-
-    // 304: content unchanged since last fetch — keep current data
-    if (response.status === 304) return null
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} fetching ${url}`)
-    }
-
-    const data: unknown = await response.json()
-    const etag = response.headers.get("etag") ?? ""
-
-    return { data, etag }
+    polkadotList = result.data
+    etags.polkadot = result.etag
+    persistBlob(
+      polkadotBlobStore,
+      { etag: result.etag, data: result.data },
+      "Polkadot phishing list"
+    )
+  } catch (error) {
+    log.error("Error refreshing Polkadot phishing list", { error })
   }
+}
 
-  async refreshMetamaskList() {
-    try {
-      const result = await this.fetchWithEtag(METAMASK_CONFIG_URL, this.#etags.metamask)
-      if (!result) return // 304 — no changes
+// ─── Initialisation observable ──────────────────────────────────────────────
 
-      if (!isValidMetamaskConfig(result.data)) {
-        throw new Error("Invalid MetaMask phishing config structure")
-      }
+/** Emits once when the DB is ready and cached phishing data has been restored. */
+const initialised$ = new Observable<true>((subscriber) => {
+  db.on(
+    "ready",
+    async () => {
+      try {
+        const [mmBlob, pdBlob] = await Promise.all([
+          metamaskBlobStore.get(),
+          polkadotBlobStore.get(),
+        ])
 
-      this.#metamaskDetector = new MetamaskDetector(result.data)
-      this.#etags.metamask = result.etag
-      await metamaskBlobStore.set({ etag: result.etag, data: result.data }).catch((cause) => {
-        const isDbClosed =
-          cause instanceof Dexie.DatabaseClosedError || cause.name === Dexie.errnames.DatabaseClosed
-        if (!isDbClosed) {
-          sentry.captureException(new Error("Failed to persist MetaMask phishing list", { cause }))
+        if (mmBlob && isValidMetamaskConfig(mmBlob.data)) {
+          metamaskDetector = new MetamaskDetector(mmBlob.data)
+          etags.metamask = mmBlob.etag
         }
-      })
-    } catch (error) {
-      log.error("Error refreshing MetaMask phishing list", { error })
-    }
-  }
-
-  async refreshPolkadotList() {
-    try {
-      const result = await this.fetchWithEtag(POLKADOT_CONFIG_URL, this.#etags.polkadot)
-      if (!result) return // 304 — no changes
-
-      if (!isValidPolkadotList(result.data)) {
-        throw new Error("Invalid Polkadot phishing list structure")
-      }
-
-      this.lists.polkadot = result.data
-      this.#etags.polkadot = result.etag
-      await polkadotBlobStore.set({ etag: result.etag, data: result.data }).catch((cause) => {
-        const isDbClosed =
-          cause instanceof Dexie.DatabaseClosedError || cause.name === Dexie.errnames.DatabaseClosed
-        if (!isDbClosed) {
-          sentry.captureException(new Error("Failed to persist Polkadot phishing list", { cause }))
+        if (pdBlob && isValidPolkadotList(pdBlob.data)) {
+          polkadotList = pdBlob.data
+          etags.polkadot = pdBlob.etag
         }
-      })
-    } catch (error) {
-      log.error("Error refreshing Polkadot phishing list", { error })
-    }
-  }
+      } catch (err) {
+        log.error("Error restoring phishing data", { err })
+      }
+      subscriber.next(true)
+      subscriber.complete()
+    },
+    false
+  )
+}).pipe(
+  catchError((err) => {
+    // on any error the user is only unprotected until the first refresh (30 s)
+    log.error(err)
+    return of(true as const)
+  }),
+  shareReplay(1)
+)
 
-  async isPhishingSite(url: string) {
-    await this.isInitialised()
-    const { val: host, ok } = getHostName(url)
-    if (!ok) return false
+// Kick off: register the DB-ready listener and start the periodic refresh timer.
+// exhaustMap prevents overlapping refreshes if a cycle takes longer than the interval.
+initialised$.subscribe()
+timer(30_000, REFRESH_INTERVAL_MIN * 60 * 1000)
+  .pipe(exhaustMap(() => refreshPhishingLists()))
+  .subscribe()
 
-    // first check our lists
-    if (this.lists.talisman.allow.includes(host)) return false
-    if (this.lists.talisman.deny.includes(host)) return true
+// ─── Public API ─────────────────────────────────────────────────────────────
 
-    // then check polkadot and metamask lists
-    const pdResult = checkHost(this.lists.polkadot.deny, host)
-    if (pdResult) {
-      log.warn(`Phishing site listed on Polkadot list: ${host}`)
-      return true
-    }
-    const { result: mmResult } = this.#metamaskDetector.check(host)
-    if (mmResult) {
-      log.warn(`Phishing site listed on MetaMask list: ${host}`)
-      return true
-    }
+/** Force-refresh both phishing lists. Exposed for manual triggers and testing. */
+export async function refreshPhishingLists(): Promise<void> {
+  await Promise.all([refreshMetamaskList(), refreshPolkadotList()])
+}
 
-    return false
-  }
+/** Check whether a URL is on a known phishing list. Waits for DB initialisation on first call. */
+export async function isPhishingSite(url: string): Promise<boolean> {
+  await firstValueFrom(initialised$)
 
-  addException(url: string) {
-    const { val: host, ok } = getHostName(url)
-    if (!ok) return false
+  const { val: host, ok } = getHostName(url)
+  if (!ok) return false
 
-    this.lists.talisman.allow.push(host)
+  // talisman allow list (includes user exceptions)
+  if (talismanAllow.has(host)) return false
+
+  // polkadot deny list
+  if (checkHost(polkadotList.deny, host)) {
+    log.warn(`Phishing site listed on Polkadot list: ${host}`)
     return true
   }
+
+  // metamask deny / fuzzy list
+  const { result: mmResult } = metamaskDetector.check(host)
+  if (mmResult) {
+    log.warn(`Phishing site listed on MetaMask list: ${host}`)
+    return true
+  }
+
+  return false
+}
+
+/** Whitelist a URL so it is no longer flagged as phishing for this session. */
+export function addException(url: string): boolean {
+  const { val: host, ok } = getHostName(url)
+  if (!ok) return false
+
+  talismanAllow.add(host)
+  return true
 }

--- a/packages/extension-core/src/domains/app/protector/index.ts
+++ b/packages/extension-core/src/domains/app/protector/index.ts
@@ -1,3 +1,1 @@
-import ParaverseProtector from "./ParaverseProtector"
-
-export const protector = new ParaverseProtector()
+export { addException, isPhishingSite } from "./ParaverseProtector"

--- a/packages/extension-core/src/domains/app/protector/index.ts
+++ b/packages/extension-core/src/domains/app/protector/index.ts
@@ -1,1 +1,1 @@
-export { addException, isPhishingSite } from "./ParaverseProtector"
+export { addException, dispose, isPhishingSite } from "./ParaverseProtector"

--- a/packages/extension-core/src/handlers/Tabs.ts
+++ b/packages/extension-core/src/handlers/Tabs.ts
@@ -21,7 +21,7 @@ import { sentry } from "../config/sentry"
 import { db } from "../db"
 import { filterAccountsByAddresses, getPublicAccounts } from "../domains/accounts/helpers"
 import type { RequestAccountList } from "../domains/accounts/types"
-import { protector } from "../domains/app/protector"
+import { isPhishingSite } from "../domains/app/protector"
 import type { SettingsStoreData } from "../domains/app/store.settings"
 import { requestDecrypt, requestEncrypt } from "../domains/encrypt/requests"
 import type {
@@ -295,7 +295,7 @@ export default class Tabs extends TabsHandler {
   }
 
   private async redirectIfPhishing(url: string): Promise<boolean> {
-    const isInDenyList = await protector.isPhishingSite(url)
+    const isInDenyList = await isPhishingSite(url)
 
     if (isInDenyList) {
       sentry.captureEvent({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1097,9 +1097,6 @@ importers:
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
-      lz-string:
-        specifier: ^1.5.0
-        version: 1.5.0
       p-queue:
         specifier: 8.1.0
         version: 8.1.0
@@ -3339,7 +3336,7 @@ packages:
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: '>=2.79.2'
+      rollup: '>=4.22.4'
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -11546,7 +11543,7 @@ snapshots:
       '@polkadot-api/metadata-compatibility': 0.2.4
       '@polkadot-api/observable-client': 0.11.2(@polkadot-api/substrate-client@0.4.0)(rxjs@7.8.2)
       '@polkadot-api/polkadot-sdk-compat': 2.3.2
-      '@polkadot-api/sm-provider': 0.1.7(@polkadot-api/smoldot@0.3.9(bufferutil@4.0.8)(utf-8-validate@6.0.4))
+      '@polkadot-api/sm-provider': 0.1.7(@polkadot-api/smoldot@0.3.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@polkadot-api/smoldot': 0.3.9(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@polkadot-api/substrate-bindings': 0.14.0
       '@polkadot-api/substrate-client': 0.4.0
@@ -11706,6 +11703,12 @@ snapshots:
       '@polkadot-api/polkadot-signer': 0.1.6
       '@polkadot-api/substrate-bindings': 0.14.0
       '@polkadot-api/utils': 0.2.0
+
+  '@polkadot-api/sm-provider@0.1.7(@polkadot-api/smoldot@0.3.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@polkadot-api/json-rpc-provider': 0.0.4
+      '@polkadot-api/json-rpc-provider-proxy': 0.2.4
+      '@polkadot-api/smoldot': 0.3.9(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
   '@polkadot-api/sm-provider@0.1.7(@polkadot-api/smoldot@0.3.9(bufferutil@4.0.8)(utf-8-validate@6.0.4))':
     dependencies:
@@ -17743,7 +17746,7 @@ snapshots:
       '@polkadot-api/polkadot-sdk-compat': 2.3.2
       '@polkadot-api/polkadot-signer': 0.1.6
       '@polkadot-api/signer': 0.2.2
-      '@polkadot-api/sm-provider': 0.1.7(@polkadot-api/smoldot@0.3.9(bufferutil@4.0.8)(utf-8-validate@6.0.4))
+      '@polkadot-api/sm-provider': 0.1.7(@polkadot-api/smoldot@0.3.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@polkadot-api/smoldot': 0.3.9(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@polkadot-api/substrate-bindings': 0.14.0
       '@polkadot-api/substrate-client': 0.4.0


### PR DESCRIPTION
⚠️ This PR bumps database schema

- fetch lists from cdn instead of github api, eliminating rate limit issues
- store lists in blob storage, which saves ~5mb and simplifies db schema
- update from source repos every 5 minutes
- fix mm file location
- refactored paraverse protector to not use a singleton so it can be tested and disposed properly