### PR TITLE
fix: changed warning border

### DIFF
--- a/apps/extension/src/ui/domains/SendFunds/SendFundsConfirmForm.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsConfirmForm.tsx
@@ -132,7 +132,7 @@ const ExternalRecipientWarning = () => {
   if (warningType === "none") return null
 
   return (
-    <div className="w-full rounded border border-alert-warn text-xs">
+    <div className="w-full rounded border border-alert-warn/25 text-xs">
       <div className="flex items-center gap-4 p-4 text-alert-warn">
         <AlertCircleIcon className="shrink-0 text-[2rem]" />
         {warningType === "network" && network && token && (
@@ -150,7 +150,7 @@ const ExternalRecipientWarning = () => {
           </div>
         )}
       </div>
-      <hr className="border-alert-warn" />
+      <hr className="border-alert-warn/25" />
       {warningType === "network" && network && token && (
         <div className="space-y-2 p-4 text-body">
           <Checkbox checked={isWarningAcknowledged} onChange={handleCheckChange}>


### PR DESCRIPTION
Fixed border (self-explanatory)

<img width="512" height="740" alt="Screenshot 2026-03-11 at 11 32 21 PM" src="https://github.com/user-attachments/assets/88f3f59d-bc5c-45fa-958e-e73123343db2" />
