### PR TITLE
feat: expired quote detection

### DIFF
--- a/apps/extension/src/ui/domains/Swap/components/SwapConfirmActions.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapConfirmActions.tsx
@@ -21,6 +21,7 @@ import { useSolanaConnection } from "@ui/util/solana/useSolanaConnection"
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { EstimateGasExecutionError } from "viem"
+import { isQuoteExpiredError } from "../helpers/isQuoteExpiredError"
 import { useConfirmReadiness, useSwapPostSubmit, useSwapTxInfo } from "../hooks/useSwapConfirmation"
 import { useSwapSlippage } from "../hooks/useSwapSlippage"
 import { useSwap } from "../SwapProvider"
@@ -28,12 +29,14 @@ import type {
   SwapModuleTransaction,
   SwapTransactionContext,
 } from "../swap-modules/common.swap-module"
+import { SwapQuoteExpiredDrawer } from "./SwapQuoteExpiredDrawer"
 import { SwapSlippageDrawer } from "./SwapSlippageDrawer"
 
 export const SwapConfirmActions: FC<{ containerId: string }> = ({ containerId }) => {
   const { t } = useTranslation()
   const {
     swapView,
+    setSwapView,
     fromBalance,
     fromAddress,
     toAddress,
@@ -383,10 +386,17 @@ export const SwapConfirmActions: FC<{ containerId: string }> = ({ containerId })
 
   const errorMessage = useMemo(() => {
     if (!exchangeError) return null
+    if (isQuoteExpiredError(exchangeError)) return null
     // biome-ignore lint/suspicious/noExplicitAny: error shape is unknown and may not extend Error
     const anyError = exchangeError as any
     return anyError?.shortMessage || anyError?.message || t("Transaction is likely to fail")
   }, [exchangeError, t])
+
+  const isQuoteExpired = useMemo(() => isQuoteExpiredError(exchangeError), [exchangeError])
+
+  const handleQuoteExpiredDismiss = useCallback(() => {
+    setSwapView("form")
+  }, [setSwapView])
 
   return (
     <>
@@ -508,6 +518,11 @@ export const SwapConfirmActions: FC<{ containerId: string }> = ({ containerId })
           onClose={slippageDrawer.close}
         />
       ) : null}
+      <SwapQuoteExpiredDrawer
+        containerId={containerId}
+        isOpen={isQuoteExpired}
+        onDismiss={handleQuoteExpiredDismiss}
+      />
     </>
   )
 }

--- a/apps/extension/src/ui/domains/Swap/components/SwapQuoteExpiredDrawer.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapQuoteExpiredDrawer.tsx
@@ -1,0 +1,36 @@
+import { AlertCircleIcon } from "@talismn/icons"
+import { Button } from "@ui/components/Button"
+import { Drawer } from "@ui/components/Drawer"
+import type { FC } from "react"
+import { useTranslation } from "react-i18next"
+
+type SwapQuoteExpiredDrawerProps = {
+  isOpen: boolean
+  containerId: string
+  onDismiss: () => void
+}
+
+export const SwapQuoteExpiredDrawer: FC<SwapQuoteExpiredDrawerProps> = ({
+  isOpen,
+  containerId,
+  onDismiss,
+}) => {
+  const { t } = useTranslation()
+
+  return (
+    <Drawer anchor="bottom" isOpen={isOpen} containerId={containerId} onDismiss={onDismiss}>
+      <div className="flex w-full flex-col items-center gap-4 rounded-t-xl bg-grey-800 p-12">
+        <AlertCircleIcon className="text-[1.875rem] text-alert-warn" />
+        <div className="mt-4 text-center font-bold text-body">{t("Quote Expired")}</div>
+        <p className="text-center text-body-secondary text-sm">
+          {t(
+            "Market conditions have changed since your quote was generated. Please go back and review the updated quote before confirming."
+          )}
+        </p>
+        <Button className="mt-8 w-full" primary onClick={onDismiss}>
+          {t("OK")}
+        </Button>
+      </div>
+    </Drawer>
+  )
+}

--- a/apps/extension/src/ui/domains/Swap/helpers/isQuoteExpiredError.ts
+++ b/apps/extension/src/ui/domains/Swap/helpers/isQuoteExpiredError.ts
@@ -1,0 +1,27 @@
+import { BaseError, HTTPError, LiFiErrorCode } from "@lifi/sdk"
+
+/**
+ * Detects errors that indicate the swap quote has become stale and should be refreshed.
+ *
+ * Covers:
+ * - LI.FI: HTTP 409 SlippageError, TransactionExpired (1018)
+ * - SimpleSwap / StealthEX: "Quote changed" error messages
+ */
+export const isQuoteExpiredError = (error: unknown): boolean => {
+  if (error instanceof HTTPError) {
+    if (error.status === 409) return true
+    if (error.code === LiFiErrorCode.SlippageError) return true
+    if (error.code === LiFiErrorCode.TransactionExpired) return true
+  }
+
+  if (error instanceof BaseError) {
+    if (error.code === LiFiErrorCode.SlippageError) return true
+    if (error.code === LiFiErrorCode.TransactionExpired) return true
+  }
+
+  if (error instanceof Error) {
+    if (/quote changed/i.test(error.message)) return true
+  }
+
+  return false
+}


### PR DESCRIPTION
with LIFI, if a tx fails to submit because quote isnt valid anymore, it should open a drawer to inform the user that quote needs to be refreshed. when closing the drawer, quote will refresh.