### PR TITLE
fix: popup out of bounds

### DIFF
--- a/apps/extension/entrypoints/popup/main.tsx
+++ b/apps/extension/entrypoints/popup/main.tsx
@@ -49,12 +49,13 @@ const adjustPopupSize = async () => {
       throw new Error(`Invalid width (${width}) or height (${height})`)
 
     if (width !== window.outerWidth || height !== window.outerHeight) {
-      chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, {
+      await chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, {
         width,
         height,
       })
 
       // store delta to open next popups at the right size
+      // only persisted after successful resize to avoid storing invalid values
       await appStore.set({ popupSizeDelta: [deltaWidth, deltaHeight] })
     }
   } catch (cause) {

--- a/apps/extension/src/core/libs/WindowManager.ts
+++ b/apps/extension/src/core/libs/WindowManager.ts
@@ -130,23 +130,28 @@ class WindowManager {
     }
 
     let popup: chrome.windows.Window
+    let usedFallback = false
     try {
       popup = await chrome.windows.create(popupCreateArgs)
     } catch (err) {
       log.error("Failed to open popup", err)
 
-      // retry with default size, as an invalid size could be the source of the error
+      // retry with default size and without position constraints,
+      // as invalid size or out-of-bounds position could be the source of the error
+      const { top: _, left: __, ...fallbackArgs } = popupCreateArgs
       popup = await chrome.windows.create({
-        ...popupCreateArgs,
+        ...fallbackArgs,
         width: WINDOW_OPTS.width,
         height: WINDOW_OPTS.height,
       })
+      usedFallback = true
     }
 
     if (typeof popup?.id !== "undefined") {
       this.#windows.push(popup.id || 0)
       // firefox compatibility (cannot be set at creation)
-      if (IS_FIREFOX && popup.left !== left && popup.state !== "fullscreen") {
+      // skip repositioning if fallback was used, as original position was invalid
+      if (!usedFallback && IS_FIREFOX && popup.left !== left && popup.state !== "fullscreen") {
         await chrome.windows.update(popup.id, { left, top })
       }
     }

--- a/apps/extension/src/core/libs/WindowManager.ts
+++ b/apps/extension/src/core/libs/WindowManager.ts
@@ -139,9 +139,8 @@ class WindowManager {
       // retry with default size and without position constraints,
       // as invalid size or out-of-bounds position could be the source of the error
       popup = await chrome.windows.create({
+        ...WINDOW_OPTS,
         url: popupCreateArgs.url,
-        width: WINDOW_OPTS.width,
-        height: WINDOW_OPTS.height,
       })
       usedFallback = true
     }

--- a/apps/extension/src/core/libs/WindowManager.ts
+++ b/apps/extension/src/core/libs/WindowManager.ts
@@ -138,9 +138,8 @@ class WindowManager {
 
       // retry with default size and without position constraints,
       // as invalid size or out-of-bounds position could be the source of the error
-      const { top: _, left: __, ...fallbackArgs } = popupCreateArgs
       popup = await chrome.windows.create({
-        ...fallbackArgs,
+        url: popupCreateArgs.url,
         width: WINDOW_OPTS.width,
         height: WINDOW_OPTS.height,
       })

--- a/apps/extension/src/core/libs/WindowManager.ts
+++ b/apps/extension/src/core/libs/WindowManager.ts
@@ -2,7 +2,7 @@ import { IS_FIREFOX } from "@common/constants"
 import { log } from "@common/log"
 import { sleep } from "@talismn/util"
 
-import { appStore } from "../domains/app/store.app"
+import { appStore, DEFAULT_APP_STATE } from "../domains/app/store.app"
 import type { RequestRoute } from "../domains/app/types"
 
 const WINDOW_OPTS: chrome.windows.CreateData & { width: number; height: number } = {
@@ -143,6 +143,9 @@ class WindowManager {
         url: popupCreateArgs.url,
       })
       usedFallback = true
+
+      // reset stored delta so next popup doesn't repeat the same failure
+      await appStore.set({ popupSizeDelta: DEFAULT_APP_STATE.popupSizeDelta })
     }
 
     if (typeof popup?.id !== "undefined") {

--- a/playwright/e2e-tests/testnet-transfers.spec.ts
+++ b/playwright/e2e-tests/testnet-transfers.spec.ts
@@ -57,9 +57,15 @@ test("Transfer Assets", async ({ importAccount, onboardedPage, walletPopup, exte
       await popup.getByPlaceholder("0").fill(data.amount)
       await expect(popup.getByTestId("component-review-button")).toBeEnabled({ timeout: 10000 })
       await popup.getByTestId("component-review-button").click()
-      await expect(popup.getByTestId("send-funds-confirm-button").getByRole("button")).toBeEnabled()
-      await popup.getByTestId("send-funds-confirm-button").click()
-      await expect(popup.getByRole("button", { name: "Close" })).toBeVisible()
+
+      // acknowledge external address warning if present
+      const warning = popup.getByTestId("send-funds-confirm-button").getByRole("checkbox").first()
+      if (await warning.isVisible({ timeout: 2000 }).catch(() => false)) await warning.check()
+
+      const confirmBtn = popup.getByTestId("send-funds-confirm-button").getByRole("button")
+      await expect(confirmBtn).toBeEnabled({ timeout: 15000 })
+      await confirmBtn.click()
+      await expect(popup.getByRole("button", { name: "Close" })).toBeVisible({ timeout: 30000 })
       await popup.close()
     })
   }


### PR DESCRIPTION
If popup fails to open because it would be out of bounds, fallback to a simple and safe popup opening request without specifying the location