### PR TITLE
E2E - More account types and password test

### DIFF
--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddMnemonic/MnemonicForm.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddMnemonic/MnemonicForm.tsx
@@ -284,7 +284,10 @@ export const AccountAddMnemonicForm = () => {
           <div className="mt-2 flex w-full items-center justify-between gap-4 overflow-hidden text-xs">
             <div className="shrink-0 text-grey-600">{t("Word count: {{words}}", { words })}</div>
             <DevMnemonicButton setValue={setValue} />
-            <div className="grow truncate text-right text-alert-warn">
+            <div
+              className="grow truncate text-right text-alert-warn"
+              data-testid="mnemonic-error-message"
+            >
               {errors.mnemonic?.message}
             </div>
           </div>

--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddPrivateKeyForm.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddPrivateKeyForm.tsx
@@ -161,7 +161,7 @@ export const AccountAddPrivateKeyForm = ({ onSuccess }: AccountAddPageProps) => 
   }, [fldPlatform.state.value, fldPrivateKey.state.value])
 
   return (
-    <div className="flex w-full flex-col gap-8">
+    <div className="flex w-full flex-col gap-8" data-testid="private-key-add-form">
       <HeaderBlock title={t("Import via Private Key")} />
 
       <form

--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddWatchedForm.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddWatchedForm.tsx
@@ -46,11 +46,18 @@ export const AccountAddWatchedForm = ({ onSuccess }: AccountAddPageProps) => {
         .test("is-valid-address", t("Invalid address"), (val, ctx) => {
           const { platform, address } = val
 
-          if (platform !== getAccountPlatformFromAddress(address))
+          try {
+            if (platform !== getAccountPlatformFromAddress(address))
+              return ctx.createError({
+                path: "address",
+                message: t("Invalid address"),
+              })
+          } catch {
             return ctx.createError({
               path: "address",
               message: t("Invalid address"),
             })
+          }
 
           return true
         })
@@ -220,6 +227,7 @@ export const AccountAddWatchedForm = ({ onSuccess }: AccountAddPageProps) => {
             primary
             disabled={!isValid}
             processing={isSubmitting}
+            data-testid="account-add-watched-button"
           >
             {t("Add")}
           </Button>

--- a/apps/extension/src/ui/domains/Account/AccountAdd/Container.tsx
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/Container.tsx
@@ -41,7 +41,7 @@ export const AccountCreateContainer = ({ className }: { className?: string }) =>
 
   return (
     <div className={cn("justify-left flex flex-col gap-8", className)}>
-      <div className="flex overflow-auto">
+      <div className="flex overflow-auto" data-testid="container-account-method">
         <MethodTypeTab
           icon={<PlusIcon />}
           title={t("New")}

--- a/apps/extension/src/ui/domains/Portfolio/GetStarted/GetStarted.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/GetStarted/GetStarted.tsx
@@ -49,7 +49,10 @@ export const GetStarted = () => {
   if (hasAccounts && isHidden) return null
 
   return (
-    <div className="@container relative flex w-full flex-col gap-8 rounded-sm bg-black-secondary p-8">
+    <div
+      className="@container relative flex w-full flex-col gap-8 rounded-sm bg-black-secondary p-8"
+      data-testid="section-get-started"
+    >
       {hasAccounts && (
         <IconButton
           className="absolute top-6 right-6 text-body-disabled enabled:focus-visible:text-body-secondary enabled:hover:text-body-secondary"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:e2e:ui": "pnpm exec playwright test --ui",
     "test:e2e:debug": "pnpm exec playwright test --debug",
     "test:e2e:trace": "pnpm exec playwright test --trace on && pnpm exec playwright show-report",
-    "test:e2e:stress": "pnpm exec playwright test --repeat-each=20 --workers 1 --trace on",
+    "test:e2e:stress": "pnpm exec playwright test --repeat-each=10 --workers 1 --trace on",
     "clean": "pnpm run -r --parallel clean & rm -rf .wxt dist coverage test-results playwright-report .turbo node_modules review & wait",
     "knip": "knip",
     "knip:fix": "knip --fix",

--- a/playwright/e2e-tests/accounts.spec.ts
+++ b/playwright/e2e-tests/accounts.spec.ts
@@ -1,0 +1,35 @@
+import { test } from "./fixtures"
+
+test("Import various account types", async ({
+  addNewAccount,
+  importAccount,
+  addWatchedAccount,
+  importPrivateKey,
+}) => {
+  await importAccount({ type: "ethereum" })
+  await importAccount({ type: "substrate" })
+  await importAccount({ type: "solana" })
+  await addNewAccount({ type: "ethereum" })
+  await addNewAccount({ type: "substrate" })
+  await addNewAccount({ type: "solana" })
+  await addWatchedAccount({
+    type: "substrate",
+    address: "5EYCAe5ijiYfyeZ2JJCGq56LmPyNRAKzpG4QkoQkkQNB5e6Z",
+    name: "Substrate Watched",
+  })
+  await addWatchedAccount({ type: "ethereum", address: "vitalik.eth", name: "Vitalik Watched" })
+  await addWatchedAccount({
+    type: "solana",
+    address: "5xJvx7YrqCqgyzxx4PQXt1AVbxioUsGABf2zevmYC8UL",
+    name: "Solana Watched",
+  })
+  await importPrivateKey({
+    type: "ethereum",
+    privateKey: "a7532a2d81f249c1018fcf6de4d00591e17d3d99bbc7f47af7720db72f61372f",
+  })
+  await importPrivateKey({
+    type: "solana",
+    privateKey:
+      "5ULDg64KAnVpPh4ganq476Zv2iybdT3JT2HBsaUoQuJqRUffkd845oWNzcKQU1QhqZqT6Z4jCDerrV9mbpShwnNK",
+  })
+})

--- a/playwright/e2e-tests/constants.ts
+++ b/playwright/e2e-tests/constants.ts
@@ -1,8 +1,0 @@
-export const DEFAULT_PASSWORD = "talismanwallet"
-export const NEW_ACC_NAME = "PW e2e - Fresh"
-export const ETH_ACC_NAME = "PW e2e - ETH"
-const _ETH_ACC_ADDRESS = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
-export const ETH_TEST_MNEMONIC = "test test test test test test test test test test test junk"
-export const DOT_ACC_NAME = "PW e2e - DOT"
-const _DOT_ACC_ADDRESS = "5GmS1wtCfR4tK5SSgnZbVT4kYw5W8NmxmijcsxCQE6oLW6A8"
-export const DOT_TEST_MNEMONIC = "test test test test test test test test test test test junk"

--- a/playwright/e2e-tests/fixtures.ts
+++ b/playwright/e2e-tests/fixtures.ts
@@ -9,7 +9,7 @@ type AccountType = "ethereum" | "substrate" | "solana"
 type WatchedAccountType = "ethereum" | "substrate" | "solana"
 type PrivateKeyAccountType = "ethereum" | "solana"
 
-export const randomName = (prefix: string) => {
+const randomName = (prefix: string) => {
   const suffix = xxhashAsHex(randomBytes(16)).slice("0x".length, "0x".length + 3)
   return `${prefix} (${suffix})`
 }

--- a/playwright/e2e-tests/fixtures.ts
+++ b/playwright/e2e-tests/fixtures.ts
@@ -1,11 +1,22 @@
+import { existsSync } from "node:fs"
+
 import { randomBytes } from "@noble/hashes/utils"
 import type { BrowserContext, Locator, Page } from "@playwright/test"
 import { test as base, chromium } from "@playwright/test"
 import { xxhashAsHex } from "@polkadot/util-crypto"
 
-import * as constants from "./constants"
+type AccountType = "ethereum" | "substrate" | "solana"
+type WatchedAccountType = "ethereum" | "substrate" | "solana"
+type PrivateKeyAccountType = "ethereum" | "solana"
 
-type AccountType = "ethereum" | "substrate"
+export const randomName = (prefix: string) => {
+  const suffix = xxhashAsHex(randomBytes(16)).slice("0x".length, "0x".length + 3)
+  return `${prefix} (${suffix})`
+}
+
+// Default values if nothing gets defined
+export const DEFAULT_PASSWORD = "talismanwallet"
+const DEFAULT_TEST_MNEMONIC = "test test test test test test test test test test test junk"
 
 export const test = base.extend<{
   context: BrowserContext
@@ -13,11 +24,23 @@ export const test = base.extend<{
   onboardedPage: Page
   importAccount: (opts: { type: AccountType; name?: string; mnemonic?: string }) => Promise<Page>
   addNewAccount: (opts: { type: AccountType; name?: string }) => Promise<Page>
+  addWatchedAccount: (opts: {
+    type: WatchedAccountType
+    address: string
+    name?: string
+  }) => Promise<Page>
+  importPrivateKey: (opts: {
+    type: PrivateKeyAccountType
+    privateKey: string
+    name?: string
+  }) => Promise<Page>
   walletPopup: (opts: { locator: Locator }) => Promise<Page>
 }>({
   // biome-ignore lint/correctness/noEmptyPattern: Playwright fixtures require destructuring pattern
   context: async ({}, utilize) => {
-    const pathToExtension = "./apps/extension/dist/chrome-mv3"
+    const prodPath = "./apps/extension/dist/chrome-mv3"
+    const devPath = "./apps/extension/dist/chrome-mv3-dev"
+    const pathToExtension = existsSync(prodPath) ? prodPath : devPath
     const context = await chromium.launchPersistentContext("", {
       headless: false,
       args: [
@@ -60,16 +83,17 @@ export const test = base.extend<{
     // Password validation
     await page.getByPlaceholder("Enter password").fill("12345")
     await expect(page.getByText("Password must be at least 6 characters long")).toBeVisible()
-    await page.getByPlaceholder("Enter password").fill(constants.DEFAULT_PASSWORD)
+    await page.getByPlaceholder("Enter password").fill(DEFAULT_PASSWORD)
     await page.getByPlaceholder("Confirm password").fill("wrong-confirmation-password")
     await expect(page.getByText("Passwords must match")).toBeVisible()
     await expect(page.getByTestId("onboarding-password-confirm-button")).toBeDisabled()
-    await page.getByPlaceholder("Confirm password").fill(constants.DEFAULT_PASSWORD)
+    await page.getByPlaceholder("Confirm password").fill(DEFAULT_PASSWORD)
     await page.getByTestId("onboarding-password-confirm-button").click()
     // accepting privacy terms
     await page.getByTestId("onboarding-privacy-accept-button").click()
     // Enter Talisman
     await page.getByTestId("onboarding-enter-talisman-button").click()
+    await expect(page.getByTestId("section-get-started")).toBeVisible({ timeout: 5000 })
     await utilize(page)
   },
 
@@ -80,26 +104,53 @@ export const test = base.extend<{
       name,
       mnemonic,
     }: {
-      type: "ethereum" | "substrate"
+      type: "ethereum" | "substrate" | "solana"
       name?: string
       mnemonic?: string
     }) => {
-      const accName =
-        name || (type === "ethereum" ? constants.ETH_ACC_NAME : constants.DOT_ACC_NAME)
-      const seed =
-        mnemonic ||
-        (type === "ethereum"
-          ? process.env.E2E_TESTS_MNEMONIC || constants.ETH_TEST_MNEMONIC
-          : process.env.E2E_TESTS_MNEMONIC || constants.DOT_TEST_MNEMONIC)
-
+      const defaultNames: Record<AccountType, string> = {
+        ethereum: randomName("PW e2e - ETH"),
+        substrate: randomName("PW e2e - DOT"),
+        solana: randomName("PW e2e - SOL"),
+      }
+      const accName = name || defaultNames[type]
+      const seed = mnemonic || process.env.E2E_TESTS_MNEMONIC || DEFAULT_TEST_MNEMONIC
       await onboardedPage.goto(
         `chrome-extension://${extensionId}/dashboard.html#/accounts/add/mnemonic`
       )
       await onboardedPage.getByTestId(`account-platform-selector-${type}`).click()
-      await onboardedPage.getByPlaceholder("Choose a name").fill(accName)
-      await onboardedPage.getByPlaceholder("Enter your 12 or 24 word recovery phrase").fill(seed)
-      await expect(onboardedPage.getByTestId("account-add-mnemonic-import-button")).toBeEnabled()
-      await onboardedPage.getByTestId("account-add-mnemonic-import-button").click()
+
+      const nameInput = onboardedPage.getByPlaceholder("Choose a name")
+      const mnemonicInput = onboardedPage.getByPlaceholder(
+        "Enter your 12 or 24 word recovery phrase"
+      )
+      const importButton = onboardedPage.getByTestId("account-add-mnemonic-import-button")
+
+      await nameInput.fill(accName)
+
+      const mnemonicError = onboardedPage.getByTestId("mnemonic-error-message")
+
+      // Try to submit a short seed phrase
+      await mnemonicInput.fill("test test test")
+      await expect(mnemonicError).toHaveText("Invalid recovery phrase")
+      await expect(importButton).toBeDisabled()
+
+      // Try to submit an invalid seed phrase
+      await mnemonicInput.fill("aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll")
+      await expect(mnemonicError).toHaveText("Invalid recovery phrase")
+      await expect(importButton).toBeDisabled()
+
+      // Try to submit a very long seed phrase
+      await mnemonicInput.fill(
+        "test test test test test test test test test test test test test test test test test test test test test test test test test"
+      )
+      await expect(mnemonicError).toHaveText("Invalid recovery phrase")
+      await expect(importButton).toBeDisabled()
+
+      // Try to submit a valid seed phrase
+      await mnemonicInput.fill(seed)
+      await expect(importButton).toBeEnabled()
+      await importButton.click()
       await expect(onboardedPage.getByTestId("top-actions-buttons")).toBeVisible()
       expect(onboardedPage.url()).toContain("portfolio")
       return onboardedPage
@@ -111,19 +162,17 @@ export const test = base.extend<{
       type,
       name,
     }: {
-      type: "ethereum" | "substrate"
+      type: "ethereum" | "substrate" | "solana"
       name?: string
     }) => {
-      // randomize the name of the account if not provided
-      const suffixLength = 3
-      const randomBuffer = randomBytes(16)
-      const getRandomChars = xxhashAsHex(randomBuffer).slice(
-        "0x".length,
-        "0x".length + suffixLength
-      )
-      const accName = name || `${constants.NEW_ACC_NAME} (${getRandomChars})`
+      const accName = name || randomName("PW - E2E - Fresh")
 
-      const convertedType = type === "substrate" ? "polkadot" : "ethereum"
+      const platformMap: Record<AccountType, string> = {
+        substrate: "polkadot",
+        ethereum: "ethereum",
+        solana: "solana",
+      }
+      const convertedType = platformMap[type]
 
       await onboardedPage.goto(
         `chrome-extension://${extensionId}/dashboard.html#/accounts/add/derived?platform=${convertedType}`
@@ -151,6 +200,68 @@ export const test = base.extend<{
       return onboardedPage
     }
     await utilize(addNewAccount)
+  },
+  addWatchedAccount: async ({ onboardedPage, extensionId }, utilize) => {
+    const addWatchedAccount = async ({
+      type,
+      address,
+      name,
+    }: {
+      type: WatchedAccountType
+      address: string
+      name?: string
+    }) => {
+      const accName = name || address
+
+      await onboardedPage.goto(`chrome-extension://${extensionId}/dashboard.html#/accounts/add/`)
+      await onboardedPage
+        .getByTestId("container-account-method")
+        .getByText("Add a Watched Account")
+        .click()
+      await onboardedPage.getByRole("button", { name: `Watch ${type} Account` }).click()
+      await onboardedPage.getByPlaceholder("Choose a name").fill(accName)
+      await onboardedPage.getByPlaceholder("Enter wallet address").fill(address)
+
+      const addButton = onboardedPage.getByTestId("account-add-watched-button")
+      await expect(addButton).toBeEnabled()
+      await addButton.click()
+
+      await expect(onboardedPage.getByTestId("top-actions-buttons")).toBeVisible()
+      expect(onboardedPage.url()).toContain("portfolio")
+      return onboardedPage
+    }
+    await utilize(addWatchedAccount)
+  },
+  importPrivateKey: async ({ onboardedPage, extensionId }, utilize) => {
+    const importPrivateKey = async ({
+      type,
+      privateKey,
+      name,
+    }: {
+      type: PrivateKeyAccountType
+      privateKey: string
+      name?: string
+    }) => {
+      const accName = name || randomName("PW - PrivKey")
+
+      await onboardedPage.goto(`chrome-extension://${extensionId}/dashboard.html#/accounts/add/pk`)
+
+      await onboardedPage.getByText("Select account platform").click()
+      const platformLabel = type === "ethereum" ? "Ethereum" : "Solana"
+      await onboardedPage.getByTestId("private-key-add-form").getByText(platformLabel).click()
+
+      await onboardedPage.getByPlaceholder("Choose a name").fill(accName)
+      await onboardedPage.getByPlaceholder("Enter your private key").fill(privateKey)
+
+      const saveButton = onboardedPage.getByRole("button", { name: "Save" })
+      await expect(saveButton).toBeEnabled()
+      await saveButton.click()
+
+      await expect(onboardedPage.getByTestId("top-actions-buttons")).toBeVisible()
+      expect(onboardedPage.url()).toContain("portfolio")
+      return onboardedPage
+    }
+    await utilize(importPrivateKey)
   },
   walletPopup: async ({ context }, utilize) => {
     const walletPopup = async ({ locator }: { locator: Locator }): Promise<Page> => {

--- a/playwright/e2e-tests/fresh.spec.ts
+++ b/playwright/e2e-tests/fresh.spec.ts
@@ -1,9 +1,0 @@
-import { DOT_ACC_NAME, ETH_ACC_NAME } from "./constants"
-import { test } from "./fixtures"
-
-test("Import accounts & add new ones", async ({ addNewAccount, importAccount }) => {
-  await importAccount({ type: "ethereum", name: ETH_ACC_NAME })
-  await importAccount({ type: "substrate", name: DOT_ACC_NAME })
-  await addNewAccount({ type: "ethereum" })
-  await addNewAccount({ type: "substrate" })
-})

--- a/playwright/e2e-tests/metamask-e2e.spec.ts
+++ b/playwright/e2e-tests/metamask-e2e.spec.ts
@@ -1,10 +1,11 @@
-import { ETH_ACC_NAME } from "./constants"
 import { expect, test } from "./fixtures"
+
+const ACCOUNT_NAME = "MM ETH"
 
 test("Access Metamask e2e DApp and connect wallet", async ({ importAccount, context }) => {
   // create an ethereum account for the test
-  const ethAccount = await importAccount({ type: "ethereum", name: ETH_ACC_NAME })
-  await expect(ethAccount.getByTestId("sidebar-account-list")).toContainText(ETH_ACC_NAME)
+  const ethAccount = await importAccount({ type: "ethereum", name: ACCOUNT_NAME })
+  await expect(ethAccount.getByTestId("sidebar-account-list")).toContainText(ACCOUNT_NAME)
   // access metamask test dapp
   await ethAccount.goto("https://metamask.github.io/test-dapp/")
   // wait for wallet popup to appear after clicking connect
@@ -17,7 +18,7 @@ test("Access Metamask e2e DApp and connect wallet", async ({ importAccount, cont
   await popup.waitForTimeout(5000)
   await popup.bringToFront()
   await popup.setViewportSize({ width: 400, height: 600 })
-  await popup.getByRole("button", { name: ETH_ACC_NAME }).click()
+  await popup.getByRole("button", { name: ACCOUNT_NAME }).click()
   await popup.getByTestId("connection-connect-button").click()
   // verify that the account is connected on metamask test dapp
   await expect(ethAccount.locator("#accounts")).toContainText("0x")

--- a/playwright/e2e-tests/password.spec.ts
+++ b/playwright/e2e-tests/password.spec.ts
@@ -1,0 +1,89 @@
+import { DEFAULT_PASSWORD, expect, test } from "./fixtures"
+
+const NEW_PASSWORD = "newpassword123"
+
+test.describe("Password management", () => {
+  test("Change password", async ({ onboardedPage, extensionId }) => {
+    test.setTimeout(120_000)
+
+    await test.step("Navigate to change password page", async () => {
+      await onboardedPage.goto(
+        `chrome-extension://${extensionId}/dashboard.html#/settings/security-privacy-settings/change-password`
+      )
+      await expect(onboardedPage.getByText("Change your password")).toBeVisible()
+    })
+
+    const oldPasswordInput = onboardedPage.getByPlaceholder("Enter Old Password")
+    const newPasswordInput = onboardedPage.getByPlaceholder("Enter New Password")
+    const confirmPasswordInput = onboardedPage.getByPlaceholder("Confirm New Password")
+    const submitButton = onboardedPage.getByRole("button", { name: "Submit" })
+
+    await test.step("Reject password shorter than 6 characters", async () => {
+      await oldPasswordInput.fill(DEFAULT_PASSWORD)
+      await newPasswordInput.fill("abc")
+      await expect(
+        onboardedPage.getByText("Password must be at least 6 characters long")
+      ).toBeVisible()
+      await expect(submitButton).toBeDisabled()
+    })
+
+    await test.step("Reject mismatched passwords", async () => {
+      await newPasswordInput.fill(NEW_PASSWORD)
+      await confirmPasswordInput.fill("doesnotmatch")
+      await expect(onboardedPage.getByText("Passwords must match")).toBeVisible()
+      await expect(submitButton).toBeDisabled()
+    })
+
+    await test.step("Reject incorrect old password", async () => {
+      await oldPasswordInput.fill("wrongpassword")
+      await newPasswordInput.fill(NEW_PASSWORD)
+      await confirmPasswordInput.fill(NEW_PASSWORD)
+      await expect(submitButton).toBeEnabled()
+      await submitButton.click()
+      await expect(onboardedPage.getByText("Incorrect password")).toBeVisible({ timeout: 10_000 })
+    })
+
+    await test.step("Change password with valid inputs", async () => {
+      await oldPasswordInput.fill(DEFAULT_PASSWORD)
+      await newPasswordInput.fill(NEW_PASSWORD)
+      await confirmPasswordInput.fill(NEW_PASSWORD)
+      await expect(submitButton).toBeEnabled()
+      await submitButton.click()
+
+      await expect(onboardedPage.getByText("Changing password")).toBeVisible()
+      await expect(onboardedPage.getByText("Password changed")).toBeVisible({ timeout: 30_000 })
+      await expect(onboardedPage).toHaveURL(/portfolio/)
+    })
+
+    await test.step("Verify new password works via lock and unlock", async () => {
+      const context = onboardedPage.context()
+
+      // Keep a blank page alive so the browser context survives when extension pages close on lock
+      const anchor = await context.newPage()
+      await anchor.goto("about:blank")
+
+      const popupPage = await context.newPage()
+      await popupPage.goto(`chrome-extension://${extensionId}/popup.html`)
+      await popupPage.setViewportSize({ width: 400, height: 600 })
+
+      // Open navigation drawer and lock the wallet
+      await popupPage.getByRole("button", { name: "More" }).click()
+      await popupPage.getByText("Lock Wallet").click()
+
+      // Extension pages close on lock — open a fresh popup to unlock
+      const loginPage = await context.newPage()
+      await loginPage.goto(`chrome-extension://${extensionId}/popup.html`)
+      await loginPage.setViewportSize({ width: 400, height: 600 })
+
+      await expect(loginPage.getByPlaceholder("Enter password")).toBeVisible()
+      await loginPage.getByPlaceholder("Enter password").fill(NEW_PASSWORD)
+      await loginPage.getByRole("button", { name: "Unlock" }).click()
+
+      await expect(loginPage.getByRole("button", { name: "Portfolio" })).toBeVisible({
+        timeout: 10_000,
+      })
+
+      await anchor.close()
+    })
+  })
+})

--- a/playwright/e2e-tests/testnet-transfers.spec.ts
+++ b/playwright/e2e-tests/testnet-transfers.spec.ts
@@ -1,11 +1,13 @@
-import { DOT_ACC_NAME, ETH_ACC_NAME } from "./constants"
 import { expect, test } from "./fixtures"
 import { testAssets } from "./transfers"
 
+const dotAccName = "DOT Transfer"
+const ethAccName = "ETH Transfer"
+
 test("Transfer Assets", async ({ importAccount, onboardedPage, walletPopup, extensionId }) => {
   test.setTimeout(120_000)
-  await importAccount({ type: "substrate", name: DOT_ACC_NAME })
-  await importAccount({ type: "ethereum", name: ETH_ACC_NAME })
+  await importAccount({ type: "substrate", name: dotAccName })
+  await importAccount({ type: "ethereum", name: ethAccName })
   await onboardedPage.goto(
     `chrome-extension://${extensionId}/dashboard.html#/settings/networks-tokens/networks`
   )
@@ -33,9 +35,9 @@ test("Transfer Assets", async ({ importAccount, onboardedPage, walletPopup, exte
   for (const data of testAssets) {
     await test.step(`Transferring ${data.assetName} on ${data.chain}`, async () => {
       if (data.chainType === "substrate") {
-        await onboardedPage.getByTestId("sidebar-account-list").getByText(DOT_ACC_NAME).click()
+        await onboardedPage.getByTestId("sidebar-account-list").getByText(dotAccName).click()
       } else {
-        await onboardedPage.getByTestId("sidebar-account-list").getByText(ETH_ACC_NAME).click()
+        await onboardedPage.getByTestId("sidebar-account-list").getByText(ethAccName).click()
       }
       const popup = await walletPopup({ locator: sendButton })
       // searches for the specific token by asset name, type and chain.


### PR DESCRIPTION
### Bug Fix

 - Watched accounts form — wrapped getAccountPlatformFromAddress in a try-catch inside yup validation to prevent "Unknown address encoding" errors when the address field is 
empty/invalid

### Test Infrastructure

 - Fixtures overhaul — refactored fixtures.ts with new helpers:
  - Extracted randomName() utility for generating unique account names
  - Added importPrivateKey fixture (Ethereum & Solana)
  - Simplified addWatchedAccount (removed unnecessary platform mapping)
  - Removed defaultMnemonics record (single constant fallback)
  - Auto-detect prod vs dev extension build path via existsSync
 - Removed constants.ts — inlined values into fixtures
 - Deleted fresh.spec.ts — removed old test

### New Tests

 - accounts.spec.ts — covers importing mnemonic, creating new, watched, and private key accounts across all supported chains
 - password.spec.ts — dedicated password validation tests

### Minor

 - Added/updated data-testid attributes in extension UI components
 - Simplified Metamask E2E test (local constant instead of import)