### PR TITLE
feat(chaindata-provider): support optional chaindataSlimUrl override

### DIFF
--- a/.changeset/quick-cars-pull.md
+++ b/.changeset/quick-cars-pull.md
@@ -1,0 +1,5 @@
+---
+"@talismn/chaindata-provider": minor
+---
+
+added optional chaindata slim url arg

--- a/packages/chaindata-provider/src/provider/ChaindataProvider.test.ts
+++ b/packages/chaindata-provider/src/provider/ChaindataProvider.test.ts
@@ -19,7 +19,7 @@ import { ChaindataProvider, type ChaindataStorage } from "./ChaindataProvider"
 let githubSubject: Subject<Chaindata>
 
 vi.mock("../state/githubChaindata", () => ({
-  get githubChaindata$() {
+  getGithubChaindata$() {
     return githubSubject
   },
 }))

--- a/packages/chaindata-provider/src/provider/ChaindataProvider.ts
+++ b/packages/chaindata-provider/src/provider/ChaindataProvider.ts
@@ -56,6 +56,7 @@ export type ChaindataProviderOptions = {
   persistedStorage?: ChaindataStorage | Promise<ChaindataStorage | undefined>
   customChaindata$?: Observable<CustomChaindata> | CustomChaindata
   dynamicTokens$?: ReplaySubject<Token[]>
+  chaindataSlimUrl?: string
 }
 
 export class ChaindataProvider implements IChaindataProvider {
@@ -67,6 +68,7 @@ export class ChaindataProvider implements IChaindataProvider {
     persistedStorage,
     customChaindata$,
     dynamicTokens$,
+    chaindataSlimUrl,
   }: ChaindataProviderOptions = {}) {
     tryToDeleteOldChaindataDb()
 
@@ -75,7 +77,7 @@ export class ChaindataProvider implements IChaindataProvider {
       ? persistedStorage.then((storage) => ({ ...DEFAULT_STORAGE, ...storage }))
       : { ...DEFAULT_STORAGE, ...persistedStorage }
     this.#storage$ = replaySubjectFrom(mergedStorage)
-    const defaultChaindata$ = getDefaultChaindata$(this.#storage$)
+    const defaultChaindata$ = getDefaultChaindata$(this.#storage$, chaindataSlimUrl)
 
     this.#dynamicTokens$ = replaySubjectFrom(dynamicTokens$ ?? [])
 

--- a/packages/chaindata-provider/src/state/defaultChaindata.test.ts
+++ b/packages/chaindata-provider/src/state/defaultChaindata.test.ts
@@ -21,7 +21,7 @@ import type { Chaindata } from "./schema"
 let mockGithubChaindata$: Subject<Chaindata>
 
 vi.mock("./githubChaindata", () => ({
-  get githubChaindata$() {
+  getGithubChaindata$() {
     return mockGithubChaindata$
   },
 }))

--- a/packages/chaindata-provider/src/state/defaultChaindata.ts
+++ b/packages/chaindata-provider/src/state/defaultChaindata.ts
@@ -3,13 +3,16 @@ import { firstValueFrom, map, Observable, type Subject, shareReplay } from "rxjs
 
 import log from "../log"
 import type { ChaindataStorage } from "../provider/ChaindataProvider"
-import { githubChaindata$ } from "./githubChaindata"
+import { getGithubChaindata$ } from "./githubChaindata"
 import initChaindata from "./initChaindata.json"
 import { type Chaindata, ChaindataFileSchema } from "./schema"
 
 const EMPTY_DATA: Chaindata = { networks: [], tokens: [], miniMetadatas: [] }
 
-export const getDefaultChaindata$ = (storage$: Subject<ChaindataStorage>) => {
+export const getDefaultChaindata$ = (
+  storage$: Subject<ChaindataStorage>,
+  chaindataUrl?: string
+) => {
   const storageValidated$ = storage$.pipe(
     map((data) => {
       const start = performance.now()
@@ -30,7 +33,7 @@ export const getDefaultChaindata$ = (storage$: Subject<ChaindataStorage>) => {
   )
 
   return new Observable<Chaindata>((subscriber) => {
-    const githubToStorageSubscription = githubChaindata$.subscribe({
+    const githubToStorageSubscription = getGithubChaindata$(chaindataUrl).subscribe({
       error: async () => {
         const storageData = await firstValueFrom(storageValidated$)
 

--- a/packages/chaindata-provider/src/state/githubChaindata.ts
+++ b/packages/chaindata-provider/src/state/githubChaindata.ts
@@ -8,33 +8,37 @@ const REFRESH_INTERVAL = 300_000 // 5 mins
 
 let lastUpdatedAt = 0
 
-export const githubChaindata$ = new Observable<Chaindata>((subscriber) => {
-  const controller = new AbortController()
-  subscriber.add(() => controller.abort())
+export const getGithubChaindata$ = (chaindataUrl?: string) =>
+  new Observable<Chaindata>((subscriber) => {
+    const controller = new AbortController()
+    subscriber.add(() => controller.abort())
 
-  let timeout: ReturnType<typeof setTimeout> | null = null
-  subscriber.add(() => timeout && clearTimeout(timeout))
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    subscriber.add(() => timeout && clearTimeout(timeout))
 
-  const refresh = async () => {
-    try {
-      const delay = Math.max(0, lastUpdatedAt + 60_000 - Date.now())
-      if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay))
-      if (controller.signal.aborted) return
+    const refresh = async () => {
+      try {
+        const delay = Math.max(0, lastUpdatedAt + 60_000 - Date.now())
+        if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay))
+        if (controller.signal.aborted) return
 
-      log.debug("[defaultChaindata$] Refreshing chaindata from GitHub")
-      const data = await fetchChaindata(controller.signal)
-      lastUpdatedAt = Date.now()
+        log.debug("[defaultChaindata$] Refreshing chaindata from GitHub")
+        const data = await fetchChaindata(controller.signal, chaindataUrl)
+        lastUpdatedAt = Date.now()
 
-      // data is already validated by fetchChaindata (net.ts)
-      subscriber.next(data)
-    } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") return
+        // data is already validated by fetchChaindata (net.ts)
+        subscriber.next(data)
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") return
 
-      log.error("Failed to fetch chaindata", error)
-      if (!subscriber.closed) subscriber.error(error)
-    } finally {
-      if (!controller.signal.aborted) timeout = setTimeout(refresh, REFRESH_INTERVAL)
+        log.error("Failed to fetch chaindata", error)
+        if (!subscriber.closed) subscriber.error(error)
+      } finally {
+        if (!controller.signal.aborted) timeout = setTimeout(refresh, REFRESH_INTERVAL)
+      }
     }
-  }
-  refresh()
-}).pipe(shareReplay({ bufferSize: 1, refCount: true }))
+    refresh()
+  }).pipe(shareReplay({ bufferSize: 1, refCount: true }))
+
+/** @deprecated Use getGithubChaindata$() instead */
+export const githubChaindata$ = getGithubChaindata$()

--- a/packages/chaindata-provider/src/state/net.ts
+++ b/packages/chaindata-provider/src/state/net.ts
@@ -64,5 +64,5 @@ const fetchJsonFromGithubUrl = async <T>(
 }
 
 // export because of generate-init-data script
-export const fetchChaindata = (signal?: AbortSignal) =>
-  fetchJsonFromGithubUrl(CHAINDATA_CONSOLIDATED_URL, { schema: ChaindataFileSchema, signal })
+export const fetchChaindata = (signal?: AbortSignal, url?: string) =>
+  fetchJsonFromGithubUrl(url ?? CHAINDATA_CONSOLIDATED_URL, { schema: ChaindataFileSchema, signal })


### PR DESCRIPTION
Allow ChaindataProvider consumers to pass a custom that replaces the default consolidated chaindata URL when fetching.

- Add  to ChaindataProviderOptions
- Thread the URL through getDefaultChaindata$ → getGithubChaindata$ → fetchChaindata
- Convert githubChaindata$ singleton into getGithubChaindata$ factory
- Remove stray console.log from net.ts