### PR TITLE
fix: dev improvements

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,6 @@
-pnpm biome check --staged --error-on-warnings --no-errors-on-unmatched
+# Auto-fix formatter issues and re-stage the fixed files
+pnpm biome format --staged --write --no-errors-on-unmatched
+git update-index --again
+
+# Block the commit on lint issues
+pnpm biome lint --staged --error-on-warnings --no-errors-on-unmatched

--- a/apps/extension/src/core/domains/app/store.settings.ts
+++ b/apps/extension/src/core/domains/app/store.settings.ts
@@ -83,4 +83,18 @@ if (DEBUG) {
       return { ...prev, disableBalanceFetching: next }
     })
   }
+
+  // Warn loudly on every startup if balance fetching has been disabled
+  settingsStore.get().then((settings) => {
+    if (settings.disableBalanceFetching) {
+      // biome-ignore lint/suspicious/noConsole: dev helper
+      console.warn(
+        "%c ⚠️ BALANCE FETCHING IS DISABLED ⚠️ %c\nLive balance updates are turned off. Cached/stale balances will be shown instead.\nRun %ctoggleBalanceFetching()%c in this console to re-enable.",
+        "background: #ff4400; color: white; font-size: 16px; font-weight: bold; padding: 8px 12px; border-radius: 4px;",
+        "font-size: 13px; padding: 4px 0;",
+        "background: #333; color: #0f0; font-size: 13px; padding: 2px 6px; border-radius: 3px;",
+        "font-size: 13px;"
+      )
+    }
+  })
 }


### PR DESCRIPTION
1. The pre-commit hook will now just format any unformatted code instead of complaining about it,
    but it still blocks and complains if there's any lint errors.
3. Added a console warning during development when balance fetching is disabled, so it's easier to notice.