### PR TITLE
fix: vertical alignment of balance title in portfolio when a single account is selected

### DIFF
--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/AssetState.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/AssetState.tsx
@@ -22,7 +22,7 @@ export const AssetState = ({
 }: AssetStateProps) => {
   if (!render) return null
   return (
-    <div className="flex flex-col justify-center gap-2 overflow-hidden p-8">
+    <div className="flex h-full flex-col justify-center gap-2 overflow-hidden p-8">
       <div className="flex w-full items-baseline gap-4 overflow-hidden">
         <div className="shrink-0 whitespace-nowrap font-bold text-white capitalize">{title}</div>
         {/* show description next to title when address is set */}


### PR DESCRIPTION
This one's been slowly killing me for... months? years? :rofl:

#### Before
<img width="975" height="302" alt="Screenshot_2026-04-23_at_18 22 43" src="https://github.com/user-attachments/assets/f835a015-739e-432c-bc94-4241bd4607ea" />

#### After
<img width="961" height="297" alt="Screenshot_2026-04-23_at_18 31 30" src="https://github.com/user-attachments/assets/4dcf8b03-be8b-43da-b056-5643ba79ef45" />
