### PR TITLE
feat: added Keyring methods for mobile app compatibility

### DIFF
--- a/.changeset/fair-eagles-serve.md
+++ b/.changeset/fair-eagles-serve.md
@@ -1,0 +1,5 @@
+---
+"@talismn/keyring": patch
+---
+
+feat: added Keyring methods for mobile app compatibility

--- a/packages/keyring/src/keyring/Keyring.ts
+++ b/packages/keyring/src/keyring/Keyring.ts
@@ -83,6 +83,39 @@ export class Keyring {
     }
   }
 
+  /** Returns true if a password has been set on this keyring. */
+  public hasPassword(): boolean {
+    return this.#data.passwordCheck !== null
+  }
+
+  /**
+   * Verify a password against the keyring's passwordCheck blob.
+   * Returns true on success, false on wrong password.
+   * Throws if no password has been set (caller should check hasPassword() first).
+   */
+  public async verifyPassword(password: string): Promise<boolean> {
+    if (!this.#data.passwordCheck) {
+      throw new Error("No password set — call hasPassword() before verifyPassword()")
+    }
+    try {
+      await this.checkPassword(password)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Initialize the password on a fresh keyring that has no password set.
+   * Throws if a password is already set (use changePassword flow instead).
+   */
+  public async initializePassword(password: string): Promise<void> {
+    if (this.#data.passwordCheck !== null) {
+      throw new Error("Password already set — cannot re-initialize")
+    }
+    await this.checkPassword(password, true)
+  }
+
   public toJson() {
     return structuredClone(this.#data)
   }


### PR DESCRIPTION
Added 3 self-explanatory methods:

- `Keyring::hasPassword`
- `Keyring::verifyPassword`
- `Keyring::initializePassword`

`hasPassword` so we can determine if a password has already been set in the keyring (to show onboarding or not)
`verifyPassword` so we can test if an entered password is correct (when unlocking the wallet)
`initializePassword` so we can set a password but skip account onboarding