### PR TITLE
chore: tidy up packages

### DIFF
--- a/.changeset/grumpy-eels-cough.md
+++ b/.changeset/grumpy-eels-cough.md
@@ -1,0 +1,7 @@
+---
+"@talismn/chain-connectors": patch
+"@talismn/balances": patch
+"@talismn/sapi": patch
+---
+
+chore: remove @polkadot/util and @polkadot/util-crypto

--- a/packages/balances/package.json
+++ b/packages/balances/package.json
@@ -52,7 +52,6 @@
   "devDependencies": {
     "@polkadot/api-contract": "16.1.2",
     "@polkadot/types": "16.1.2",
-    "@polkadot/util": "13.5.3",
     "@talismn/tsconfig": "workspace:*",
     "@types/lodash-es": "4.17.12",
     "typescript": "^5.6.3"
@@ -60,8 +59,6 @@
   "peerDependencies": {
     "@polkadot/api-contract": "*",
     "@polkadot/types": "*",
-    "@polkadot/util": "*",
-    "@polkadot/util-crypto": "*",
     "@substrate/txwrapper-core": "*"
   },
   "types": "./dist/index.d.ts",

--- a/packages/balances/src/modules/substrate-psp22/fetchTokens.ts
+++ b/packages/balances/src/modules/substrate-psp22/fetchTokens.ts
@@ -1,6 +1,5 @@
 import { Abi } from "@polkadot/api-contract"
 import { TypeRegistry } from "@polkadot/types"
-import { hexToNumber, u8aToString } from "@polkadot/util"
 import {
   type SubPsp22Token,
   SubPsp22TokenSchema,
@@ -13,6 +12,9 @@ import type { IBalanceModule } from "../../types/IBalanceModule"
 import psp22Abi from "../abis/psp22.json"
 import type { MODULE_TYPE, TokenConfig } from "./config"
 import { makeContractCaller } from "./util"
+
+const hexToNumber = (hex: string): number => Number(hex)
+const u8aToString = (value: Uint8Array): string => new TextDecoder().decode(value)
 
 export const fetchTokens: IBalanceModule<typeof MODULE_TYPE, TokenConfig>["fetchTokens"] = async ({
   networkId,

--- a/packages/balances/src/modules/substrate-psp22/util.ts
+++ b/packages/balances/src/modules/substrate-psp22/util.ts
@@ -1,7 +1,20 @@
 import type { TypeRegistry } from "@polkadot/types"
 import type { ContractExecResult } from "@polkadot/types/interfaces"
-import { u8aConcatStrict, u8aToHex } from "@polkadot/util"
 import type { IChainConnectorDot } from "@talismn/chain-connectors"
+
+const u8aToHex = (value: Uint8Array): `0x${string}` =>
+  `0x${Array.from(value, (b) => b.toString(16).padStart(2, "0")).join("")}` as `0x${string}`
+
+const u8aConcatStrict = (arrays: readonly Uint8Array[]): Uint8Array => {
+  const length = arrays.reduce((total, arr) => total + arr.length, 0)
+  const result = new Uint8Array(length)
+  let offset = 0
+  for (const arr of arrays) {
+    result.set(arr, offset)
+    offset += arr.length
+  }
+  return result
+}
 
 export const makeContractCaller =
   ({

--- a/packages/chain-connectors/package.json
+++ b/packages/chain-connectors/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@polkadot/rpc-provider": "16.1.2",
-    "@polkadot/util": "13.5.3",
     "@polkadot/x-global": "13.5.3",
     "@polkadot/x-ws": "13.5.3",
     "@talismn/tsconfig": "workspace:*",
@@ -46,7 +45,6 @@
   },
   "peerDependencies": {
     "@polkadot/rpc-provider": "*",
-    "@polkadot/util": "*",
     "@polkadot/x-global": "*",
     "@polkadot/x-ws": "*"
   },

--- a/packages/chain-connectors/src/dot/Websocket.ts
+++ b/packages/chain-connectors/src/dot/Websocket.ts
@@ -7,13 +7,16 @@ import type {
   ProviderInterfaceEmitCb,
 } from "@polkadot/rpc-provider/types"
 import { getWSErrorString } from "@polkadot/rpc-provider/ws/errors"
-import { isChildClass, isNull, isUndefined, objectSpread } from "@polkadot/util"
 import { xglobal } from "@polkadot/x-global"
 import { WebSocket } from "@polkadot/x-ws"
 import EventEmitter from "eventemitter3"
 
 import log from "../log"
 import { ExponentialBackoff } from "./helpers"
+
+// biome-ignore lint/complexity/noBannedTypes: checking class hierarchy
+const isChildClass = (Parent: Function, Child: Function | undefined | null): boolean =>
+  Child != null && (Child === Parent || Child.prototype instanceof Parent)
 
 type ProviderInterfaceEmitted = PjsProviderInterfaceEmitted | "stale-rpcs"
 
@@ -389,7 +392,7 @@ export class Websocket implements ProviderInterface {
     // the assigned id now does not match what the API user originally received. It has
     // a slight complication in solving - since we cannot rely on the send id, but rather
     // need to find the actual subscription id to map it
-    if (isUndefined(this.#subscriptions[subscription])) {
+    if (this.#subscriptions[subscription] === undefined) {
       // log.debug(() => `Unable to find active subscription=${subscription}`)
 
       return false
@@ -398,7 +401,7 @@ export class Websocket implements ProviderInterface {
     delete this.#subscriptions[subscription]
 
     try {
-      return this.isConnected && !isNull(this.#websocket) ? this.send<boolean>(method, [id]) : true
+      return this.isConnected && this.#websocket !== null ? this.send<boolean>(method, [id]) : true
     } catch {
       return false
     }
@@ -462,7 +465,7 @@ export class Websocket implements ProviderInterface {
       const response = JSON.parse(message.data) as UnknownJsonRpcResponse
 
       // biome-ignore lint/correctness/noVoidTypeReturn: legacy
-      return isUndefined(response.method)
+      return response.method === undefined
         ? this.#onSocketMessageResult(response)
         : this.#onSocketMessageSubscribe(response)
     } catch (e) {
@@ -490,10 +493,7 @@ export class Websocket implements ProviderInterface {
       if (subscription) {
         const subId = `${subscription.type}::${result}`
 
-        this.#subscriptions[subId] = objectSpread({}, subscription, {
-          method,
-          params,
-        })
+        this.#subscriptions[subId] = { ...subscription, method, params }
 
         // if we have a result waiting for this subscription already
         if (this.#waitingForId[subId]) {

--- a/packages/sapi/package.json
+++ b/packages/sapi/package.json
@@ -33,7 +33,6 @@
     "@polkadot-api/utils": "0.2.0",
     "@polkadot/types": "16.1.2",
     "@polkadot/types-codec": "16.1.2",
-    "@polkadot/util": "13.5.3",
     "@talismn/scale": "workspace:*",
     "anylogger": "^1.0.11",
     "polkadot-api": "1.23.3",

--- a/packages/sapi/src/helpers/getExtrinsicDispatchInfo.ts
+++ b/packages/sapi/src/helpers/getExtrinsicDispatchInfo.ts
@@ -1,9 +1,7 @@
 import type { GenericExtrinsic } from "@polkadot/types"
 import type { RuntimeDispatchInfo } from "@polkadot/types/interfaces"
 import type { Codec } from "@polkadot/types-codec/types"
-import { assert, u8aConcatStrict } from "@polkadot/util"
-import type { HexString } from "@polkadot/util/types"
-
+import { mergeUint8 } from "@polkadot-api/utils"
 import type { JsonRpcRequestSend } from "../types"
 import type { Chain } from "./types"
 
@@ -16,7 +14,8 @@ export const getExtrinsicDispatchInfo = async (
   chain: Chain,
   signedExtrinsic: GenericExtrinsic
 ): Promise<ExtrinsicDispatchInfo> => {
-  assert(signedExtrinsic.isSigned, "Extrinsic must be signed (or fakeSigned) in order to query fee")
+  if (!signedExtrinsic.isSigned)
+    throw new Error("Extrinsic must be signed (or fakeSigned) in order to query fee")
 
   const len = signedExtrinsic.registry.createType("u32", signedExtrinsic.encodedLength)
 
@@ -39,13 +38,13 @@ const stateCall = async <K extends string = string>(
   method: string,
   resultType: K,
   args: Codec[],
-  blockHash?: HexString,
+  blockHash?: `0x${string}`,
   isCacheable?: boolean
 ) => {
   // on a state call there are always arguments
   const registry = args[0].registry
 
-  const bytes = registry.createType("Raw", u8aConcatStrict(args.map((arg) => arg.toU8a())))
+  const bytes = registry.createType("Raw", mergeUint8(...args.map((arg) => arg.toU8a())))
 
   const result = await request("state_call", [method, bytes.toHex(), blockHash], isCacheable)
 

--- a/packages/sapi/src/helpers/getSignerPayloadJSON.ts
+++ b/packages/sapi/src/helpers/getSignerPayloadJSON.ts
@@ -1,5 +1,4 @@
 import type { SignerPayloadJSON } from "@polkadot/types/types"
-import { u8aToHex } from "@polkadot/util"
 import { mergeUint8, toHex } from "@polkadot-api/utils"
 import { Binary } from "polkadot-api"
 
@@ -81,7 +80,7 @@ export const getSignerPayloadJSON = async (
   }
 
   const { payload, txMetadata } = getPayloadWithMetadataHash(chain, chainInfo, basePayload)
-  const shortMetadata = txMetadata ? u8aToHex(txMetadata) : undefined
+  const shortMetadata = txMetadata ? (toHex(txMetadata) as `0x${string}`) : undefined
 
   // Avail support
   if (payload.signedExtensions.includes("CheckAppId"))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,9 +712,6 @@ importers:
       '@polkadot-api/utils':
         specifier: 0.2.0
         version: 0.2.0
-      '@polkadot/util-crypto':
-        specifier: 13.5.3
-        version: 13.5.3(@polkadot/util@13.5.3)
       '@solana/spl-token':
         specifier: ^0.4.13
         version: 0.4.13(@solana/web3.js@1.98.4(bufferutil@4.0.8)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -779,9 +776,6 @@ importers:
       '@polkadot/types':
         specifier: 16.1.2
         version: 16.1.2
-      '@polkadot/util':
-        specifier: 13.5.3
-        version: 13.5.3
       '@talismn/tsconfig':
         specifier: workspace:*
         version: link:../../config/tsconfig
@@ -822,9 +816,6 @@ importers:
       '@polkadot/rpc-provider':
         specifier: 16.1.2
         version: 16.1.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@polkadot/util':
-        specifier: 13.5.3
-        version: 13.5.3
       '@polkadot/x-global':
         specifier: 13.5.3
         version: 13.5.3
@@ -1036,9 +1027,6 @@ importers:
       '@polkadot/types-codec':
         specifier: 16.1.2
         version: 16.1.2
-      '@polkadot/util':
-        specifier: 13.5.3
-        version: 13.5.3
       '@talismn/scale':
         specifier: workspace:*
         version: link:../scale
@@ -6546,7 +6534,7 @@ packages:
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '>=8.17.1'
+      ws: '>=7.5.10'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}


### PR DESCRIPTION
Removes `@polakdot/util` and `@polkadot/util-crypto` from the balances packages, meaning downstream consumers don't need to bloat their apps with their (surprisingly large, since they pull in `@polkadot/wasm-crypto`) contribution to the bundle size.