### PR TITLE
fix: lifi swap module filters

### DIFF
--- a/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
+++ b/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
@@ -410,7 +410,13 @@ const TokensList: FC<TokensListProps> = ({
 
     return networkFilteredTokens
       .filter((t) =>
-        matchesSearchTerms(searchTerms, [t.token.symbol, t.token.name, t.chainNameSearch])
+        matchesSearchTerms(searchTerms, [
+          t.token.symbol,
+          t.token.name,
+          t.chainNameSearch,
+          "contractAddress" in t.token ? t.token.contractAddress : undefined,
+          "mintAddress" in t.token ? t.token.mintAddress : undefined,
+        ])
       )
       .sort((t1, t2) => {
         const s1 = t1.token.symbol.toLowerCase()

--- a/apps/extension/src/ui/domains/Swap/components/SelectTokenButton.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SelectTokenButton.tsx
@@ -1,4 +1,4 @@
-import type { Token, TokenId } from "@talismn/chaindata-provider"
+import { isTokenInTypes, type Token, type TokenId } from "@talismn/chaindata-provider"
 import { AlertTriangleIcon, ChevronDownIcon, PlusIcon } from "@talismn/icons"
 import { Button } from "@ui/components/Button"
 import { Drawer } from "@ui/components/Drawer"
@@ -105,6 +105,16 @@ const TokenPickerModalContent: FC<{
     [filterByTab, allowedTokenIds]
   )
 
+  const assetIdSet = useMemo(() => new Set(filteredTokenIds), [filteredTokenIds])
+
+  // Also show any EVM ERC-20 or Solana SPL/Token2022 token so users can attempt
+  // LI.FI routes for tokens not in the default list (e.g. RWAs).
+  const tokenFilter = useCallback(
+    (token: Token) =>
+      assetIdSet.has(token.id) || isTokenInTypes(token, ["evm-erc20", "sol-spl", "sol-token2022"]),
+    [assetIdSet]
+  )
+
   const handleSelectTokenId = useCallback(
     (tokenId: string, acceptWarning?: boolean) => {
       if (!acceptWarning && !acknowledgedTokenIds.has(tokenId)) {
@@ -125,9 +135,6 @@ const TokenPickerModalContent: FC<{
     },
     [safeTokens, tokensMap, onSelect, acknowledgedTokenIds, acknowledgeToken]
   )
-
-  const assetIdSet = useMemo(() => new Set(filteredTokenIds), [filteredTokenIds])
-  const tokenFilter = useCallback((token: Token) => assetIdSet.has(token.id), [assetIdSet])
 
   return (
     <WizardModalDialog
@@ -190,11 +197,11 @@ const OpenSelectorButton = ({
 
   return (
     <BaseButton onClick={onClick}>
-      <div className="relative h-[32px] w-[32px] shrink-0">
+      <div className="relative size-16 shrink-0">
         <TokenLogo tokenId={token.id} className="size-16" />
         <NetworkLogo
           networkId={token.networkId} // TODO remove cast once we have a correctly typed networkId
-          className="absolute -right-[2px] -bottom-[2px] h-[14px] w-[14px] rounded-full border-[1.5px] border-grey-900"
+          className="absolute -right-1 -bottom-1 size-7 rounded-full border-[1.5px] border-grey-900"
         />
       </div>
       <div className="flex flex-col items-start gap-1 overflow-hidden">

--- a/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/lifi-custom-address-token.spec.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/lifi-custom-address-token.spec.ts
@@ -82,13 +82,13 @@ vi.mock("@ui/state/chaindata", () => ({
   getNetworksMapById$: vi.fn(({ platform }: { platform: string }) =>
     of(platform === "ethereum" ? { "1": ethereumNetwork } : {})
   ),
-  getToken$: vi.fn(() => of(nativeToken)),
+  getToken$: vi.fn((id: string) => of(id === CUSTOM_ID ? customToken : nativeToken)),
   getTokensMap$: vi.fn(({ platform }: { platform: string }) =>
     of(platform === "ethereum" ? { [NATIVE_ID]: nativeToken, [CUSTOM_ID]: customToken } : {})
   ),
 }))
 
-const { addKnownLifiToken, lifiSwapModule } = await import("../lifi-swap-module")
+const { lifiSwapModule } = await import("../lifi-swap-module")
 
 const makeRoute = (): Route =>
   ({
@@ -142,11 +142,11 @@ const makeRoute = (): Route =>
   }) as unknown as Route
 
 describe("lifi custom address tokens", () => {
-  it("adds a known ERC-20 as a LI.FI candidate and routes by address", async () => {
+  it("resolves an unlisted ERC-20 on-the-fly and routes by address", async () => {
     const signal = new AbortController().signal
 
-    addKnownLifiToken(customToken)
-
+    // The custom token is an ERC-20 on an EVM chain known to LI.FI,
+    // so getLifiAssetIds includes it even though it's not in LI.FI's default list.
     await expect(lifiSwapModule.getFromAssets(signal)).resolves.toContain(CUSTOM_ID)
 
     mockLifiGetRoutes.mockResolvedValue({

--- a/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/lifi-custom-address-token.spec.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/lifi-custom-address-token.spec.ts
@@ -1,0 +1,177 @@
+import type { Route, RoutesResponse } from "@lifi/types"
+import { type EvmErc20Token, evmErc20TokenId } from "@talismn/chaindata-provider"
+import { describe, expect, it, vi } from "vitest"
+
+const CUSTOM_ADDRESS = "0x96f6ef951840721adbf46ac996b59e0235cb985c"
+const CUSTOM_ID = evmErc20TokenId("1", CUSTOM_ADDRESS)
+const NATIVE_ID = "1:evm-native"
+
+const customToken = {
+  id: CUSTOM_ID,
+  type: "evm-erc20",
+  platform: "ethereum",
+  networkId: "1",
+  contractAddress: CUSTOM_ADDRESS,
+  decimals: 18,
+  symbol: "USDY",
+  name: "Ondo U.S. Dollar Yield",
+  __isCustom: false,
+} as EvmErc20Token & { __isCustom: boolean }
+
+const nativeToken = {
+  id: NATIVE_ID,
+  type: "evm-native",
+  platform: "ethereum",
+  networkId: "1",
+  decimals: 18,
+  symbol: "ETH",
+}
+
+const ethereumNetwork = {
+  id: "1",
+  name: "Ethereum",
+  platform: "ethereum",
+  nativeTokenId: NATIVE_ID,
+}
+
+const mockLifiGetRoutes = vi.fn()
+
+vi.mock("@lifi/sdk", () => ({
+  createConfig: vi.fn(),
+  getRoutes: (...args: unknown[]) => mockLifiGetRoutes(...args),
+  getStepTransaction: vi.fn(),
+  getTokens: vi.fn().mockResolvedValue({
+    tokens: {
+      "1": [
+        {
+          address: "0x0000000000000000000000000000000000000000",
+          chainId: 1,
+          decimals: 18,
+          symbol: "ETH",
+          name: "Ether",
+        },
+      ],
+    },
+  }),
+  getToken: vi.fn(),
+  ChainType: { EVM: "EVM", SVM: "SVM" },
+}))
+
+vi.mock("@core/domains/app/store.remoteConfig", () => ({
+  remoteConfigStore: {
+    get: vi.fn().mockResolvedValue({
+      lifi: { solanaChainId: 1151111081099710 },
+      lifiTalismanTokens: [],
+      lifiCustomFeeTokens: {},
+    }),
+  },
+}))
+
+vi.mock("@ui/domains/Ethereum/usePublicClient", () => ({
+  getExtensionPublicClient: vi.fn(() => ({})),
+}))
+
+vi.mock("../../hooks/useSwapSlippage", () => ({
+  getSwapSlippageDecimal: vi.fn().mockResolvedValue(0.005),
+}))
+
+const { of } = await import("rxjs")
+
+vi.mock("@ui/state/chaindata", () => ({
+  getNetworkById$: vi.fn(() => of(ethereumNetwork)),
+  getNetworksMapById$: vi.fn(({ platform }: { platform: string }) =>
+    of(platform === "ethereum" ? { "1": ethereumNetwork } : {})
+  ),
+  getToken$: vi.fn(() => of(nativeToken)),
+  getTokensMap$: vi.fn(({ platform }: { platform: string }) =>
+    of(platform === "ethereum" ? { [NATIVE_ID]: nativeToken, [CUSTOM_ID]: customToken } : {})
+  ),
+}))
+
+const { addKnownLifiToken, lifiSwapModule } = await import("../lifi-swap-module")
+
+const makeRoute = (): Route =>
+  ({
+    id: "manual-token-route",
+    fromChainId: 1,
+    toChainId: 1,
+    fromAmount: "1000",
+    fromAmountUSD: "1.00",
+    toAmount: "900",
+    toAmountMin: "890",
+    toAmountUSD: "0.89",
+    gasCostUSD: "0.01",
+    containsSwitchChain: false,
+    steps: [
+      {
+        id: "step-1",
+        type: "lifi",
+        tool: "kyberswap",
+        toolDetails: { key: "kyberswap", name: "Kyberswap", logoURI: "https://logo" },
+        action: {
+          fromChainId: 1,
+          toChainId: 1,
+          fromAmount: "1000",
+          fromToken: {
+            address: CUSTOM_ADDRESS,
+            chainId: 1,
+            decimals: 18,
+            symbol: "USDY",
+          },
+          toToken: {
+            address: "0x0000000000000000000000000000000000000000",
+            chainId: 1,
+            decimals: 18,
+            symbol: "ETH",
+          },
+        },
+        estimate: {
+          tool: "kyberswap",
+          fromAmount: "1000",
+          toAmount: "900",
+          toAmountMin: "890",
+          executionDuration: 10,
+          feeCosts: [],
+          gasCosts: [],
+        },
+        includedSteps: [],
+      },
+    ],
+    insurance: { state: "NOT_INSURABLE", feeAmountUsd: "0" },
+    tags: [],
+  }) as unknown as Route
+
+describe("lifi custom address tokens", () => {
+  it("adds a known ERC-20 as a LI.FI candidate and routes by address", async () => {
+    const signal = new AbortController().signal
+
+    addKnownLifiToken(customToken)
+
+    await expect(lifiSwapModule.getFromAssets(signal)).resolves.toContain(CUSTOM_ID)
+
+    mockLifiGetRoutes.mockResolvedValue({
+      routes: [makeRoute()],
+      unavailableRoutes: { failed: [], filteredOut: [] },
+    } satisfies RoutesResponse)
+
+    const result = await lifiSwapModule.getQuote(
+      {
+        fromTokenId: CUSTOM_ID,
+        toTokenId: NATIVE_ID,
+        fromAmount: 1000n,
+        fromAddress: "0x70045A9F59A354550EC0272f73AAe03B01Fb8a7a",
+        toAddress: "0x70045A9F59A354550EC0272f73AAe03B01Fb8a7a",
+      },
+      signal
+    )
+
+    expect(result).not.toBeNull()
+    expect(mockLifiGetRoutes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromTokenAddress: CUSTOM_ADDRESS,
+        toTokenAddress: "0x0000000000000000000000000000000000000000",
+      }),
+      { signal }
+    )
+  })
+})

--- a/apps/extension/src/ui/domains/Swap/swap-modules/lifi-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/lifi-swap-module.ts
@@ -162,19 +162,23 @@ const lifiAssetFromSolToken = async (token: SolToken): Promise<LifiInternalAsset
   },
 })
 
-export const addKnownLifiToken = (token: EvmErc20Token) => {
-  const asset = lifiAssetFromErc20(token)
-  assetsByTokenId.set(asset.tokenId, asset)
+const resolveOrBuildAsset = async (tokenId: string): Promise<LifiInternalAsset | null> => {
+  const cached = resolveAsset(tokenId)
+  if (cached) return cached
 
-  cachedAssetsPromise = (cachedAssetsPromise ?? fetchLifiAssets())
-    .then((assets) => {
-      assetsByTokenId.set(asset.tokenId, asset)
-      return [...assets.filter((item) => item.tokenId !== asset.tokenId), asset]
-    })
-    .catch((err) => {
-      cachedAssetsPromise = null
-      throw err
-    })
+  const token = await firstValueFrom(getToken$(tokenId))
+  if (token?.type === "evm-erc20") {
+    const asset = lifiAssetFromErc20(token as EvmErc20Token)
+    assetsByTokenId.set(tokenId, asset)
+    return asset
+  }
+  if (token?.type === "sol-spl" || token?.type === "sol-token2022") {
+    const asset = await lifiAssetFromSolToken(token as SolToken)
+    assetsByTokenId.set(tokenId, asset)
+    return asset
+  }
+
+  return null
 }
 
 const getLifiAssets = async (_signal: AbortSignal): Promise<LifiInternalAsset[]> => {
@@ -323,32 +327,12 @@ const getRoutes = async (
     if (!fromTokenId || !toTokenId || !fromAmount) return null
     if (signal.aborted) return null
 
-    let fromAsset = resolveAsset(fromTokenId)
-    let toAsset = resolveAsset(toTokenId)
-
     // For tokens not in LI.FI's default list, construct the asset
     // from chaindata so the contract address is passed directly to the SDK.
-    if (!fromAsset) {
-      const token = await firstValueFrom(getToken$(fromTokenId))
-      if (token?.type === "evm-erc20") {
-        fromAsset = lifiAssetFromErc20(token as EvmErc20Token)
-        assetsByTokenId.set(fromTokenId, fromAsset)
-      } else if (token?.type === "sol-spl" || token?.type === "sol-token2022") {
-        fromAsset = await lifiAssetFromSolToken(token as SolToken)
-        assetsByTokenId.set(fromTokenId, fromAsset)
-      }
-    }
-    if (!toAsset) {
-      const token = await firstValueFrom(getToken$(toTokenId))
-      if (token?.type === "evm-erc20") {
-        toAsset = lifiAssetFromErc20(token as EvmErc20Token)
-        assetsByTokenId.set(toTokenId, toAsset)
-      } else if (token?.type === "sol-spl" || token?.type === "sol-token2022") {
-        toAsset = await lifiAssetFromSolToken(token as SolToken)
-        assetsByTokenId.set(toTokenId, toAsset)
-      }
-    }
-
+    const [fromAsset, toAsset] = await Promise.all([
+      resolveOrBuildAsset(fromTokenId),
+      resolveOrBuildAsset(toTokenId),
+    ])
     if (!fromAsset || !toAsset) return null
 
     const SWAP_PLACEHOLDER_ADDRESS = "0x70045A9F59A354550EC0272f73AAe03B01Fb8a7a"

--- a/apps/extension/src/ui/domains/Swap/swap-modules/lifi-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/lifi-swap-module.ts
@@ -1,10 +1,17 @@
 import { remoteConfigStore } from "@core/domains/app/store.remoteConfig"
 import * as lifiSdk from "@lifi/sdk"
 import { VersionedTransaction } from "@solana/web3.js"
-import type { EthNetworkId, SolNetworkId } from "@talismn/chaindata-provider"
+import type {
+  EthNetworkId,
+  EvmErc20Token,
+  SolNetworkId,
+  SolSplToken,
+  SolToken2022Token,
+} from "@talismn/chaindata-provider"
 import {
   evmErc20TokenId,
   evmNativeTokenId,
+  isTokenCustom,
   solNativeTokenId,
   solSplTokenId,
   solToken2022TokenId,
@@ -117,6 +124,59 @@ const assetsByTokenId = new Map<string, LifiInternalAsset>()
 const resolveAsset = (tokenId: string): LifiInternalAsset | undefined =>
   assetsByTokenId.get(tokenId)
 
+const lifiTokenFromErc20 = (token: EvmErc20Token): lifiSdk.Token => ({
+  address: token.contractAddress,
+  chainId: Number(token.networkId),
+  decimals: token.decimals,
+  symbol: token.symbol,
+  name: token.name ?? token.symbol,
+  logoURI: token.logo,
+  priceUSD: "0",
+})
+
+const lifiAssetFromErc20 = (token: EvmErc20Token): LifiInternalAsset => ({
+  tokenId: token.id,
+  chainId: token.networkId,
+  contractAddress: token.contractAddress,
+  decimals: token.decimals,
+  symbol: token.symbol,
+  lifiToken: lifiTokenFromErc20(token),
+})
+
+type SolToken = SolSplToken | SolToken2022Token
+
+const lifiAssetFromSolToken = async (token: SolToken): Promise<LifiInternalAsset> => ({
+  tokenId: token.id,
+  chainId: SOLANA_NETWORK_ID,
+  contractAddress: token.mintAddress,
+  decimals: token.decimals,
+  symbol: token.symbol,
+  lifiToken: {
+    address: token.mintAddress,
+    chainId: await getLifiSolanaChainId(),
+    decimals: token.decimals,
+    symbol: token.symbol,
+    name: token.name ?? token.symbol,
+    logoURI: token.logo,
+    priceUSD: "0",
+  },
+})
+
+export const addKnownLifiToken = (token: EvmErc20Token) => {
+  const asset = lifiAssetFromErc20(token)
+  assetsByTokenId.set(asset.tokenId, asset)
+
+  cachedAssetsPromise = (cachedAssetsPromise ?? fetchLifiAssets())
+    .then((assets) => {
+      assetsByTokenId.set(asset.tokenId, asset)
+      return [...assets.filter((item) => item.tokenId !== asset.tokenId), asset]
+    })
+    .catch((err) => {
+      cachedAssetsPromise = null
+      throw err
+    })
+}
+
 const getLifiAssets = async (_signal: AbortSignal): Promise<LifiInternalAsset[]> => {
   if (!cachedAssetsPromise) {
     cachedAssetsPromise = fetchLifiAssets().catch((err) => {
@@ -203,22 +263,56 @@ const fetchLifiAssets = async (): Promise<LifiInternalAsset[]> => {
       })
     })
 
+  const lifiEvmChainIds = new Set(Object.keys(allSdkTokens).map((chainId) => Number(chainId)))
+  const resultByTokenId = new Map(result.map((asset) => [asset.tokenId, asset]))
+
+  for (const token of Object.values(knownEvmTokens)) {
+    if (token.type !== "evm-erc20") continue
+    if (!isTokenCustom(token)) continue
+    if (!knownEvmNetworks[token.networkId]) continue
+    if (!lifiEvmChainIds.has(Number(token.networkId))) continue
+    if (resultByTokenId.has(token.id)) continue
+
+    resultByTokenId.set(token.id, lifiAssetFromErc20(token))
+  }
+
+  const assets = [...resultByTokenId.values()]
+
   // Populate the lookup cache
   assetsByTokenId.clear()
-  for (const asset of result) assetsByTokenId.set(asset.tokenId, asset)
+  for (const asset of assets) assetsByTokenId.set(asset.tokenId, asset)
 
-  return result
+  return assets
 }
 
-const getFromAssets = async (signal: AbortSignal): Promise<string[]> => {
+// Include all EVM ERC-20 and Solana SPL/Token2022 tokens on LI.FI-supported chains
+// in addition to the standard list. LI.FI can route tokens not in its default list
+// when there is on-chain liquidity, allowing users to swap RWA and other niche tokens.
+const getLifiAssetIds = async (signal: AbortSignal): Promise<string[]> => {
   const assets = await getLifiAssets(signal)
-  return [...new Set(assets.map((a) => a.tokenId))]
+  const ids = new Set(assets.map((a) => a.tokenId))
+
+  const lifiChainIds = new Set(assets.map((a) => a.chainId))
+
+  const allEvmTokens = await firstValueFrom(getTokensMap$({ platform: "ethereum" }))
+  for (const token of Object.values(allEvmTokens)) {
+    if (token.type === "evm-erc20" && lifiChainIds.has(token.networkId)) ids.add(token.id)
+  }
+
+  if (lifiChainIds.has(SOLANA_NETWORK_ID)) {
+    const allSolTokens = await firstValueFrom(getTokensMap$({ platform: "solana" }))
+    for (const token of Object.values(allSolTokens)) {
+      if (token.type === "sol-spl" || token.type === "sol-token2022") ids.add(token.id)
+    }
+  }
+
+  return [...ids]
 }
 
-const getToAssets = async (_fromTokenId: string | null, signal: AbortSignal): Promise<string[]> => {
-  const assets = await getLifiAssets(signal)
-  return [...new Set(assets.map((a) => a.tokenId))]
-}
+const getFromAssets = async (signal: AbortSignal): Promise<string[]> => getLifiAssetIds(signal)
+
+const getToAssets = async (_fromTokenId: string | null, signal: AbortSignal): Promise<string[]> =>
+  getLifiAssetIds(signal)
 
 const getRoutes = async (
   params: QuoteParams,
@@ -229,8 +323,32 @@ const getRoutes = async (
     if (!fromTokenId || !toTokenId || !fromAmount) return null
     if (signal.aborted) return null
 
-    const fromAsset = resolveAsset(fromTokenId)
-    const toAsset = resolveAsset(toTokenId)
+    let fromAsset = resolveAsset(fromTokenId)
+    let toAsset = resolveAsset(toTokenId)
+
+    // For tokens not in LI.FI's default list, construct the asset
+    // from chaindata so the contract address is passed directly to the SDK.
+    if (!fromAsset) {
+      const token = await firstValueFrom(getToken$(fromTokenId))
+      if (token?.type === "evm-erc20") {
+        fromAsset = lifiAssetFromErc20(token as EvmErc20Token)
+        assetsByTokenId.set(fromTokenId, fromAsset)
+      } else if (token?.type === "sol-spl" || token?.type === "sol-token2022") {
+        fromAsset = await lifiAssetFromSolToken(token as SolToken)
+        assetsByTokenId.set(fromTokenId, fromAsset)
+      }
+    }
+    if (!toAsset) {
+      const token = await firstValueFrom(getToken$(toTokenId))
+      if (token?.type === "evm-erc20") {
+        toAsset = lifiAssetFromErc20(token as EvmErc20Token)
+        assetsByTokenId.set(toTokenId, toAsset)
+      } else if (token?.type === "sol-spl" || token?.type === "sol-token2022") {
+        toAsset = await lifiAssetFromSolToken(token as SolToken)
+        assetsByTokenId.set(toTokenId, toAsset)
+      }
+    }
+
     if (!fromAsset || !toAsset) return null
 
     const SWAP_PLACEHOLDER_ADDRESS = "0x70045A9F59A354550EC0272f73AAe03B01Fb8a7a"


### PR DESCRIPTION
- lets users swap tokens via LI.FI that aren't in LI.FI's default token list (e.g. RWA tokens like USDY)
- search token by contract/mint address in the token picker (used in swaps, send funds, ramp, etc.)