### PR TITLE
fix: isolate Sentry from global state

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -44,7 +44,6 @@
     "@react-rxjs/core": "^0.10.7",
     "@scure/bip39": "^1.6.0",
     "@sentry/browser": "8.35.0",
-    "@sentry/react": "8.35.0",
     "@sentry/types": "8.35.0",
     "@solana/qr-code-styling": "1.6.0",
     "@solana/spl-token": "^0.4.13",

--- a/apps/extension/src/core/background.ts
+++ b/apps/extension/src/core/background.ts
@@ -18,6 +18,20 @@ import { migrateConnectAllSubstrate } from "./libs/migrations/legacyMigrations"
 
 sentry.init()
 
+// the manual client excludes Sentry's GlobalHandlers integration (it relies on global state),
+// so capture uncaught errors and unhandled rejections with our own listeners.
+// mechanism hints mirror GlobalHandlers so these are reported as unhandled crashes
+self.addEventListener("error", (event) => {
+  sentry.captureException(event.error ?? event.message, {
+    mechanism: { handled: false, type: "onerror" },
+  })
+})
+self.addEventListener("unhandledrejection", (event) => {
+  sentry.captureException(event.reason, {
+    mechanism: { handled: false, type: "onunhandledrejection" },
+  })
+})
+
 // Initialize @polkadot/util-crypto WASM module at startup.
 // Vite loads WASM asynchronously, so we must ensure readiness before handling
 // any requests that might touch WASM-only interfaces.

--- a/apps/extension/src/core/background.ts
+++ b/apps/extension/src/core/background.ts
@@ -16,7 +16,7 @@ import { setWalletReady } from "./libs/isWalletReady"
 import { MigrationRunner, migrations } from "./libs/migrations"
 import { migrateConnectAllSubstrate } from "./libs/migrations/legacyMigrations"
 
-sentry.init()
+sentry.init("background")
 
 // the manual client excludes Sentry's GlobalHandlers integration (it relies on global state),
 // so capture uncaught errors and unhandled rejections with our own listeners.

--- a/apps/extension/src/core/config/sentry.spec.ts
+++ b/apps/extension/src/core/config/sentry.spec.ts
@@ -1,0 +1,110 @@
+import { Scope } from "@sentry/browser"
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest"
+
+import { sentry } from "./sentry"
+
+// the wrapper reimplements @sentry/core's parseEventHintOrCaptureContext to route
+// `hintOrContext` to either an EventHint or a CaptureContext: these tests lock that
+// routing so it can't silently drift on SDK upgrades (crash mechanism hints depend on it)
+describe("sentry wrapper", () => {
+  let captureException: MockInstance
+  let captureMessage: MockInstance
+
+  beforeEach(() => {
+    captureException = vi
+      .spyOn(Scope.prototype, "captureException")
+      .mockReturnValue("test-event-id")
+    captureMessage = vi.spyOn(Scope.prototype, "captureMessage").mockReturnValue("test-event-id")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe("captureException", () => {
+    it("wraps a plain ScopeContext ({ extra }) as captureContext", () => {
+      const error = new Error("test")
+      sentry.captureException(error, { extra: { chainId: "0x123" } })
+
+      expect(captureException).toHaveBeenCalledWith(error, {
+        captureContext: { extra: { chainId: "0x123" } },
+      })
+    })
+
+    it("wraps a plain ScopeContext ({ tags }) as captureContext", () => {
+      const error = new Error("test")
+      sentry.captureException(error, { tags: { networkId: "solana" } })
+
+      expect(captureException).toHaveBeenCalledWith(error, {
+        captureContext: { tags: { networkId: "solana" } },
+      })
+    })
+
+    it("passes an EventHint ({ mechanism }) through unchanged", () => {
+      const error = new Error("crash")
+      const hint = { mechanism: { handled: false, type: "onerror" } }
+      sentry.captureException(error, hint)
+
+      expect(captureException).toHaveBeenCalledWith(error, hint)
+    })
+
+    it("passes an EventHint ({ captureContext, mechanism }) through unchanged", () => {
+      const error = new Error("boundary")
+      const hint = {
+        captureContext: { contexts: { react: { componentStack: "at App" } } },
+        mechanism: { handled: true },
+      }
+      sentry.captureException(error, hint)
+
+      expect(captureException).toHaveBeenCalledWith(error, hint)
+    })
+
+    it("wraps a Scope instance as captureContext", () => {
+      const error = new Error("test")
+      const customScope = new Scope()
+      sentry.captureException(error, customScope)
+
+      expect(captureException).toHaveBeenCalledWith(error, { captureContext: customScope })
+    })
+
+    it("wraps a scope callback as captureContext", () => {
+      const error = new Error("test")
+      const callback = (scope: Scope) => scope
+      sentry.captureException(error, callback)
+
+      expect(captureException).toHaveBeenCalledWith(error, { captureContext: callback })
+    })
+
+    it("passes undefined hint through", () => {
+      const error = new Error("test")
+      sentry.captureException(error)
+
+      expect(captureException).toHaveBeenCalledWith(error, undefined)
+    })
+
+    it("returns the event id from the scope", () => {
+      expect(sentry.captureException(new Error("test"))).toEqual("test-event-id")
+    })
+  })
+
+  describe("captureMessage", () => {
+    it("routes a severity level string as level", () => {
+      sentry.captureMessage("something happened", "warning")
+
+      expect(captureMessage).toHaveBeenCalledWith("something happened", "warning", undefined)
+    })
+
+    it("routes a capture context object as context", () => {
+      const captureContext = { extra: { foo: "bar" } }
+      sentry.captureMessage("something happened", captureContext)
+
+      expect(captureMessage).toHaveBeenCalledWith("something happened", undefined, {
+        captureContext,
+      })
+    })
+
+    it("returns the event id from the scope", () => {
+      expect(sentry.captureMessage("test")).toEqual("test-event-id")
+    })
+  })
+})

--- a/apps/extension/src/core/config/sentry.ts
+++ b/apps/extension/src/core/config/sentry.ts
@@ -1,4 +1,4 @@
-import { DEBUG } from "@common/constants"
+import { DEBUG, IS_FIREFOX } from "@common/constants"
 import { log } from "@common/log"
 import {
   BrowserClient,
@@ -26,6 +26,11 @@ settingsStore.observable.subscribe((settings) => useErrorTracking.next(settings.
 
 // setup of the Sentry scope following this guide:
 // https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/
+// this module is shared by the background and UI contexts: each bundle gets its own
+// isolated client + scope, and the global Sentry carrier is never touched
+
+// for DEBUG logging purposes only - MV3 background service worker has no window
+const CONTEXT = typeof window === "undefined" ? "Background" : "UI"
 
 // filter integrations that use the global variable
 const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
@@ -35,7 +40,7 @@ const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
 })
 
 const client = new BrowserClient({
-  enabled: true,
+  enabled: !IS_FIREFOX,
   environment: process.env.BUILD,
   dsn: process.env.SENTRY_DSN,
   transport: makeFetchTransport,
@@ -59,7 +64,7 @@ const client = new BrowserClient({
 
     // Print to console instead of Sentry in DEBUG/development builds
     if (DEBUG) {
-      log.error("[DEBUG - Background] Sentry event occurred", event)
+      log.error(`[DEBUG - ${CONTEXT}] Sentry event occurred`, event)
       return null
     }
 

--- a/apps/extension/src/core/config/sentry.ts
+++ b/apps/extension/src/core/config/sentry.ts
@@ -120,9 +120,9 @@ export const sentry: TalismanSentryClient = {
   captureEvent: (event, hint) => scope.captureEvent(event, hint),
   captureMessage: (message, captureContext) => {
     const level = typeof captureContext === "string" ? captureContext : undefined
-    const context = typeof captureContext !== "string" ? { captureContext } : undefined
+    const ctx = typeof captureContext !== "string" ? { captureContext } : undefined
 
-    return scope.captureMessage(message, level, context)
+    return scope.captureMessage(message, level, ctx)
   },
 }
 

--- a/apps/extension/src/core/config/sentry.ts
+++ b/apps/extension/src/core/config/sentry.ts
@@ -11,7 +11,7 @@ import {
   Scope,
 } from "@sentry/browser"
 import type { Event } from "@sentry/types"
-import { firstValueFrom, ReplaySubject } from "rxjs"
+import { firstValueFrom, of, ReplaySubject, timeout } from "rxjs"
 
 import { trackIndexedDbErrorExtras } from "../domains/app/store.errors"
 import { settingsStore } from "../domains/app/store.settings"
@@ -29,14 +29,14 @@ settingsStore.observable.subscribe((settings) => useErrorTracking.next(settings.
 // this module is shared by the background and UI contexts: each bundle gets its own
 // isolated client + scope, and the global Sentry carrier is never touched
 
-// for DEBUG logging purposes only - MV3 background service worker has no window
-const CONTEXT = typeof window === "undefined" ? "Background" : "UI"
+type SentryContext = "background" | "ui"
+
+// set by init(), for DEBUG logging purposes only
+let context: SentryContext | "unknown" = "unknown"
 
 // filter integrations that use the global variable
 const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
-  return !["BrowserApiErrors", "TryCatch", "Breadcrumbs", "GlobalHandlers"].includes(
-    defaultIntegration.name
-  )
+  return !["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"].includes(defaultIntegration.name)
 })
 
 const client = new BrowserClient({
@@ -48,7 +48,6 @@ const client = new BrowserClient({
   integrations: integrations,
   release: process.env.RELEASE,
   sampleRate: 1,
-  maxBreadcrumbs: 20,
   ignoreErrors: [
     /(No window with id: )(\d+).?/,
     /(disconnected from wss)[(]?:\/\/[\w./:-]+: \d+:: Normal Closure[)]?/,
@@ -64,28 +63,17 @@ const client = new BrowserClient({
 
     // Print to console instead of Sentry in DEBUG/development builds
     if (DEBUG) {
-      log.error(`[DEBUG - ${CONTEXT}] Sentry event occurred`, event)
+      log.error(`[DEBUG - ${context}] Sentry event occurred`, event)
       return null
     }
 
-    const errorTracking = await firstValueFrom(useErrorTracking)
+    // fall back to not sending if the setting can't be read (e.g. corrupted storage),
+    // so the event is dropped instead of hanging in the client forever
+    const errorTracking = await firstValueFrom(
+      useErrorTracking.pipe(timeout({ first: 5_000, with: () => of(false) }))
+    )
     return errorTracking ? event : null
   },
-  beforeBreadcrumb: (breadCrumb, _hint) => {
-    if (breadCrumb.data?.url) {
-      breadCrumb.data.url = normalizeUrl(breadCrumb.data.url)
-    }
-    return breadCrumb
-  },
-
-  // Set tracesSampleRate to capture 5%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 0.05,
-
-  // disable replays
-  replaysSessionSampleRate: 0,
-  replaysOnErrorSampleRate: 0,
 })
 
 const scope = new Scope()
@@ -109,14 +97,17 @@ scope.addEventProcessor(async (event: Event) => {
 })
 
 type TalismanSentryClient = {
-  init: () => void
+  init: (context: SentryContext) => void
   captureException: typeof captureException
   captureEvent: typeof captureEvent
   captureMessage: typeof captureMessage
 }
 
 export const sentry: TalismanSentryClient = {
-  init: () => client.init(),
+  init: (ctx) => {
+    context = ctx
+    client.init()
+  },
   captureException: (exception, hintOrContext) => {
     // From https://github.com/getsentry/sentry-javascript/blob/0d558dea4a580dce7717f5093ad3b62a3c4733bd/packages/core/src/utils/prepareEvent.ts#L358
     const hint =

--- a/apps/extension/src/core/domains/analytics/store.ts
+++ b/apps/extension/src/core/domains/analytics/store.ts
@@ -1,8 +1,8 @@
 import { DEBUG, IS_FIREFOX } from "@common/constants"
 import { log } from "@common/log"
-import * as Sentry from "@sentry/browser"
 import { v4 } from "uuid"
 
+import { sentry } from "../../config/sentry"
 import { StorageProvider } from "../../libs/Store"
 import { remoteConfigStore } from "../app/store.remoteConfig"
 import { settingsStore } from "../app/store.settings"
@@ -57,7 +57,7 @@ class AnalyticsStore extends StorageProvider<AnalyticsData> {
       const error = new Error("Failed to identify posthog client", { cause })
       // biome-ignore lint/suspicious/noConsole: legacy
       console.error(error)
-      Sentry.captureException(error)
+      sentry.captureException(error)
     }
     return
   }

--- a/apps/extension/src/core/domains/keyring/utils.ts
+++ b/apps/extension/src/core/domains/keyring/utils.ts
@@ -1,8 +1,8 @@
 import { log } from "@common/log"
-import { captureException } from "@sentry/browser"
 import type { KeypairCurve } from "@talismn/crypto"
 import { Err, Ok, type Result } from "ts-results"
 
+import { sentry } from "../../config/sentry"
 import { getDerivationPathForCurve } from "../accounts/helpers"
 import { passwordStore } from "../app/store.password"
 import { keyringStore } from "./store"
@@ -51,7 +51,7 @@ export const getNextDerivationPathForMnemonicId = async (
     return Err("Reached maximum number of derived accounts")
   } catch (error) {
     log.error("Unable to get next derivation path", error)
-    captureException(error)
+    sentry.captureException(error)
     return Err("Unable to get next derivation path")
   }
 }

--- a/apps/extension/src/core/libs/migrations/runner.ts
+++ b/apps/extension/src/core/libs/migrations/runner.ts
@@ -1,8 +1,8 @@
 import { log } from "@common/log"
 import { assert } from "@polkadot/util"
-import { captureException } from "@sentry/browser"
 import { BehaviorSubject } from "rxjs"
 
+import { sentry } from "../../config/sentry"
 import { StorageProvider } from "../Store"
 import type { MigrationContext, Migrations } from "./types"
 
@@ -145,7 +145,7 @@ export class MigrationRunner extends StorageProvider<Record<string, MigrationRun
     } catch (e) {
       this.status.next("error")
       log.error(e)
-      if ((e as Error).cause) captureException(e)
+      if ((e as Error).cause) sentry.captureException(e)
       const stillPending = pending.filter((i) => !applied.includes(i))
       log.error(`${stillPending.length} migrations were not applied`)
       return false

--- a/apps/extension/src/core/libs/migrations/types.ts
+++ b/apps/extension/src/core/libs/migrations/types.ts
@@ -1,5 +1,6 @@
 import { log } from "@common/log"
-import { captureException } from "@sentry/browser"
+
+import { sentry } from "../../config/sentry"
 
 /**
  * MigrationContext
@@ -26,7 +27,7 @@ export class MigrationFunction {
 
   async onError(error: Error) {
     await this._onError(error)
-    captureException(error)
+    sentry.captureException(error)
     this.error = error
     this.status = "error"
   }

--- a/apps/extension/src/sentry.ts
+++ b/apps/extension/src/sentry.ts
@@ -1,88 +1,21 @@
-import { DEBUG, IS_FIREFOX } from "@common/constants"
-import { log } from "@common/log"
-import {
-  trackIndexedDbErrorExtras,
-  triggerIndexedDbUnavailablePopup,
-} from "@core/domains/app/store.errors"
-import { settingsStore } from "@core/domains/app/store.settings"
-import * as SentryReact from "@sentry/react"
-import type { Event } from "@sentry/types"
-import { firstValueFrom, ReplaySubject } from "rxjs"
+import { sentry } from "@core/config/sentry"
+import { triggerIndexedDbUnavailablePopup } from "@core/domains/app/store.errors"
 
-const normalizeUrl = (url: string) => {
-  return url.replace(/(webpack_require__@)?(moz|chrome)-extension:\/\/[^/]+\//, "~/")
-}
-
-// cache latest value of useErrorTracking so that we don't need to check localStorage for every error sent to sentry
-const useErrorTracking = new ReplaySubject<boolean>(1)
-settingsStore.observable.subscribe((settings) => useErrorTracking.next(settings.useErrorTracking))
-
+// Sentry must not be initialised in the global state (`Sentry.init`) in browser extensions,
+// or events may leak between the extension and other Sentry instances (see #2418, #547).
+// `sentry` is a manual client + scope, following this guide:
+// https://docs.sentry.io/platforms/javascript/best-practices/shared-environments/
 export const initSentryFrontend = () => {
-  SentryReact.init({
-    enabled: !IS_FIREFOX,
-    environment: process.env.BUILD,
-    dsn: process.env.SENTRY_DSN,
-    integrations: [SentryReact.browserTracingIntegration()],
-    release: process.env.RELEASE,
-    sampleRate: 1,
-    maxBreadcrumbs: 20,
-    ignoreErrors: [
-      /(No window with id: )(\d+).?/,
-      /(disconnected from wss)[(]?:\/\/[\w./:-]+: \d+:: Normal Closure[)]?/,
-      /^disconnected from .+: [0-9]+:: .+$/,
-      /^unsubscribed from .+: [0-9]+:: .+$/,
-      /(Could not establish connection. Receiving end does not exist.)/,
-      /(track.getCapabilities is not a function)/,
-    ],
-    // prevents sending the event if user has disabled error tracking
-    beforeSend: async (event, hint) => {
-      // Track extra information about IndexedDB errors
-      await trackIndexedDbErrorExtras(event, hint)
+  sentry.init()
 
-      // Print to console instead of Sentry in DEBUG/development builds
-      if (DEBUG) {
-        log.error("[DEBUG - UI] Sentry event occurred", event)
-        return null
-      }
-
-      const errorTracking = await firstValueFrom(useErrorTracking)
-      return errorTracking ? event : null
-    },
-    beforeBreadcrumb: (breadCrumb) => {
-      if (breadCrumb.data?.url) {
-        breadCrumb.data.url = normalizeUrl(breadCrumb.data.url)
-      }
-      return breadCrumb
-    },
-
-    // Set tracesSampleRate to capture 5%
-    // of transactions for performance monitoring.
-    // We recommend adjusting this value in production
-    tracesSampleRate: 0.05,
-
-    // disable replays
-    replaysSessionSampleRate: 0,
-    replaysOnErrorSampleRate: 0,
-  })
-  const scope = SentryReact.getCurrentScope()
-  scope.addEventProcessor(async (event: Event) => {
-    if (event.request?.url) {
-      event.request.url = normalizeUrl(event.request.url)
-    }
-
-    if (event.exception?.values && event.exception.values.length > 0) {
-      const firstValue = event.exception.values[0]
-      if (!firstValue.stacktrace?.frames) return event
-      firstValue.stacktrace.frames = firstValue.stacktrace.frames.map((frame) => {
-        if (frame.filename) frame.filename = normalizeUrl(frame.filename)
-        return frame
-      })
-    }
-
-    return event
-  })
-
+  // the manual client excludes Sentry's GlobalHandlers integration (it relies on global state),
+  // so capture uncaught errors and unhandled rejections with our own listeners.
+  // these pages are wholly owned by the extension, so listening here doesn't leak anywhere
   window.addEventListener("error", (event) => {
+    sentry.captureException(event.error ?? event.message)
     triggerIndexedDbUnavailablePopup(event.error)
+  })
+  window.addEventListener("unhandledrejection", (event) => {
+    sentry.captureException(event.reason)
   })
 }

--- a/apps/extension/src/sentry.ts
+++ b/apps/extension/src/sentry.ts
@@ -10,12 +10,17 @@ export const initSentryFrontend = () => {
 
   // the manual client excludes Sentry's GlobalHandlers integration (it relies on global state),
   // so capture uncaught errors and unhandled rejections with our own listeners.
-  // these pages are wholly owned by the extension, so listening here doesn't leak anywhere
+  // these pages are wholly owned by the extension, so listening here doesn't leak anywhere.
+  // mechanism hints mirror GlobalHandlers so these are reported as unhandled crashes
   window.addEventListener("error", (event) => {
-    sentry.captureException(event.error ?? event.message)
+    sentry.captureException(event.error ?? event.message, {
+      mechanism: { handled: false, type: "onerror" },
+    })
     triggerIndexedDbUnavailablePopup(event.error)
   })
   window.addEventListener("unhandledrejection", (event) => {
-    sentry.captureException(event.reason)
+    sentry.captureException(event.reason, {
+      mechanism: { handled: false, type: "onunhandledrejection" },
+    })
   })
 }

--- a/apps/extension/src/sentry.ts
+++ b/apps/extension/src/sentry.ts
@@ -6,7 +6,7 @@ import { triggerIndexedDbUnavailablePopup } from "@core/domains/app/store.errors
 // `sentry` is a manual client + scope, following this guide:
 // https://docs.sentry.io/platforms/javascript/best-practices/shared-environments/
 export const initSentryFrontend = () => {
-  sentry.init()
+  sentry.init("ui")
 
   // the manual client excludes Sentry's GlobalHandlers integration (it relies on global state),
   // so capture uncaught errors and unhandled rejections with our own listeners.

--- a/apps/extension/src/ui/apps/dashboard/routes/Networks/EditNetworkPage/index.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Networks/EditNetworkPage/index.tsx
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/correctness/noChildrenProp: legacy
-import * as Sentry from "@sentry/browser"
+import { sentry } from "@core/config/sentry"
 import {
   getGithubTokenLogoUrlByCoingeckoId,
   isNetworkCustom,
@@ -436,7 +436,7 @@ const ConfirmRemove: FC<{
       await api.networkRemove(network.id)
       isNetworkKnown(saved) ? onClose() : navigate(-1)
     } catch (err) {
-      Sentry.captureException(err)
+      sentry.captureException(err)
       notify({
         type: "error",
         title: t("Error"),

--- a/apps/extension/src/ui/apps/dashboard/routes/Tokens/EditTokenPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Tokens/EditTokenPage.tsx
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/correctness/noChildrenProp: legacy */
 
 import { log } from "@common/log"
-import * as Sentry from "@sentry/browser"
+import { sentry } from "@core/config/sentry"
 import {
   getGithubTokenLogoUrlByCoingeckoId,
   isTokenCustom,
@@ -527,7 +527,7 @@ const ConfirmRemove: FC<{
       await api.tokenRemove(token.id)
       isTokenKnown(saved) ? onClose() : navigate(-1)
     } catch (err) {
-      Sentry.captureException(err)
+      sentry.captureException(err)
       notify({
         type: "error",
         title: t("Error"),

--- a/apps/extension/src/ui/components/AppPill.tsx
+++ b/apps/extension/src/ui/components/AppPill.tsx
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/browser"
+import { sentry } from "@core/config/sentry"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
 import { type FC, useMemo } from "react"
 
@@ -11,7 +11,7 @@ export const AppPill: FC<{ url?: string }> = ({ url }) => {
       const typedUrl = new URL(url)
       return typedUrl.hostname
     } catch (err) {
-      Sentry.captureException(err)
+      sentry.captureException(err)
       return null
     }
   }, [url])

--- a/apps/extension/src/ui/components/TalismanErrorBoundary.tsx
+++ b/apps/extension/src/ui/components/TalismanErrorBoundary.tsx
@@ -1,13 +1,52 @@
 import { DEBUG, DISCORD_TALISMAN_URL } from "@common/constants"
-import { ErrorBoundary as SentryErrorBoundary } from "@sentry/react"
+import { sentry } from "@core/config/sentry"
 import { TalismanDeadHandIcon } from "@talismn/icons"
 import { Button } from "@ui/components/Button"
 import type { DexieError } from "dexie"
-import { type ReactNode, useCallback } from "react"
+import { Component, type ErrorInfo, type ReactNode, useCallback } from "react"
 
-export const TalismanErrorBoundary = ({ children }: { children?: ReactNode }) => (
-  <SentryErrorBoundary fallback={ErrorMessage}>{children}</SentryErrorBoundary>
-)
+type TalismanErrorBoundaryProps = {
+  children?: ReactNode
+}
+
+type TalismanErrorBoundaryState = {
+  error: unknown
+  eventId?: string
+}
+
+/**
+ * Error boundary that reports errors to our manual Sentry client.
+ * Don't use @sentry/react's ErrorBoundary: it captures via the global Sentry instance,
+ * which must not be initialised in browser extensions (see #2418).
+ */
+export class TalismanErrorBoundary extends Component<
+  TalismanErrorBoundaryProps,
+  TalismanErrorBoundaryState
+> {
+  constructor(props: TalismanErrorBoundaryProps) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error: unknown): Partial<TalismanErrorBoundaryState> {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    const eventId = sentry.captureException(error, {
+      captureContext: { contexts: { react: { componentStack: info.componentStack } } },
+    })
+    this.setState({ eventId })
+  }
+
+  render() {
+    if (this.state.error) {
+      return <ErrorMessage error={this.state.error} eventId={this.state.eventId} />
+    }
+
+    return this.props.children
+  }
+}
 
 function ErrorMessage({ error, eventId }: { error: unknown; eventId?: string }) {
   const isDbVersionError = (error as DexieError)?.inner?.name === "VersionError"

--- a/apps/extension/src/ui/components/TalismanErrorBoundary.tsx
+++ b/apps/extension/src/ui/components/TalismanErrorBoundary.tsx
@@ -33,8 +33,19 @@ export class TalismanErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
+    // mirror @sentry/react's captureReactException: link an error carrying the React
+    // component stack via `cause`, surfaced as a navigable stacktrace by the
+    // LinkedErrors integration
+    if (error instanceof Error && info.componentStack && !error.cause) {
+      const boundaryError = new Error(error.message)
+      boundaryError.name = `React ErrorBoundary ${error.name}`
+      boundaryError.stack = info.componentStack
+      error.cause = boundaryError
+    }
+
     const eventId = sentry.captureException(error, {
       captureContext: { contexts: { react: { componentStack: info.componentStack } } },
+      mechanism: { handled: true },
     })
     this.setState({ eventId })
   }

--- a/apps/extension/src/ui/components/TalismanErrorBoundary.tsx
+++ b/apps/extension/src/ui/components/TalismanErrorBoundary.tsx
@@ -10,7 +10,8 @@ type TalismanErrorBoundaryProps = {
 }
 
 type TalismanErrorBoundaryState = {
-  error: unknown
+  hasError: boolean
+  error?: unknown
   eventId?: string
 }
 
@@ -25,11 +26,14 @@ export class TalismanErrorBoundary extends Component<
 > {
   constructor(props: TalismanErrorBoundaryProps) {
     super(props)
-    this.state = { error: null }
+    this.state = { hasError: false }
   }
 
-  static getDerivedStateFromError(error: unknown): Partial<TalismanErrorBoundaryState> {
-    return { error }
+  // an explicit flag rather than gating on the error itself: thrown values may be falsy
+  static getDerivedStateFromError(
+    error: unknown
+  ): Pick<TalismanErrorBoundaryState, "hasError" | "error"> {
+    return { hasError: true, error }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
@@ -51,7 +55,7 @@ export class TalismanErrorBoundary extends Component<
   }
 
   render() {
-    if (this.state.error) {
+    if (this.state.hasError) {
       return <ErrorMessage error={this.state.error} eventId={this.state.eventId} />
     }
 

--- a/apps/extension/src/ui/domains/Ethereum/util/getFeeHistoryAnalysis.ts
+++ b/apps/extension/src/ui/domains/Ethereum/util/getFeeHistoryAnalysis.ts
@@ -1,6 +1,6 @@
 import { log } from "@common/log"
+import { sentry } from "@core/config/sentry"
 import type { EthBaseFeeTrend } from "@core/domains/signing/types"
-import * as Sentry from "@sentry/browser"
 import { formatGwei, type PublicClient, parseGwei } from "viem"
 
 const BLOCKS_HISTORY_LENGTH = 10
@@ -112,7 +112,7 @@ export const getFeeHistoryAnalysis = async (
     }
     return result
   } catch (err) {
-    Sentry.captureException(err)
+    sentry.captureException(err)
     throw new Error("Failed to load fee history", { cause: err as Error })
   }
 }

--- a/apps/extension/src/ui/domains/Settings/MigratePassword/context.ts
+++ b/apps/extension/src/ui/domains/Settings/MigratePassword/context.ts
@@ -1,5 +1,5 @@
+import { sentry } from "@core/config/sentry"
 import { passwordStore } from "@core/domains/app/store.password"
-import * as Sentry from "@sentry/react"
 import { api } from "@ui/api"
 import { useMnemonicsAllBackedUp } from "@ui/hooks/useMnemonicsAllBackedUp"
 import { useSensitiveState } from "@ui/hooks/useSensitiveState"
@@ -33,7 +33,7 @@ const useMigratePasswordProvider = ({ onComplete }: { onComplete: () => void }) 
   }, [password])
 
   useEffect(() => {
-    if (error && useErrorTracking) Sentry.captureException(error)
+    if (error && useErrorTracking) sentry.captureException(error)
   }, [error, useErrorTracking])
 
   const hasPassword = !!password

--- a/apps/extension/src/ui/domains/Settings/MigratePassword/context.ts
+++ b/apps/extension/src/ui/domains/Settings/MigratePassword/context.ts
@@ -5,7 +5,6 @@ import { useMnemonicsAllBackedUp } from "@ui/hooks/useMnemonicsAllBackedUp"
 import { useSensitiveState } from "@ui/hooks/useSensitiveState"
 import useStatus, { statusOptions } from "@ui/hooks/useStatus"
 import { useMnemonics } from "@ui/state/mnemonics"
-import { useSetting } from "@ui/state/settings"
 import { provideContext } from "@ui/util/provideContext"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
@@ -17,7 +16,6 @@ const useMigratePasswordProvider = ({ onComplete }: { onComplete: () => void }) 
   const [mnemonic, setMnemonic] = useSensitiveState<string>()
   const [passwordTrimmed, setPasswordTrimmed] = useState<boolean>()
   const [error, setError] = useState<Error>()
-  const [useErrorTracking] = useSetting("useErrorTracking")
   const { setStatus, status, message } = useStatus()
   const allBackedUp = useMnemonicsAllBackedUp()
   const mnemonics = useMnemonics()
@@ -33,8 +31,9 @@ const useMigratePasswordProvider = ({ onComplete }: { onComplete: () => void }) 
   }, [password])
 
   useEffect(() => {
-    if (error && useErrorTracking) sentry.captureException(error)
-  }, [error, useErrorTracking])
+    // the user's error tracking preference is enforced centrally, in the client's beforeSend
+    if (error) sentry.captureException(error)
+  }, [error])
 
   const hasPassword = !!password
   const hasNewPassword = !!newPassword

--- a/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessage.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessage.tsx
@@ -1,9 +1,9 @@
 import { log } from "@common/log"
+import { sentry } from "@core/config/sentry"
 import type { Account } from "@core/domains/keyring/exports"
 import type { EthSignRequest } from "@core/domains/signing/types"
 import { isHexString, stripHexPrefix } from "@ethereumjs/util"
 import { hexToString } from "@polkadot/util"
-import * as Sentry from "@sentry/browser"
 import { ParsedMessage } from "@spruceid/siwe-parser"
 import { Button } from "@ui/components/Button"
 import { Drawer } from "@ui/components/Drawer"
@@ -59,7 +59,7 @@ const useEthSignMessage = (request: EthSignRequest) => {
 
         return convertToYaml(typedMessage)
       } catch (err) {
-        Sentry.captureException(err)
+        sentry.captureException(err)
       }
     }
     try {

--- a/apps/extension/src/ui/util/getAccountAvatarDataUri.tsx
+++ b/apps/extension/src/ui/util/getAccountAvatarDataUri.tsx
@@ -1,5 +1,5 @@
+import { sentry } from "@core/config/sentry"
 import type { IdenticonType } from "@core/domains/accounts/types"
-import * as Sentry from "@sentry/browser"
 import { TalismanOrb } from "@talismn/orb"
 import { PolkadotAvatar } from "@ui/domains/Account/AccountIcon/PolkadotAvatar"
 import { renderToString } from "react-dom/server"
@@ -32,7 +32,7 @@ const generateAccountAvatarDataUri = (address: string, iconType: IdenticonType) 
     // encode as base64 data uri
     return `data:image/svg+xml;base64,${Buffer.from(svg, "utf8").toString("base64")}`
   } catch (err) {
-    Sentry.captureException(err)
+    sentry.captureException(err)
     return null
   }
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -94,8 +94,11 @@
   },
   "overrides": [
     {
-      // the manual Sentry client wrapper is the only allowed importer of the Sentry SDK
-      "includes": ["apps/extension/src/core/config/sentry.ts"],
+      // the manual Sentry client wrapper (and its spec) are the only allowed importers of the Sentry SDK
+      "includes": [
+        "apps/extension/src/core/config/sentry.ts",
+        "apps/extension/src/core/config/sentry.spec.ts"
+      ],
       "linter": {
         "rules": {
           "style": {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -62,7 +62,16 @@
       },
       "style": {
         "noNonNullAssertion": "off",
-        "useImportType": "warn"
+        "useImportType": "warn",
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "@sentry/browser": "Import { sentry } from \"@core/config/sentry\" instead: the global Sentry API must not be used in a browser extension (#2418) and is a silent no-op without Sentry.init().",
+              "@sentry/react": "Import { sentry } from \"@core/config/sentry\" instead: the global Sentry API must not be used in a browser extension (#2418) and is a silent no-op without Sentry.init()."
+            }
+          }
+        }
       },
       "nursery": {
         "useSortedClasses": {
@@ -84,6 +93,17 @@
     }
   },
   "overrides": [
+    {
+      // the manual Sentry client wrapper is the only allowed importer of the Sentry SDK
+      "includes": ["apps/extension/src/core/config/sentry.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": "off"
+          }
+        }
+      }
+    },
     {
       "includes": ["*.test.ts", "*.test.tsx", "*.spec.ts", "*.spec.tsx", "tests/**"],
       "linter": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,9 +331,6 @@ importers:
       '@sentry/browser':
         specifier: 8.35.0
         version: 8.35.0
-      '@sentry/react':
-        specifier: 8.35.0
-        version: 8.35.0(react@18.3.1)
       '@sentry/types':
         specifier: 8.35.0
         version: 8.35.0
@@ -2997,7 +2994,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3422,7 +3419,7 @@ packages:
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: '>=4.22.4'
+      rollup: '>=2.79.2'
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -3700,6 +3697,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -3811,12 +3809,6 @@ packages:
   '@sentry/core@8.35.0':
     resolution: {integrity: sha512-Ci0Nmtw5ETWLqQJGY4dyF+iWh7PWKy6k303fCEoEmqj2czDrKJCp7yHBNV0XYbo00prj2ZTbCr6I7albYiyONA==}
     engines: {node: '>=14.18'}
-
-  '@sentry/react@8.35.0':
-    resolution: {integrity: sha512-8Y+s4pE9hvT2TwSo5JS/Enw2cNFlwiLcJDNGCj/Hho+FePFYA59hbN06ouTHWARnO+swANHKZQj24Wp57p1/tg==}
-    engines: {node: '>=14.18'}
-    peerDependencies:
-      react: ^16.14.0 || 17.x || 18.x || 19.x
 
   '@sentry/types@8.35.0':
     resolution: {integrity: sha512-AVEZjb16MlYPifiDDvJ19dPQyDn0jlrtC1PHs6ZKO+Rzyz+2EX2BRdszvanqArldexPoU1p5Bn2w81XZNXThBA==}
@@ -6603,9 +6595,6 @@ packages:
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
-
-  hoist-non-react-statics@3.3.2:
-    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -13977,15 +13966,6 @@ snapshots:
       '@sentry/types': 8.35.0
       '@sentry/utils': 8.35.0
 
-  '@sentry/react@8.35.0(react@18.3.1)':
-    dependencies:
-      '@sentry/browser': 8.35.0
-      '@sentry/core': 8.35.0
-      '@sentry/types': 8.35.0
-      '@sentry/utils': 8.35.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.3.1
-
   '@sentry/types@8.35.0': {}
 
   '@sentry/utils@8.35.0':
@@ -17617,10 +17597,6 @@ snapshots:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
-
-  hoist-non-react-statics@3.3.2:
-    dependencies:
-      react-is: 16.13.1
 
   hookable@5.5.3: {}
 


### PR DESCRIPTION
- Fixes https://github.com/TalismanSociety/talisman/issues/2418

Frontend was initialised with SentryReact.init() which registers the client on the global __SENTRY__ carrier and patches global APIs (onerror, fetch, history...), leaking events between the extension and other Sentry SDK instances (#2418, #547).

- share the background's manual BrowserClient + Scope setup (core/config/sentry) with the UI, per https://docs.sentry.io/platforms/javascript/best-practices/shared-environments/
- replace the GlobalHandlers integration with our own window error/unhandledrejection listeners on extension pages
- replace @sentry/react's ErrorBoundary (captures via the global instance) with a custom boundary reporting to the manual client, and drop the @sentry/react dependency
- drop browserTracingIntegration (relies on global state)
- route stray global captureException calls in background code (keyring, migrations, analytics) to the manual client: they were silently dropped since the background never initialises the global instance