### PR TITLE
chore: bump bignumber.js to v11

### DIFF
--- a/.changeset/bignumber-v11-bump.md
+++ b/.changeset/bignumber-v11-bump.md
@@ -1,0 +1,6 @@
+---
+"@talismn/util": patch
+"@talismn/balances": patch
+---
+
+bump bignumber.js to 11.1.3

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -80,7 +80,7 @@
     "anylogger": "^1.0.11",
     "anylogger-loglevel": "^1.0.0",
     "bcryptjs": "^3.0.3",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^11.1.3",
     "blueimp-md5": "2.19.0",
     "bs58": "^6.0.0",
     "chart.js": "^4.5.1",

--- a/packages/balances/package.json
+++ b/packages/balances/package.json
@@ -40,7 +40,7 @@
     "@talismn/token-rates": "workspace:*",
     "@talismn/util": "workspace:*",
     "anylogger": "^1.0.11",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^11.1.3",
     "lodash-es": "4.18.1",
     "p-queue": "8.1.0",
     "polkadot-api": "1.23.3",

--- a/packages/balances/src/configureBigNumber.test.ts
+++ b/packages/balances/src/configureBigNumber.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import BigNumber from "./configureBigNumber"
+
+describe("configureBigNumber", () => {
+  // bignumber.js v10+ throws on invalid input by default. We disable STRICT to
+  // preserve the v9 behaviour of returning NaN. Guard against accidental removal.
+  it("returns NaN for invalid input instead of throwing", () => {
+    expect(() => new BigNumber("not-a-number")).not.toThrow()
+    expect(new BigNumber("not-a-number").isNaN()).toBe(true)
+
+    expect(() => new BigNumber("")).not.toThrow()
+    expect(new BigNumber("").isNaN()).toBe(true)
+  })
+
+  it("still parses valid input normally", () => {
+    expect(new BigNumber("1.5").toString(10)).toBe("1.5")
+  })
+})

--- a/packages/balances/src/configureBigNumber.ts
+++ b/packages/balances/src/configureBigNumber.ts
@@ -1,0 +1,10 @@
+import BigNumber from "bignumber.js"
+
+// bignumber.js v10+ throws on invalid input by default (the STRICT option).
+// Restore the v9 behaviour of returning NaN so existing callers are unaffected.
+// The bignumber.js config is a shared singleton, so this applies process-wide.
+// Import BigNumber from here (rather than directly from "bignumber.js") to
+// guarantee this config has run before any value is constructed.
+BigNumber.set({ STRICT: false })
+
+export default BigNumber

--- a/packages/balances/src/index.ts
+++ b/packages/balances/src/index.ts
@@ -1,3 +1,5 @@
+import "./configureBigNumber"
+
 export * from "./BalancesProvider"
 export * from "./modules"
 export * from "./types"

--- a/packages/balances/src/modules/evm-uniswapv2/fetchBalances.ts
+++ b/packages/balances/src/modules/evm-uniswapv2/fetchBalances.ts
@@ -1,8 +1,8 @@
 import { parseTokenId } from "@talismn/chaindata-provider"
 import { isEthereumAddress } from "@talismn/crypto"
-import BigNumber from "bignumber.js"
 import { keyBy, uniq } from "lodash-es"
 import { getContract, type PublicClient } from "viem"
+import BigNumber from "../../configureBigNumber"
 
 import type { ExtraAmount } from "../../types"
 import type { FetchBalanceResults, IBalanceModule } from "../../types/IBalanceModule"

--- a/packages/balances/src/types/balances.ts
+++ b/packages/balances/src/types/balances.ts
@@ -12,7 +12,7 @@ import {
   type NonFunctionProperties,
   planckToTokens,
 } from "@talismn/util"
-import BigNumber from "bignumber.js"
+import BigNumber from "../configureBigNumber"
 
 import log from "../log"
 import type { SubDTaoBalanceMeta } from "../modules"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^11.1.3",
     "lodash-es": "4.18.1",
     "rxjs": "7.8.2"
   },

--- a/packages/util/src/configureBigNumber.test.ts
+++ b/packages/util/src/configureBigNumber.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import BigNumber from "./configureBigNumber"
+
+describe("configureBigNumber", () => {
+  // bignumber.js v10+ throws on invalid input by default. We disable STRICT to
+  // preserve the v9 behaviour of returning NaN. Guard against accidental removal.
+  it("returns NaN for invalid input instead of throwing", () => {
+    expect(() => new BigNumber("not-a-number")).not.toThrow()
+    expect(new BigNumber("not-a-number").isNaN()).toBe(true)
+
+    expect(() => new BigNumber("")).not.toThrow()
+    expect(new BigNumber("").isNaN()).toBe(true)
+  })
+
+  it("still parses valid input normally", () => {
+    expect(new BigNumber("1.5").toString(10)).toBe("1.5")
+  })
+})

--- a/packages/util/src/configureBigNumber.ts
+++ b/packages/util/src/configureBigNumber.ts
@@ -1,0 +1,10 @@
+import BigNumber from "bignumber.js"
+
+// bignumber.js v10+ throws on invalid input by default (the STRICT option).
+// Restore the v9 behaviour of returning NaN so existing callers are unaffected.
+// The bignumber.js config is a shared singleton, so this applies process-wide.
+// Import BigNumber from here (rather than directly from "bignumber.js") to
+// guarantee this config has run before any value is constructed.
+BigNumber.set({ STRICT: false })
+
+export default BigNumber

--- a/packages/util/src/formatDecimals.ts
+++ b/packages/util/src/formatDecimals.ts
@@ -1,4 +1,4 @@
-import BigNumber from "bignumber.js"
+import BigNumber from "./configureBigNumber"
 
 const MIN_DIGITS = 4 // less truncates more than what compact formating is
 export const MAX_DECIMALS_FORMAT = 12

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,3 +1,5 @@
+import "./configureBigNumber"
+
 export * from "./addTrailingSlash"
 export * from "./BigMath"
 export * from "./deferred"

--- a/packages/util/src/planckToTokens.ts
+++ b/packages/util/src/planckToTokens.ts
@@ -1,4 +1,4 @@
-import BigNumber from "bignumber.js"
+import BigNumber from "./configureBigNumber"
 
 export function planckToTokens(planck: string, tokenDecimals: number): string
 export function planckToTokens(planck: string, tokenDecimals?: number): string | undefined

--- a/packages/util/src/tokensToPlanck.ts
+++ b/packages/util/src/tokensToPlanck.ts
@@ -1,4 +1,4 @@
-import BigNumber from "bignumber.js"
+import BigNumber from "./configureBigNumber"
 
 export function tokensToPlanck(tokens: string, tokenDecimals: number): string
 export function tokensToPlanck(tokens: string, tokenDecimals?: number): string | undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,8 +446,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       bignumber.js:
-        specifier: ^9.1.2
-        version: 9.1.2
+        specifier: ^11.1.3
+        version: 11.1.3
       blueimp-md5:
         specifier: 2.19.0
         version: 2.19.0
@@ -743,8 +743,8 @@ importers:
         specifier: ^1.0.11
         version: 1.0.11
       bignumber.js:
-        specifier: ^9.1.2
-        version: 9.1.2
+        specifier: ^11.1.3
+        version: 11.1.3
       lodash-es:
         specifier: 4.18.1
         version: 4.18.1
@@ -1110,8 +1110,8 @@ importers:
   packages/util:
     dependencies:
       bignumber.js:
-        specifier: ^9.1.2
-        version: 9.1.2
+        specifier: ^11.1.3
+        version: 11.1.3
       lodash-es:
         specifier: 4.18.1
         version: 4.18.1
@@ -4380,6 +4380,9 @@ packages:
   bigint-buffer@1.1.5:
     resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
     engines: {node: '>= 10.0.0'}
+
+  bignumber.js@11.1.3:
+    resolution: {integrity: sha512-+esZiNSo6VgFokTsYX6mYqNJfFd/IczzZCd4Z7cR8e+AQWhvIcj6nqQ1h9814D9u/TApU0jjTVmfWL0Pd1ZBdA==}
 
   bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
@@ -13429,6 +13432,8 @@ snapshots:
   bigint-buffer@1.1.5:
     dependencies:
       bindings: 1.5.0
+
+  bignumber.js@11.1.3: {}
 
   bignumber.js@9.1.2: {}
 


### PR DESCRIPTION
Updates bignumber.js from `9.1.2` to `11.1.3` across `@talismn/util`, `@talismn/balances` and the extension.

### Behaviour
bignumber.js v10+ throws on invalid input (`null`/`undefined`/non-numeric strings) where v9 returned `NaN`. To keep existing callers working unchanged, a small `configureBigNumber` module sets `STRICT: false` (the maintainer's intended v9→v11 compatibility switch) and re-exports the configured `BigNumber`; the modules that construct BigNumbers import it so the config always runs before any value is built.

Valid-input results and every other default (`DECIMAL_PLACES`, `ROUNDING_MODE`, `EXPONENTIAL_AT`, `RANGE`, …) are identical between v9 and v11 — formatting output is byte-for-byte unchanged.

Pinned to `11.1.3` (11.1.4 is still inside the release-age window).

### Verify
- `@talismn/util` + `@talismn/balances` tests (incl. an existing `planckToTokens("abc") === "NaN"` case + new `configureBigNumber` guards), typecheck, biome
- `build:packages` (tsup d.ts) and extension typecheck + production `wxt zip`