### PR TITLE
fix: rename folder modal registration

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/layout/notifications/DashboardNotificationsAndModals.tsx
+++ b/apps/extension/src/ui/apps/dashboard/layout/notifications/DashboardNotificationsAndModals.tsx
@@ -3,6 +3,8 @@ import { AccountExportModal } from "@ui/domains/Account/AccountExportModal"
 import { AccountExportPrivateKeyModal } from "@ui/domains/Account/AccountExportPrivateKeyModal"
 import { AccountRemoveModal } from "@ui/domains/Account/AccountRemoveModal"
 import { AccountRenameModal } from "@ui/domains/Account/AccountRenameModal"
+import { DeleteFolderModal } from "@ui/domains/Account/DeleteFolderModal"
+import { RenameFolderModal } from "@ui/domains/Account/RenameFolderModal"
 import { AddProxyModal } from "@ui/domains/AccountProxies/AddProxy/AddProxyModal"
 import { ManageProxyModal } from "@ui/domains/AccountProxies/ManageProxy/ManageProxyModal"
 import { CopyAddressModal } from "@ui/domains/CopyAddress"
@@ -56,6 +58,8 @@ export const DashboardNotificationsAndModals = () => {
       <AccountExportPrivateKeyModal />
       <AccountRemoveModal />
       <AccountRenameModal />
+      <RenameFolderModal />
+      <DeleteFolderModal />
       <BondModal />
       <BittensorBondModal />
       <BittensorConvictionLockModal />

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/Accounts.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/Accounts.tsx
@@ -3,7 +3,6 @@ import type { AnalyticsPage } from "@ui/api/analytics"
 import { DashboardLayout } from "@ui/apps/dashboard/layout"
 import { HeaderBlock } from "@ui/components/HeaderBlock"
 import { Spacer } from "@ui/components/Spacer"
-import { DeleteFolderModal } from "@ui/domains/Account/DeleteFolderModal"
 import {
   ManageAccountsLists,
   ManageAccountsProvider,
@@ -11,7 +10,6 @@ import {
   ManageAccountsWelcome,
 } from "@ui/domains/Account/ManageAccounts"
 import { NewFolderModal } from "@ui/domains/Account/NewFolderModal"
-import { RenameFolderModal } from "@ui/domains/Account/RenameFolderModal"
 import { useAnalyticsPageView } from "@ui/hooks/useAnalyticsPageView"
 import { accounts$, accountsCatalog$ } from "@ui/state/accounts"
 import { balancesHydrate$ } from "@ui/state/balances"
@@ -42,8 +40,6 @@ const Content = () => {
         <ManageAccountsLists />
       </ManageAccountsProvider>
       <NewFolderModal />
-      <RenameFolderModal />
-      <DeleteFolderModal />
       <ManageAccountsWelcome />
     </>
   )

--- a/apps/extension/src/ui/apps/popup/index.tsx
+++ b/apps/extension/src/ui/apps/popup/index.tsx
@@ -10,6 +10,8 @@ import { AccountExportModal } from "@ui/domains/Account/AccountExportModal"
 import { AccountExportPrivateKeyModal } from "@ui/domains/Account/AccountExportPrivateKeyModal"
 import { AccountRemoveModal } from "@ui/domains/Account/AccountRemoveModal"
 import { AccountRenameModal } from "@ui/domains/Account/AccountRenameModal"
+import { DeleteFolderModal } from "@ui/domains/Account/DeleteFolderModal"
+import { RenameFolderModal } from "@ui/domains/Account/RenameFolderModal"
 import { AddProxyModal } from "@ui/domains/AccountProxies/AddProxy/AddProxyModal"
 import { ManageProxyModal } from "@ui/domains/AccountProxies/ManageProxy/ManageProxyModal"
 import { CopyAddressModal } from "@ui/domains/CopyAddress"
@@ -104,6 +106,8 @@ const Popup = () => {
         <AccountExportPrivateKeyModal />
         <AccountRemoveModal />
         <AccountRenameModal />
+        <RenameFolderModal />
+        <DeleteFolderModal />
         <BondModal />
         <BittensorBondModal />
         <BittensorConvictionLockModal />

--- a/apps/extension/src/ui/apps/popup/pages/ManageAccounts.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/ManageAccounts.tsx
@@ -1,7 +1,6 @@
 import { ChevronLeftIcon } from "@talismn/icons"
 import { type AnalyticsPage, sendAnalyticsEvent } from "@ui/api/analytics"
 import { IconButton } from "@ui/components/IconButton"
-import { DeleteFolderModal } from "@ui/domains/Account/DeleteFolderModal"
 import {
   ManageAccountsLists,
   ManageAccountsProvider,
@@ -9,7 +8,6 @@ import {
   ManageAccountsWelcome,
 } from "@ui/domains/Account/ManageAccounts"
 import { NewFolderModal } from "@ui/domains/Account/NewFolderModal"
-import { RenameFolderModal } from "@ui/domains/Account/RenameFolderModal"
 import { useCallback } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -52,8 +50,6 @@ export const ManageAccountsPage = () => (
       </ManageAccountsProvider>
     </PopupContent>
     <NewFolderModal />
-    <DeleteFolderModal />
-    <RenameFolderModal />
     <ManageAccountsWelcome />
   </PopupLayout>
 )


### PR DESCRIPTION
- Registers the RenameFolderModal and RemoveFolderModal in portfolio so they can be opened from context menu
- Fixes https://github.com/TalismanSociety/talisman-qa/issues/127