### PR TITLE
chore: ⬆️ bump @zondax/ledger-substrate to v2

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -74,7 +74,7 @@
     "@wallet-standard/base": "^1.1.0",
     "@wallet-standard/features": "^1.1.0",
     "@yieldxyz/sdk": "^0.0.6",
-    "@zondax/ledger-substrate": "1.1.2",
+    "@zondax/ledger-substrate": "2.3.5",
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
     "anylogger": "^1.0.11",

--- a/apps/extension/src/ui/domains/Account/LedgerPolkadotAccountPicker/LedgerPolkadotAccountPickerCustom.tsx
+++ b/apps/extension/src/ui/domains/Account/LedgerPolkadotAccountPicker/LedgerPolkadotAccountPickerCustom.tsx
@@ -8,11 +8,11 @@ import { FormFieldInputText } from "@ui/components/FormFieldInputText"
 import { Tooltip, TooltipTrigger } from "@ui/components/Tooltip"
 import { Fiat } from "@ui/domains/Asset/Fiat"
 import { getTalismanLedgerError, TalismanLedgerError } from "@ui/hooks/ledger/errors"
+import type { SubstrateAppParams } from "@ui/hooks/ledger/legacy"
 import { useAccountImportBalances } from "@ui/hooks/useAccountImportBalances"
 import { useAccounts } from "@ui/state/accounts"
 import { useNetworkById } from "@ui/state/chaindata"
 import { cn } from "@ui/util/cn"
-import type { SubstrateAppParams } from "@zondax/ledger-substrate/dist/common"
 import {
   type ChangeEventHandler,
   type FC,

--- a/apps/extension/src/ui/domains/Account/LedgerPolkadotAccountPicker/LedgerPolkadotAccountPickerDefault.tsx
+++ b/apps/extension/src/ui/domains/Account/LedgerPolkadotAccountPicker/LedgerPolkadotAccountPickerDefault.tsx
@@ -3,10 +3,10 @@ import type { Account, LedgerPolkadotCurve } from "@core/domains/keyring/exports
 import { isAddressEqual } from "@talismn/crypto"
 import { isNotNil } from "@talismn/util"
 import { getTalismanLedgerError } from "@ui/hooks/ledger/errors"
+import type { SubstrateAppParams } from "@ui/hooks/ledger/legacy"
 import { useAccountImportBalances } from "@ui/hooks/useAccountImportBalances"
 import { useAccounts } from "@ui/state/accounts"
 import { useNetworkById, useNetworks } from "@ui/state/chaindata"
-import type { SubstrateAppParams } from "@zondax/ledger-substrate/dist/common"
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 

--- a/apps/extension/src/ui/domains/Account/LedgerPolkadotAccountPicker/types.ts
+++ b/apps/extension/src/ui/domains/Account/LedgerPolkadotAccountPicker/types.ts
@@ -1,5 +1,5 @@
 import type { DotNetworkId } from "@talismn/chaindata-provider"
-import type { SubstrateAppParams } from "@zondax/ledger-substrate/dist/common"
+import type { SubstrateAppParams } from "@ui/hooks/ledger/legacy"
 
 import type { LedgerAccountDefSubstrate } from "../AccountAdd/AccountAddLedger/context"
 import type { DerivedAccountBase } from "../DerivedAccountPickerBase"

--- a/apps/extension/src/ui/domains/Account/LedgerPolkadotAccountPicker/useGetLedgerPolkadotAddress.ts
+++ b/apps/extension/src/ui/domains/Account/LedgerPolkadotAccountPicker/useGetLedgerPolkadotAddress.ts
@@ -1,11 +1,9 @@
 import type { LedgerPolkadotCurve } from "@core/domains/keyring/exports"
 import { normalizeAddress } from "@talismn/crypto"
 import { getPolkadotLedgerDerivationPath } from "@ui/hooks/ledger/common"
+import type { SubstrateAppParams } from "@ui/hooks/ledger/legacy"
 import { useLedgerPolkadot } from "@ui/hooks/ledger/useLedgerPolkadot"
-import type {
-  GenericeResponseAddress,
-  SubstrateAppParams,
-} from "@zondax/ledger-substrate/dist/common"
+import type { GenericeResponseAddress } from "@zondax/ledger-substrate/dist/common"
 import { useCallback, useRef } from "react"
 
 export const useGetLedgerPolkadotAddress = (

--- a/apps/extension/src/ui/domains/Account/LedgerPolkadotLegacyAccountPicker/LedgerPolkadotLegacyAccountPickerCustom.tsx
+++ b/apps/extension/src/ui/domains/Account/LedgerPolkadotLegacyAccountPicker/LedgerPolkadotLegacyAccountPickerCustom.tsx
@@ -9,12 +9,12 @@ import { FormFieldInputText } from "@ui/components/FormFieldInputText"
 import { Tooltip, TooltipTrigger } from "@ui/components/Tooltip"
 import { Fiat } from "@ui/domains/Asset/Fiat"
 import { getTalismanLedgerError, TalismanLedgerError } from "@ui/hooks/ledger/errors"
+import type { SubstrateAppParams } from "@ui/hooks/ledger/legacy"
 import { useLedgerSubstrateAppByChain } from "@ui/hooks/ledger/useLedgerSubstrateApp"
 import { useAccountImportBalances } from "@ui/hooks/useAccountImportBalances"
 import { useAccounts } from "@ui/state/accounts"
 import { useNetworkById } from "@ui/state/chaindata"
 import { cn } from "@ui/util/cn"
-import type { SubstrateAppParams } from "@zondax/ledger-substrate/dist/common"
 import {
   type ChangeEventHandler,
   type FC,

--- a/apps/extension/src/ui/hooks/ledger/common.ts
+++ b/apps/extension/src/ui/hooks/ledger/common.ts
@@ -1,6 +1,6 @@
 import type { DotNetworkId } from "@talismn/chaindata-provider"
-import { supportedApps } from "@zondax/ledger-substrate"
-import type { SubstrateAppParams } from "@zondax/ledger-substrate/dist/common"
+import type { SubstrateAppParams } from "./legacy"
+import { supportedApps } from "./legacy"
 
 export const CHAIN_ID_TO_LEDGER_APP_NAME: Partial<Record<DotNetworkId, string>> = {
   "kusama": "Kusama",

--- a/apps/extension/src/ui/hooks/ledger/legacy/index.ts
+++ b/apps/extension/src/ui/hooks/ledger/legacy/index.ts
@@ -1,0 +1,4 @@
+export type { ResponseAddress, ResponseBase, ResponseSign } from "./substrateApp"
+export { SubstrateApp } from "./substrateApp"
+export type { SubstrateAppParams } from "./supportedApps"
+export { supportedApps } from "./supportedApps"

--- a/apps/extension/src/ui/hooks/ledger/legacy/substrateApp.test.ts
+++ b/apps/extension/src/ui/hooks/ledger/legacy/substrateApp.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+
+import { SubstrateApp } from "./substrateApp"
+import { supportedApps } from "./supportedApps"
+
+// These are byte-identical guards for the code vendored from
+// @zondax/ledger-substrate@1.1.2. If any of them break, the bytes we send to a
+// legacy Ledger app (or the app we resolve for an account) have drifted from
+// upstream and signing for un-migrated accounts is at risk.
+
+describe("legacy SubstrateApp.serializePath", () => {
+  it("serializes the Polkadot index-0 path m/44'/354'/0'/0'/0'", () => {
+    const HARDENED = 0x80000000
+    // slip0044 for Polkadot is 0x80000162 (354'); account/change/addressIndex hardened to 0
+    const path = SubstrateApp.serializePath(0x80000162, HARDENED, HARDENED, HARDENED)
+
+    expect(path).toHaveLength(20)
+    // 0x8000002c | 0x80000162 | 0x80000000 | 0x80000000 | 0x80000000, little-endian
+    expect(path.toString("hex")).toBe("2c00008062010080000000800000008000000080")
+  })
+
+  it("serializes the Kusama index-0 path m/44'/434'/0'/0'/0'", () => {
+    const HARDENED = 0x80000000
+    // slip0044 for Kusama is 0x800001b2 (434')
+    const path = SubstrateApp.serializePath(0x800001b2, HARDENED, HARDENED, HARDENED)
+
+    // 0x8000002c | 0x800001b2 | 0x80000000 | 0x80000000 | 0x80000000, little-endian
+    expect(path.toString("hex")).toBe("2c000080b2010080000000800000008000000080")
+  })
+
+  it("rejects non-integer inputs", () => {
+    expect(() => SubstrateApp.serializePath(0x80000162, 1.5, 0, 0)).toThrow(
+      "Input must be an integer"
+    )
+  })
+})
+
+describe("legacy SubstrateApp.GetChunks", () => {
+  it("splits messages into 250-byte chunks", () => {
+    const chunks = SubstrateApp.GetChunks(Buffer.alloc(300))
+    expect(chunks.map((c) => c.length)).toEqual([250, 50])
+  })
+
+  it("returns a single chunk for short messages", () => {
+    const chunks = SubstrateApp.GetChunks(Buffer.alloc(10))
+    expect(chunks.map((c) => c.length)).toEqual([10])
+  })
+})
+
+describe("legacy supportedApps registry", () => {
+  it("contains the full upstream set", () => {
+    expect(supportedApps).toHaveLength(47)
+  })
+
+  it.each([
+    ["Polkadot", 0x90, 0x80000162, 0],
+    ["Kusama", 0x99, 0x800001b2, 2],
+    ["Acala", 0x9b, 0x80000313, 10],
+    ["Bittensor", 0xb4, 0x800003ed, 42],
+    ["Statemine", 0x97, 0x800001b2, 2],
+  ])("resolves %s to its CLA / SLIP-0044 / ss58 prefix", (name, cla, slip0044, ss58) => {
+    const app = supportedApps.find((a) => a.name === name)
+    expect(app).toEqual({ name, cla, slip0044, ss58_addr_type: ss58 })
+  })
+
+  it("has no duplicate CLA bytes", () => {
+    const clas = supportedApps.map((a) => a.cla)
+    expect(new Set(clas).size).toBe(clas.length)
+  })
+})

--- a/apps/extension/src/ui/hooks/ledger/legacy/substrateApp.ts
+++ b/apps/extension/src/ui/hooks/ledger/legacy/substrateApp.ts
@@ -5,13 +5,16 @@
  *  (the device-specific apps — Kusama, Acala, …) in favour of the single
  *  `PolkadotGenericApp`. Talisman still has to sign for accounts that were
  *  created under those legacy apps (and have not been migrated to the generic
- *  app), so we keep a byte-identical copy of the APDU implementation here while
- *  the live dependency moves to v2 for the generic app.
+ *  app), so we keep a TS reimplementation of the APDU layer here while the live
+ *  dependency moves to v2 for the generic app.
+ *
+ *  This is a reimplementation, not a verbatim copy — the methods are rewritten,
+ *  but every `transport.send` (CLA / INS / P1 / P2 / payload + path
+ *  serialization) is byte-for-byte what 1.1.2 sent, so the device sees identical
+ *  bytes. Verified against the 1.1.2 dist and guarded by substrateApp.test.ts.
  *
  *  Only the methods Talisman actually uses are kept (`getAddress`, `sign`,
  *  `signRaw`); the deprecated allowlist/upload/version helpers were removed.
- *  The serialization and `transport.send` calls are unchanged from upstream so
- *  the bytes sent to the device are identical.
  *
  *  (c) 2019 - 2024 Zondax AG
  *  (c) 2016-2017 Ledger

--- a/apps/extension/src/ui/hooks/ledger/legacy/substrateApp.ts
+++ b/apps/extension/src/ui/hooks/ledger/legacy/substrateApp.ts
@@ -1,0 +1,304 @@
+/** ******************************************************************************
+ *  Vendored from @zondax/ledger-substrate@1.1.2 (Apache-2.0).
+ *
+ *  @zondax/ledger-substrate v2 dropped the legacy per-chain `SubstrateApp`
+ *  (the device-specific apps — Kusama, Acala, …) in favour of the single
+ *  `PolkadotGenericApp`. Talisman still has to sign for accounts that were
+ *  created under those legacy apps (and have not been migrated to the generic
+ *  app), so we keep a byte-identical copy of the APDU implementation here while
+ *  the live dependency moves to v2 for the generic app.
+ *
+ *  Only the methods Talisman actually uses are kept (`getAddress`, `sign`,
+ *  `signRaw`); the deprecated allowlist/upload/version helpers were removed.
+ *  The serialization and `transport.send` calls are unchanged from upstream so
+ *  the bytes sent to the device are identical.
+ *
+ *  (c) 2019 - 2024 Zondax AG
+ *  (c) 2016-2017 Ledger
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************* */
+import type Transport from "@ledgerhq/hw-transport"
+
+const CHUNK_SIZE = 250
+
+const INS = { GET_ADDR: 0x01, SIGN: 0x02, SIGN_RAW: 0x03 } as const
+type SignIns = typeof INS.SIGN | typeof INS.SIGN_RAW
+
+const PAYLOAD_TYPE = { INIT: 0x00, ADD: 0x01, LAST: 0x02 } as const
+
+const SCHEME = { ED25519: 0x00, SR25519: 0x01, ECDSA: 0x02 } as const
+type Scheme = (typeof SCHEME)[keyof typeof SCHEME]
+
+const ERROR_CODE = { NoError: 0x9000, InvalidData: 0x6984 } as const
+
+const ERROR_DESCRIPTION: Record<number, string> = {
+  1: "U2F: Unknown",
+  2: "U2F: Bad request",
+  3: "U2F: Configuration unsupported",
+  4: "U2F: Device Ineligible",
+  5: "U2F: Timeout",
+  14: "Timeout",
+  36864: "No errors",
+  36865: "Device is busy",
+  26626: "Error deriving keys",
+  25600: "Execution Error",
+  26368: "Wrong Length",
+  27010: "Empty Buffer",
+  27011: "Output buffer too small",
+  27012: "Data is invalid",
+  27013: "Conditions not satisfied",
+  27014: "Transaction rejected",
+  27264: "Bad key handle",
+  27392: "Invalid P1/P2",
+  27904: "Instruction not supported",
+  28161: "App does not seem to be open",
+  28416: "Unknown error",
+  28417: "Sign/verify error",
+}
+
+const errorCodeToString = (statusCode: number) =>
+  statusCode in ERROR_DESCRIPTION
+    ? ERROR_DESCRIPTION[statusCode]
+    : `Unknown Status Code: ${statusCode}`
+
+const isDict = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v) && !(v instanceof Date)
+
+export interface ResponseBase {
+  error_message: string
+  return_code: number
+}
+
+export interface ResponseAddress extends ResponseBase {
+  address: string
+  pubKey: string
+}
+
+export interface ResponseSign extends ResponseBase {
+  signature: Buffer
+}
+
+const processErrorResponse = (response: unknown): ResponseBase => {
+  if (response != null) {
+    if (isDict(response)) {
+      if (Object.hasOwn(response, "returnCode"))
+        return {
+          return_code: response.returnCode as number,
+          error_message: errorCodeToString(response.returnCode as number),
+        }
+
+      if (Object.hasOwn(response, "statusCode"))
+        return {
+          return_code: response.statusCode as number,
+          error_message: errorCodeToString(response.statusCode as number),
+        }
+
+      if (Object.hasOwn(response, "return_code") && Object.hasOwn(response, "error_message"))
+        return response as unknown as ResponseBase
+    }
+
+    return {
+      return_code: 0xffff,
+      error_message: String(response),
+    }
+  }
+
+  return {
+    return_code: 0xffff,
+    error_message: String(response),
+  }
+}
+
+/**
+ * Class representing a legacy (per-chain) Substrate Ledger application.
+ */
+export class SubstrateApp {
+  transport: Transport
+  cla: number
+  slip0044: number
+
+  constructor(transport: Transport, cla: number, slip0044: number) {
+    if (transport == null) {
+      throw new Error("Transport has not been defined")
+    }
+    this.transport = transport
+    this.cla = cla
+    this.slip0044 = slip0044
+  }
+
+  static serializePath(
+    slip0044: number,
+    account: number,
+    change: number,
+    addressIndex: number
+  ): Buffer {
+    if (!Number.isInteger(account)) throw new Error("Input must be an integer")
+    if (!Number.isInteger(change)) throw new Error("Input must be an integer")
+    if (!Number.isInteger(addressIndex)) throw new Error("Input must be an integer")
+
+    const buf = Buffer.alloc(20)
+    buf.writeUInt32LE(0x8000002c, 0)
+    buf.writeUInt32LE(slip0044, 4)
+    buf.writeUInt32LE(account, 8)
+    buf.writeUInt32LE(change, 12)
+    buf.writeUInt32LE(addressIndex, 16)
+    return buf
+  }
+
+  static GetChunks(message: Buffer): Buffer[] {
+    const chunks: Buffer[] = []
+    const buffer = Buffer.from(message)
+
+    for (let i = 0; i < buffer.length; i += CHUNK_SIZE) {
+      let end = i + CHUNK_SIZE
+      if (i > buffer.length) {
+        end = buffer.length
+      }
+      chunks.push(buffer.subarray(i, end))
+    }
+
+    return chunks
+  }
+
+  static signGetChunks(
+    slip0044: number,
+    account: number,
+    change: number,
+    addressIndex: number,
+    message: Buffer
+  ): Buffer[] {
+    const chunks = []
+    const bip44Path = SubstrateApp.serializePath(slip0044, account, change, addressIndex)
+    chunks.push(bip44Path)
+    chunks.push(...SubstrateApp.GetChunks(message))
+    return chunks
+  }
+
+  async getAddress(
+    account: number,
+    change: number,
+    addressIndex: number,
+    requireConfirmation = false,
+    scheme: Scheme = SCHEME.ED25519
+  ): Promise<ResponseAddress> {
+    const bip44Path = SubstrateApp.serializePath(this.slip0044, account, change, addressIndex)
+
+    const p1 = requireConfirmation ? 1 : 0
+    const p2 = Number.isNaN(scheme) ? 0 : scheme
+
+    return this.transport.send(this.cla, INS.GET_ADDR, p1, p2, bip44Path).then((response) => {
+      const errorCodeData = response.subarray(-2)
+      const errorCode = errorCodeData[0] * 256 + errorCodeData[1]
+
+      const pubkeyLen = scheme === SCHEME.ECDSA ? 33 : 32
+
+      return {
+        pubKey: response.subarray(0, pubkeyLen).toString("hex"),
+        address: response.subarray(pubkeyLen, response.length - 2).toString("ascii"),
+        return_code: errorCode,
+        error_message: errorCodeToString(errorCode),
+      }
+    }, processErrorResponse) as Promise<ResponseAddress>
+  }
+
+  private async signSendChunk(
+    chunkIdx: number,
+    chunkNum: number,
+    chunk: Buffer,
+    scheme: Scheme = SCHEME.ED25519,
+    ins: SignIns = INS.SIGN
+  ): Promise<{ signature: Buffer | null; return_code: number; error_message: string }> {
+    let payloadType: number = PAYLOAD_TYPE.ADD
+    if (chunkIdx === 1) {
+      payloadType = PAYLOAD_TYPE.INIT
+    }
+    if (chunkIdx === chunkNum) {
+      payloadType = PAYLOAD_TYPE.LAST
+    }
+
+    const p2 = Number.isNaN(scheme) ? 0 : scheme
+
+    return this.transport
+      .send(this.cla, ins, payloadType, p2, chunk, [ERROR_CODE.NoError, 0x6984, 0x6a80])
+      .then(
+        (response) => {
+          const errorCodeData = response.subarray(-2)
+          const returnCode = errorCodeData[0] * 256 + errorCodeData[1]
+          let errorMessage = errorCodeToString(returnCode)
+          let signature: Buffer | null = null
+
+          if (returnCode === 0x6a80 || returnCode === 0x6984) {
+            errorMessage = response.subarray(0, response.length - 2).toString("ascii")
+          } else if (response.length > 2) {
+            signature = response.subarray(0, response.length - 2)
+          }
+
+          return { signature, return_code: returnCode, error_message: errorMessage }
+        },
+        (e: unknown) => ({ signature: null, ...processErrorResponse(e) })
+      )
+  }
+
+  private async signImpl(
+    account: number,
+    change: number,
+    addressIndex: number,
+    message: Buffer,
+    ins: SignIns,
+    scheme: Scheme = SCHEME.ED25519
+  ): Promise<ResponseSign> {
+    const chunks = SubstrateApp.signGetChunks(this.slip0044, account, change, addressIndex, message)
+
+    // the first chunk is the bip44 path; its response is intentionally ignored
+    await this.signSendChunk(1, chunks.length, chunks[0], scheme, ins)
+
+    let result: { signature: Buffer | null; return_code: number; error_message: string } = {
+      signature: null,
+      return_code: ERROR_CODE.NoError,
+      error_message: errorCodeToString(ERROR_CODE.NoError),
+    }
+    for (let i = 1; i < chunks.length; i += 1) {
+      result = await this.signSendChunk(1 + i, chunks.length, chunks[i], scheme, ins)
+      if (result.return_code !== ERROR_CODE.NoError) {
+        break
+      }
+    }
+
+    return {
+      return_code: result.return_code,
+      error_message: result.error_message,
+      signature: result.signature as Buffer,
+    }
+  }
+
+  async sign(
+    account: number,
+    change: number,
+    addressIndex: number,
+    message: Buffer,
+    scheme: Scheme = SCHEME.ED25519
+  ): Promise<ResponseSign> {
+    return this.signImpl(account, change, addressIndex, message, INS.SIGN, scheme)
+  }
+
+  async signRaw(
+    account: number,
+    change: number,
+    addressIndex: number,
+    message: Buffer,
+    scheme: Scheme = SCHEME.ED25519
+  ): Promise<ResponseSign> {
+    return this.signImpl(account, change, addressIndex, message, INS.SIGN_RAW, scheme)
+  }
+}

--- a/apps/extension/src/ui/hooks/ledger/legacy/supportedApps.ts
+++ b/apps/extension/src/ui/hooks/ledger/legacy/supportedApps.ts
@@ -4,7 +4,8 @@
  *  The registry of legacy (per-chain) Substrate Ledger apps. @zondax/ledger-substrate
  *  v2 removed this list along with the legacy `SubstrateApp`; Talisman still needs
  *  it to resolve the CLA / SLIP-0044 of accounts created under those apps (see
- *  ./substrateApp.ts). Kept byte-identical to upstream.
+ *  ./substrateApp.ts). Values reproduced verbatim from 1.1.2
+ *  (name / cla / slip0044 / ss58); guarded by substrateApp.test.ts.
  *
  *  (c) 2019 - 2024 Zondax AG
  *  (c) 2016-2017 Ledger

--- a/apps/extension/src/ui/hooks/ledger/legacy/supportedApps.ts
+++ b/apps/extension/src/ui/hooks/ledger/legacy/supportedApps.ts
@@ -1,0 +1,315 @@
+/** ******************************************************************************
+ *  Vendored from @zondax/ledger-substrate@1.1.2 (Apache-2.0).
+ *
+ *  The registry of legacy (per-chain) Substrate Ledger apps. @zondax/ledger-substrate
+ *  v2 removed this list along with the legacy `SubstrateApp`; Talisman still needs
+ *  it to resolve the CLA / SLIP-0044 of accounts created under those apps (see
+ *  ./substrateApp.ts). Kept byte-identical to upstream.
+ *
+ *  (c) 2019 - 2024 Zondax AG
+ *  (c) 2016-2017 Ledger
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************* */
+
+export interface SubstrateAppParams {
+  name: string
+  cla: number
+  slip0044: number
+  ss58_addr_type: number
+}
+
+export const supportedApps: SubstrateAppParams[] = [
+  {
+    name: "Polkadot",
+    cla: 0x90,
+    slip0044: 0x80000162,
+    ss58_addr_type: 0,
+  },
+  {
+    name: "Polymesh",
+    cla: 0x91,
+    slip0044: 0x80000253,
+    ss58_addr_type: 12,
+  },
+  {
+    name: "Dock",
+    cla: 0x92,
+    slip0044: 0x80000252,
+    ss58_addr_type: 22,
+  },
+  {
+    name: "Centrifuge",
+    cla: 0x93,
+    slip0044: 0x800002eb,
+    ss58_addr_type: 36,
+  },
+  {
+    name: "Edgeware",
+    cla: 0x94,
+    slip0044: 0x8000020b,
+    ss58_addr_type: 7,
+  },
+  {
+    name: "Equilibrium",
+    cla: 0x95,
+    slip0044: 0x85f5e0fd,
+    ss58_addr_type: 67,
+  },
+  {
+    name: "Statemint",
+    cla: 0x96,
+    slip0044: 0x80000162,
+    ss58_addr_type: 0,
+  },
+  {
+    name: "Statemine",
+    cla: 0x97,
+    slip0044: 0x800001b2,
+    ss58_addr_type: 2,
+  },
+  {
+    name: "Nodle",
+    cla: 0x98,
+    slip0044: 0x800003eb,
+    ss58_addr_type: 37,
+  },
+  {
+    name: "Kusama",
+    cla: 0x99,
+    slip0044: 0x800001b2,
+    ss58_addr_type: 2,
+  },
+  {
+    name: "Karura",
+    cla: 0x9a,
+    slip0044: 0x800002ae,
+    ss58_addr_type: 8,
+  },
+  {
+    name: "Acala",
+    cla: 0x9b,
+    slip0044: 0x80000313,
+    ss58_addr_type: 10,
+  },
+  {
+    name: "VTB",
+    cla: 0x9c,
+    slip0044: 0x800002b6,
+    ss58_addr_type: 42,
+  },
+  {
+    name: "Peer",
+    cla: 0x9d,
+    slip0044: 0x800002ce,
+    ss58_addr_type: 42,
+  },
+  {
+    name: "Genshiro",
+    cla: 0x9e,
+    slip0044: 0x85f5e0fc,
+    ss58_addr_type: 67,
+  },
+  {
+    name: "Sora",
+    cla: 0x9f,
+    slip0044: 0x80000269,
+    ss58_addr_type: 69,
+  },
+  {
+    name: "Polkadex",
+    cla: 0xa0,
+    slip0044: 0x8000031f,
+    ss58_addr_type: 88,
+  },
+  {
+    name: "Bifrost",
+    cla: 0xa1,
+    slip0044: 0x80000314,
+    ss58_addr_type: 6,
+  },
+  {
+    name: "Reef",
+    cla: 0xa2,
+    slip0044: 0x80000333,
+    ss58_addr_type: 42,
+  },
+  {
+    name: "XXNetwork",
+    cla: 0xa3,
+    slip0044: 0x800007a3,
+    ss58_addr_type: 55,
+  },
+  {
+    name: "AlephZero",
+    cla: 0xa4,
+    slip0044: 0x80000283,
+    ss58_addr_type: 42,
+  },
+  {
+    name: "Interlay",
+    cla: 0xa5,
+    slip0044: 0x80000162,
+    ss58_addr_type: 2032,
+  },
+  {
+    name: "Parallel",
+    cla: 0xa6,
+    slip0044: 0x80000162,
+    ss58_addr_type: 172,
+  },
+  {
+    name: "Picasso",
+    cla: 0xa7,
+    slip0044: 0x800001b2,
+    ss58_addr_type: 49,
+  },
+  {
+    name: "Composable",
+    cla: 0xa8,
+    slip0044: 0x80000162,
+    ss58_addr_type: 49,
+  },
+  {
+    name: "Astar",
+    cla: 0xa9,
+    slip0044: 0x8000032a,
+    ss58_addr_type: 5,
+  },
+  {
+    name: "OriginTrail",
+    cla: 0xaa,
+    slip0044: 0x80000162,
+    ss58_addr_type: 101,
+  },
+  {
+    name: "HydraDX",
+    cla: 0xab,
+    slip0044: 0x80000162,
+    ss58_addr_type: 63,
+  },
+  {
+    name: "Stafi",
+    cla: 0xac,
+    slip0044: 0x8000038b,
+    ss58_addr_type: 20,
+  },
+  {
+    name: "Unique",
+    cla: 0xad,
+    slip0044: 0x80000295,
+    ss58_addr_type: 7391,
+  },
+  {
+    name: "BifrostKusama",
+    cla: 0xae,
+    slip0044: 0x80000314,
+    ss58_addr_type: 6,
+  },
+  {
+    name: "Phala",
+    cla: 0xaf,
+    slip0044: 0x80000162,
+    ss58_addr_type: 30,
+  },
+  {
+    name: "Khala",
+    cla: 0xb1,
+    slip0044: 0x800001b2,
+    ss58_addr_type: 30,
+  },
+  {
+    name: "Darwinia",
+    cla: 0xb2,
+    slip0044: 0x80000162,
+    ss58_addr_type: 18,
+  },
+  {
+    name: "Ajuna",
+    cla: 0xb3,
+    slip0044: 0x80000162,
+    ss58_addr_type: 1328,
+  },
+  {
+    name: "Bittensor",
+    cla: 0xb4,
+    slip0044: 0x800003ed,
+    ss58_addr_type: 42,
+  },
+  {
+    name: "Ternoa",
+    cla: 0xb5,
+    slip0044: 0x800003e3,
+    ss58_addr_type: 42,
+  },
+  {
+    name: "Pendulum",
+    cla: 0xb6,
+    slip0044: 0x80000162,
+    ss58_addr_type: 56,
+  },
+  {
+    name: "Zeitgeist",
+    cla: 0xb7,
+    slip0044: 0x80000162,
+    ss58_addr_type: 73,
+  },
+  {
+    name: "Joystream",
+    cla: 0xb8,
+    slip0044: 0x80000219,
+    ss58_addr_type: 126,
+  },
+  {
+    name: "Enjin",
+    cla: 0xb9,
+    slip0044: 0x80000483,
+    ss58_addr_type: 2135,
+  },
+  {
+    name: "Matrixchain",
+    cla: 0xba,
+    slip0044: 0x80000483,
+    ss58_addr_type: 1110,
+  },
+  {
+    name: "Quartz",
+    cla: 0xbb,
+    slip0044: 0x80000277,
+    ss58_addr_type: 255,
+  },
+  {
+    name: "Avail",
+    cla: 0xbc,
+    slip0044: 0x800002c5,
+    ss58_addr_type: 42,
+  },
+  {
+    name: "Entropy",
+    cla: 0xbd,
+    slip0044: 0x80000520,
+    ss58_addr_type: 42,
+  },
+  {
+    name: "Peaq",
+    cla: 0x61,
+    slip0044: 0x8000003c,
+    ss58_addr_type: 42,
+  },
+  {
+    name: "AvailRecovery",
+    cla: 0xbe,
+    slip0044: 0x80000162,
+    ss58_addr_type: 42,
+  },
+]

--- a/apps/extension/src/ui/hooks/ledger/useLedgerPolkadot.ts
+++ b/apps/extension/src/ui/hooks/ledger/useLedgerPolkadot.ts
@@ -4,15 +4,15 @@ import { isJsonPayload } from "@core/util/isJsonPayload"
 import type { TypeRegistry } from "@polkadot/types"
 import { hexToU8a, u8aToHex, u8aWrapBytes } from "@polkadot/util"
 import { isAddressEqual } from "@talismn/crypto"
-import { PolkadotGenericApp, supportedApps } from "@zondax/ledger-substrate"
-import type { SubstrateAppParams } from "@zondax/ledger-substrate/dist/common"
+import { PolkadotGenericApp } from "@zondax/ledger-substrate"
 import { t } from "i18next"
 import { useCallback, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { lt } from "semver"
-
 import { getPolkadotLedgerDerivationPath } from "./common"
 import { getOpenLedgerAppError, getTalismanLedgerError, TalismanLedgerError } from "./errors"
+import type { SubstrateAppParams } from "./legacy"
+import { supportedApps } from "./legacy"
 import { useLedgerTransport } from "./useLedgerTransport"
 
 type LedgerRequest<T> = (ledger: PolkadotGenericApp) => Promise<T>

--- a/apps/extension/src/ui/hooks/ledger/useLedgerSubstrateApp.ts
+++ b/apps/extension/src/ui/hooks/ledger/useLedgerSubstrateApp.ts
@@ -1,8 +1,7 @@
 import type { DotNetwork } from "@talismn/chaindata-provider"
-import { supportedApps } from "@zondax/ledger-substrate"
 import { useMemo } from "react"
-
 import { CHAIN_ID_TO_LEDGER_APP_NAME } from "./common"
+import { supportedApps } from "./legacy"
 
 export const useLedgerSubstrateAppByChain = (chain: DotNetwork | null | undefined) => {
   return useMemo(

--- a/apps/extension/src/ui/hooks/ledger/useLedgerSubstrateLegacy.ts
+++ b/apps/extension/src/ui/hooks/ledger/useLedgerSubstrateLegacy.ts
@@ -5,12 +5,9 @@ import type { TypeRegistry } from "@polkadot/types"
 import { u8aToHex, u8aWrapBytes } from "@polkadot/util"
 import { isAddressEqual } from "@talismn/crypto"
 import { useNetworkByGenesisHash } from "@ui/state/chaindata"
-import { SubstrateApp } from "@zondax/ledger-substrate"
-import type { SubstrateAppParams } from "@zondax/ledger-substrate/dist/common"
 import { t } from "i18next"
 import { useCallback, useRef } from "react"
 import { useTranslation } from "react-i18next"
-
 import { LEDGER_HARDENED_OFFSET, LEDGER_SUCCESS_CODE } from "./common"
 import {
   ERROR_LEDGER_EVM_CANNOT_SIGN_SUBSTRATE,
@@ -20,6 +17,8 @@ import {
   getTalismanLedgerError,
   TalismanLedgerError,
 } from "./errors"
+import type { SubstrateAppParams } from "./legacy"
+import { SubstrateApp } from "./legacy"
 import { useLedgerSubstrateAppByChain } from "./useLedgerSubstrateApp"
 import { useLedgerTransport } from "./useLedgerTransport"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,8 +434,8 @@ importers:
         specifier: ^0.0.6
         version: 0.0.6
       '@zondax/ledger-substrate':
-        specifier: 1.1.2
-        version: 1.1.2
+        specifier: 2.3.5
+        version: 2.3.5
       '@zxing/browser':
         specifier: ^0.1.5
         version: 0.1.5(@zxing/library@0.21.3)
@@ -1932,6 +1932,12 @@ packages:
 
   '@ledgerhq/hw-transport-mocker@6.34.4':
     resolution: {integrity: sha512-EmAXKfwhH30LGOIqvbsOtjOb4AAj1Q0XwEowXQkFhGLWUokhmlWnZSRgYhdiIoo9nDZ5it+7fG7SPUAI2RZsCA==}
+
+  '@ledgerhq/hw-transport-node-hid-noevents@6.35.4':
+    resolution: {integrity: sha512-187670Uuuek9ECcT92NQm1PnDfFHT6gBmaJinatnueMLV9lk3q4IrpFZqTotr+LhPNub+YdGQFjYJImcXvYWtw==}
+
+  '@ledgerhq/hw-transport-node-hid@6.33.4':
+    resolution: {integrity: sha512-/k0rH+wTpTmUifdxWuOER/dM3vPxW7RQIF0tByGC6noszVC3SGOZVcskBqJZ6xwIs1TvAHvZlEFvZWbnUJMBiw==}
 
   '@ledgerhq/hw-transport-webhid@6.35.4':
     resolution: {integrity: sha512-5tspX0/XMaLd5Nz45AYUcsevvG5QoYJ8/n8g4dUFfIketH8CZA9UPZbgPJD+OWykzhzYLQPGpahDmzxjItVZlQ==}
@@ -4146,6 +4152,9 @@ packages:
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
+  '@types/w3c-web-usb@1.0.14':
+    resolution: {integrity: sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==}
+
   '@types/webextension-polyfill@0.12.5':
     resolution: {integrity: sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==}
 
@@ -4256,11 +4265,11 @@ packages:
       msw:
         optional: true
 
-  '@zondax/ledger-js@1.2.0':
-    resolution: {integrity: sha512-HGvDU0s4zg0scu8ebGenFHFB6g5SLDqmrctncZUY9ie5pGibOU8C0VdjZSHbttSOCyh+IloLi/a4jyMPOEQGuQ==}
+  '@zondax/ledger-js@1.3.1':
+    resolution: {integrity: sha512-sDBwsunK2nSzkqJ5xi6QTiVVpAxSy+X1BVcMfKioBsInjktki2SezT7K8Hw6kSlYd3yfOJlw8cs+hqVtxpAGtg==}
 
-  '@zondax/ledger-substrate@1.1.2':
-    resolution: {integrity: sha512-O6DUhAYXNKuEdng0ih/6Gka6CKvDekfjtuaNAHzxv9Eq89vjRxCK8JE6Zh2qUb7DFxmyx8kdJ8um/dzs3t5Q+A==}
+  '@zondax/ledger-substrate@2.3.5':
+    resolution: {integrity: sha512-hUThBmTXGcrFOjJOZVWL61jqpgmImag7PAZ5zg+ByziHRU2CptoJrJ3v/bYrjTlsA7Jx1ydAUJDo8ajND7YTkQ==}
 
   '@zxing/browser@0.1.5':
     resolution: {integrity: sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==}
@@ -4447,6 +4456,9 @@ packages:
   axios@1.17.0:
     resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
 
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
+
   b4a@1.7.1:
     resolution: {integrity: sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==}
     peerDependencies:
@@ -4548,6 +4560,9 @@ packages:
 
   bitcoin-address-validation@2.2.3:
     resolution: {integrity: sha512-1uGCGl26Ye8JG5qcExtFLQfuib6qEZWNDo1ZlLlwp/z7ygUFby3IxolgEfgMGaC+LG9csbVASLcH8fRLv7DIOg==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   bl@5.1.0:
     resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
@@ -4756,6 +4771,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chrome-launcher@1.2.0:
     resolution: {integrity: sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==}
@@ -5082,6 +5100,10 @@ packages:
   decode-formdata@0.9.0:
     resolution: {integrity: sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -5282,6 +5304,9 @@ packages:
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -5489,6 +5514,10 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -5684,6 +5713,9 @@ packages:
       react-dom:
         optional: true
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@11.3.2:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
@@ -5772,6 +5804,9 @@ packages:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -6688,6 +6723,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
@@ -6723,6 +6762,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
@@ -6808,6 +6850,9 @@ packages:
   nanospinner@1.2.2:
     resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
@@ -6821,11 +6866,21 @@ packages:
     resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
     engines: {node: '>= 10.13'}
 
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
+
   node-addon-api@2.0.2:
     resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
 
+  node-addon-api@3.2.1:
+    resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
+
   node-addon-api@5.1.0:
     resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
+
+  node-addon-api@6.1.0:
+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -6854,6 +6909,11 @@ packages:
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  node-hid@2.1.2:
+    resolution: {integrity: sha512-qhCyQqrPpP93F/6Wc/xUR7L8mAJW0Z6R7HMQV8jCHHksAxNDe/4z4Un/H9CpLOT+5K39OPyt9tIQlavxWES3lg==}
+    engines: {node: '>=10'}
     hasBin: true
 
   node-notifier@10.0.1:
@@ -7245,6 +7305,12 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -7318,6 +7384,9 @@ packages:
   publish-browser-extension@3.0.3:
     resolution: {integrity: sha512-cBINZCkLo7YQaGoUvEHthZ0sDzgJQht28IS+SFMT2omSNhGsPiVNRkWir3qLiTrhGhW9Ci2KVHpA1QAMoBdL2g==}
     hasBin: true
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
@@ -7755,6 +7824,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
@@ -8046,6 +8121,13 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
@@ -8223,6 +8305,9 @@ packages:
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
@@ -8358,6 +8443,10 @@ packages:
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
     engines: {node: '>= 0.4'}
+
+  usb@2.9.0:
+    resolution: {integrity: sha512-G0I/fPgfHUzWH8xo2KkDxTTFruUWfppgSFJ+bQxz/kVY2x15EQ/XDB7dqD1G432G4gBG4jYQuF3U7j/orSs5nw==}
+    engines: {node: '>=10.20.0 <11.x || >=12.17.0 <13.0 || >=14.0.0'}
 
   use-sync-external-store@1.5.0:
     resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
@@ -9891,6 +9980,27 @@ snapshots:
       '@ledgerhq/hw-transport': 6.35.4
       '@ledgerhq/logs': 6.17.0
       rxjs: 7.8.2
+
+  '@ledgerhq/hw-transport-node-hid-noevents@6.35.4':
+    dependencies:
+      '@ledgerhq/devices': 8.15.1
+      '@ledgerhq/errors': 6.36.0
+      '@ledgerhq/hw-transport': 6.35.4
+      '@ledgerhq/logs': 6.17.0
+      node-hid: 2.1.2
+    optional: true
+
+  '@ledgerhq/hw-transport-node-hid@6.33.4':
+    dependencies:
+      '@ledgerhq/devices': 8.15.1
+      '@ledgerhq/errors': 6.36.0
+      '@ledgerhq/hw-transport': 6.35.4
+      '@ledgerhq/hw-transport-node-hid-noevents': 6.35.4
+      '@ledgerhq/logs': 6.17.0
+      lodash: 4.18.1
+      node-hid: 2.1.2
+      usb: 2.9.0
+    optional: true
 
   '@ledgerhq/hw-transport-webhid@6.35.4':
     dependencies:
@@ -13240,6 +13350,9 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
+  '@types/w3c-web-usb@1.0.14':
+    optional: true
+
   '@types/webextension-polyfill@0.12.5': {}
 
   '@types/webfontloader@1.6.38': {}
@@ -13374,15 +13487,18 @@ snapshots:
 
   '@yieldxyz/sdk@0.0.6': {}
 
-  '@zondax/ledger-js@1.2.0':
+  '@zondax/ledger-js@1.3.1':
     dependencies:
       '@ledgerhq/hw-transport': 6.35.4
 
-  '@zondax/ledger-substrate@1.1.2':
+  '@zondax/ledger-substrate@2.3.5':
     dependencies:
       '@ledgerhq/hw-transport': 6.35.4
-      '@zondax/ledger-js': 1.2.0
-      axios: 1.17.0
+      '@zondax/ledger-js': 1.3.1
+      axios: 1.18.1
+      buffer: 6.0.3
+    optionalDependencies:
+      '@ledgerhq/hw-transport-node-hid': 6.33.4
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13563,6 +13679,16 @@ snapshots:
       - debug
       - supports-color
 
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   b4a@1.7.1: {}
 
   balanced-match@1.0.2: {}
@@ -13640,6 +13766,13 @@ snapshots:
       base58-js: 1.0.5
       bech32: 2.0.0
       sha256-uint8array: 0.10.7
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    optional: true
 
   bl@5.1.0:
     dependencies:
@@ -13915,6 +14048,9 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4:
+    optional: true
 
   chrome-launcher@1.2.0(supports-color@10.2.2):
     dependencies:
@@ -14238,6 +14374,11 @@ snapshots:
 
   decode-formdata@0.9.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+    optional: true
+
   deep-extend@0.6.0: {}
 
   deep-freeze-strict@1.1.1: {}
@@ -14421,6 +14562,11 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       whatwg-encoding: 3.1.1
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+    optional: true
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -14724,6 +14870,9 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expand-template@2.0.3:
+    optional: true
+
   expect-type@1.3.0: {}
 
   expect@29.7.0:
@@ -14898,6 +15047,9 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  fs-constants@1.0.0:
+    optional: true
+
   fs-extra@11.3.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -15018,6 +15170,9 @@ snapshots:
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
+
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@6.0.2:
     dependencies:
@@ -15944,6 +16099,9 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0:
+    optional: true
+
   mini-svg-data-uri@1.4.4: {}
 
   minimalistic-assert@1.0.1: {}
@@ -15971,6 +16129,9 @@ snapshots:
   minipass@7.1.2: {}
 
   minipass@7.1.3: {}
+
+  mkdirp-classic@0.5.3:
+    optional: true
 
   mkdirp@3.0.1: {}
 
@@ -16046,6 +16207,9 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
 
+  napi-build-utils@2.0.0:
+    optional: true
+
   next-tick@1.1.0: {}
 
   nise@1.5.3:
@@ -16069,9 +16233,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.8.4
+    optional: true
+
   node-addon-api@2.0.2: {}
 
+  node-addon-api@3.2.1:
+    optional: true
+
   node-addon-api@5.1.0: {}
+
+  node-addon-api@6.1.0:
+    optional: true
 
   node-domexception@1.0.0: {}
 
@@ -16090,6 +16265,13 @@ snapshots:
   node-forge@1.4.0: {}
 
   node-gyp-build@4.8.4: {}
+
+  node-hid@2.1.2:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 3.2.1
+      prebuild-install: 7.1.3
+    optional: true
 
   node-notifier@10.0.1:
     dependencies:
@@ -16647,6 +16829,22 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+    optional: true
+
   prettier@2.8.8: {}
 
   pretty-format@27.5.1:
@@ -16724,6 +16922,12 @@ snapshots:
       listr2: 8.3.3
       ofetch: 1.5.1
       zod: 4.4.3
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+    optional: true
 
   punycode@1.4.1: {}
 
@@ -17212,6 +17416,16 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1:
+    optional: true
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+    optional: true
+
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
@@ -17549,6 +17763,23 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+    optional: true
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    optional: true
+
   tar-stream@3.2.0:
     dependencies:
       b4a: 1.7.1
@@ -17735,6 +17966,11 @@ snapshots:
 
   tty-browserify@0.0.1: {}
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
   tweetnacl@1.0.3: {}
 
   type-detect@4.0.8: {}
@@ -17861,6 +18097,13 @@ snapshots:
     dependencies:
       punycode: 1.4.1
       qs: 6.15.2
+
+  usb@2.9.0:
+    dependencies:
+      '@types/w3c-web-usb': 1.0.14
+      node-addon-api: 6.1.0
+      node-gyp-build: 4.8.4
+    optional: true
 
   use-sync-external-store@1.5.0(react@19.2.7):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,8 +20,10 @@ allowBuilds:
   es5-ext: false
   esbuild: false
   keccak: false
+  node-hid: false
   secp256k1: false
   spawn-sync: false
+  usb: false
   utf-8-validate: false
 
 # don't install NPM dependencies which were published less than 3 days ago
@@ -68,10 +70,10 @@ overrides:
   "@polkadot/x-textdecoder": "14.0.3"
   "@polkadot/x-textencoder": "14.0.3"
   "@polkadot/x-ws": "14.0.3"
-  # dedupe @ledgerhq/hw-transport to a single copy — @zondax/ledger-substrate 1.x
-  # pins 6.31.4 while hw-app-eth/solana 7.x and our transports use 6.35.4, which
+  # dedupe @ledgerhq/hw-transport to a single copy — @zondax/ledger-substrate 2.x
+  # pins 6.35.3 while hw-app-eth/solana 7.x and our transports use 6.35.4, which
   # otherwise produces two incompatible Transport types. The Transport API is
-  # stable across 6.x. (Drops when zondax moves to 2.x.) devices follows transport.
+  # stable across 6.x. devices follows transport.
   "@ledgerhq/devices": "8.15.1"
   "@ledgerhq/hw-transport": "6.35.4"
   "@substrate/txwrapper-core": "7.5.3"


### PR DESCRIPTION
- this required copy/pasting legacy network definitions inside our codebase, to maintain support for legacy substrate apps

QA ideas:
- adding legacy app account + signing tx on Avail Testnet
- adding polkadot app account + signing tx on polkadot asset hub
- adding polkadot MIGRATION app account for kusama + signing tx on kusama asset hub