### PR TITLE
🐛 fix solana provider event unsubscribe

### DIFF
--- a/apps/extension/src/inject/shared/EventEmitter.ts
+++ b/apps/extension/src/inject/shared/EventEmitter.ts
@@ -12,11 +12,12 @@ type Listener = (...args: any[]) => unknown
  * ignoring the Node-only `captureRejections` option.
  */
 export class EventEmitter {
-  #listeners = new Map<string, Set<Listener>>()
+  // listener → `this` context for its invocation (usually undefined)
+  #listeners = new Map<string, Map<Listener, unknown>>()
 
-  on(event: string, listener: Listener): this {
-    const listeners = this.#listeners.get(event) ?? new Set<Listener>()
-    listeners.add(listener)
+  on(event: string, listener: Listener, context?: unknown): this {
+    const listeners = this.#listeners.get(event) ?? new Map<Listener, unknown>()
+    listeners.set(listener, context)
     this.#listeners.set(event, listeners)
     return this
   }
@@ -45,9 +46,9 @@ export class EventEmitter {
     if (!listeners?.size) return false
 
     // iterate a copy so handlers that add/remove listeners during dispatch don't disrupt it
-    for (const listener of [...listeners]) {
+    for (const [listener, context] of [...listeners]) {
       try {
-        const result = listener(...args)
+        const result = listener.apply(context, args)
         if (result instanceof Promise) result.catch(() => {})
       } catch {
         // isolate sync listener errors so one bad dapp handler can't break our provider

--- a/apps/extension/src/inject/solana/provider.ts
+++ b/apps/extension/src/inject/solana/provider.ts
@@ -12,10 +12,10 @@ export const getSolanaProvider = (send: SendRequest): TalismanSol => {
     account: null,
 
     on: (event, listener, context) => {
-      eventEmitter.on(event, listener.bind(context))
+      eventEmitter.on(event, listener, context)
     },
-    off: (event, listener, context) => {
-      eventEmitter.off(event, listener.bind(context))
+    off: (event, listener) => {
+      eventEmitter.off(event, listener)
     },
 
     connect: async (options: { onlyIfTrusted?: boolean } = {}) => {


### PR DESCRIPTION
`off` re-bound the listener, producing a new function identity that never matched what `on` registered — unsubscribe was a no-op. EventEmitter now tracks the listener's context and applies it at emit time, so `on`/`off` work with the original reference.