### PR TITLE
🐛 Fix substrate-native native token fetch on string-encoded chain properties

### DIFF
--- a/.changeset/paseo-string-token-properties.md
+++ b/.changeset/paseo-string-token-properties.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": patch
+---
+
+Coerce string-encoded `tokenDecimals` in substrate-native `system_properties` (fixes native token/balance fetch on chains like the reset Paseo relay whose node serializes numbers as strings)

--- a/packages/balances/src/modules/substrate-native/fetchTokens.ts
+++ b/packages/balances/src/modules/substrate-native/fetchTokens.ts
@@ -52,13 +52,15 @@ export const fetchTokens: IBalanceModule<
   return [parsed.data]
 }
 
+// some nodes (e.g. the reset Paseo relay) serialize numbers as strings in system_properties
+// (tokenDecimals: "10"), so coerce rather than require a JSON number.
 const DotNetworkPropertiesSimple = z.object({
-  tokenDecimals: z.number().optional().default(0),
+  tokenDecimals: z.coerce.number().optional().default(0),
   tokenSymbol: z.string().optional().default("Unit"),
 })
 
 const DotNetworkPropertiesArray = z.object({
-  tokenDecimals: z.array(z.number()).nonempty(),
+  tokenDecimals: z.array(z.coerce.number()).nonempty(),
   tokenSymbol: z.array(z.string()).nonempty(),
 })
 


### PR DESCRIPTION
Some substrate nodes serialize `system_properties` numbers as strings (e.g. the reset Paseo relay returns `{"tokenDecimals":"10","tokenSymbol":"PAS"}`). The substrate-native `getChainProperties` schema only accepted a JSON number, so `DotNetworkPropertiesSchema.parse` threw and no native token was produced — breaking native balances on affected chains.

Coerce `tokenDecimals` (`z.coerce.number()`) in both the simple and array property variants.

Includes a patch changeset for `@talismn/balances`.