### PR TITLE
💚 deflake e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,10 @@ dotenv.config({ path: "apps/extension/.env" })
  */
 export default defineConfig({
   timeout: 60_000, // 60 seconds for all tests
+  // assertions poll until they pass; several forms validate asynchronously through the extension
+  // background (mnemonic validation, watched-address checks, ...), which on slow CI runners
+  // regularly exceeds the 5s default and makes those tests flaky
+  expect: { timeout: 15_000 },
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright/e2e-tests/performance.spec.ts
+++ b/playwright/e2e-tests/performance.spec.ts
@@ -62,12 +62,15 @@ const MAX_HEAP_BYTES = MAX_HEAP_MB * 1024 * 1024
 // Memory should not grow more than 50% after repeated navigation
 const MAX_MEMORY_GROWTH_RATIO = 1.5
 
+// talismandev.eth, hardcoded so the watched-account form doesn't depend on live ENS resolution
+const DEV_WALLET_ADDRESS = "0x5C9EBa3b10E45BF6db77267B40B95F3f91Fc5f67"
+
 test.describe("Performance", () => {
   test("Dashboard initial load - memory and CPU within limits", async ({
     onboardedPage,
     addWatchedAccount,
   }) => {
-    await addWatchedAccount({ type: "ethereum", address: "talismandev.eth", name: "Dev Wallet" })
+    await addWatchedAccount({ type: "ethereum", address: DEV_WALLET_ADDRESS, name: "Dev Wallet" })
     await onboardedPage.waitForTimeout(5000)
 
     const metrics = await collectMetrics(onboardedPage)
@@ -131,7 +134,7 @@ test.describe("Performance", () => {
     onboardedPage,
     addWatchedAccount,
   }) => {
-    await addWatchedAccount({ type: "ethereum", address: "talismandev.eth", name: "Dev Wallet" })
+    await addWatchedAccount({ type: "ethereum", address: DEV_WALLET_ADDRESS, name: "Dev Wallet" })
     await onboardedPage.waitForTimeout(5000)
 
     const metrics = await collectMetrics(onboardedPage)


### PR DESCRIPTION
- Bump Playwright expect timeout to 15s: several forms validate asynchronously through the extension background (mnemonic validation, watched-address checks), which regularly exceeds the 5s default on CI runners and makes assertions like `toHaveText("Invalid recovery phrase")` / `toBeEnabled()` flaky.
- Performance specs: watch a hardcoded address instead of `talismandev.eth` so the form no longer depends on live ENS resolution (the popup perf test failed all 3 attempts on CI because of it).