### PR TITLE
⚡️ reduce asset discovery churn

### DIFF
--- a/apps/extension/src/core/domains/assetDiscovery/__tests__/substrate.test.ts
+++ b/apps/extension/src/core/domains/assetDiscovery/__tests__/substrate.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { activeNetworksStore } from "../../balances/store.activeNetworks"
 import { __internal, addressToAccountId, getSystemAccountStorageKey } from "../substrate"
+import { substrateAssetDiscoveryStore } from "../substrateStore"
 
 // Alice's public key (Polkadot/Substrate dev account).
 const ALICE_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
@@ -85,5 +87,72 @@ describe("isFresh (timestamp-only TTL)", () => {
   it("is fresh at exact boundary minus 1ms", () => {
     const justInsideTTL = Date.now() - (7 * 24 * 60 * 60 * 1000 - 1)
     expect(isFresh(justInsideTTL)).toBe(true)
+  })
+})
+
+describe("flushPendingProbeResults (batched activations)", () => {
+  const { pendingProbeResults, flushPendingProbeResults } = __internal
+
+  beforeEach(() => {
+    pendingProbeResults.clear()
+    vi.restoreAllMocks()
+  })
+
+  it("activates all live networks in a single activeNetworks write, then stamps all probed networks", async () => {
+    pendingProbeResults.set("batch-alive-1", { alive: true, enqueueGen: 0 })
+    pendingProbeResults.set("batch-alive-2", { alive: true, enqueueGen: 0 })
+    pendingProbeResults.set("batch-dead-1", { alive: false, enqueueGen: 0 })
+
+    const setActiveNetworks = vi.spyOn(activeNetworksStore, "set")
+
+    await flushPendingProbeResults()
+
+    expect(setActiveNetworks).toHaveBeenCalledTimes(1)
+    expect(setActiveNetworks).toHaveBeenCalledWith({
+      "batch-alive-1": true,
+      "batch-alive-2": true,
+    })
+
+    // all three probed networks are stamped, dead one included
+    const timestamps = await substrateAssetDiscoveryStore.get()
+    expect(timestamps["batch-alive-1"]).toBeTypeOf("number")
+    expect(timestamps["batch-alive-2"]).toBeTypeOf("number")
+    expect(timestamps["batch-dead-1"]).toBeTypeOf("number")
+
+    // buffer is drained
+    expect(pendingProbeResults.size).toBe(0)
+  })
+
+  it("drops buffered results whose generation was bumped (new accounts arrived)", async () => {
+    pendingProbeResults.set("batch-stale-gen", { alive: true, enqueueGen: 5 }) // current gen is 0
+
+    const setActiveNetworks = vi.spyOn(activeNetworksStore, "set")
+
+    await flushPendingProbeResults()
+
+    expect(setActiveNetworks).not.toHaveBeenCalled()
+    // no timestamp either: the network must be re-probed by the newer job
+    const timestamps = await substrateAssetDiscoveryStore.get()
+    expect(timestamps["batch-stale-gen"]).toBeUndefined()
+  })
+
+  it("respects a user override written while the result was buffered", async () => {
+    await activeNetworksStore.set({ "batch-user-off": false })
+    pendingProbeResults.set("batch-user-off", { alive: true, enqueueGen: 0 })
+
+    const setActiveNetworks = vi.spyOn(activeNetworksStore, "set")
+
+    await flushPendingProbeResults()
+
+    expect(setActiveNetworks).not.toHaveBeenCalled()
+    const timestamps = await substrateAssetDiscoveryStore.get()
+    expect(timestamps["batch-user-off"]).toBeUndefined()
+    expect((await activeNetworksStore.get())["batch-user-off"]).toBe(false)
+  })
+
+  it("is a no-op when the buffer is empty", async () => {
+    const setActiveNetworks = vi.spyOn(activeNetworksStore, "set")
+    await flushPendingProbeResults()
+    expect(setActiveNetworks).not.toHaveBeenCalled()
   })
 })

--- a/apps/extension/src/core/domains/assetDiscovery/scanner.ts
+++ b/apps/extension/src/core/domains/assetDiscovery/scanner.ts
@@ -623,10 +623,16 @@ class AssetDiscoveryScanner {
       const evmNetworkIds = uniq(tokens.map((token) => token.networkId)).filter(
         (id): id is string => !!id
       )
-      // mark before writing so watchEnabledNetworks can't race us into a redundant scan
-      for (const networkId of evmNetworkIds) this.#selfActivatedNetworkIds.add(networkId)
+      // mark before writing so watchEnabledNetworks can't race us into a redundant scan.
+      // only mark ids that aren't already active: those are the only ones that will show
+      // up as new in watchEnabledNetworks and consume their entry — marking an already
+      // active network would leave a stale entry that would swallow a later manual
+      // re-activation
+      const activeNetworks = await activeNetworksStore.get()
+      const networkIdsToActivate = evmNetworkIds.filter((id) => !activeNetworks[id])
+      for (const networkId of networkIdsToActivate) this.#selfActivatedNetworkIds.add(networkId)
       await activeNetworksStore.set(
-        Object.fromEntries(evmNetworkIds.map((networkId) => [networkId, true]))
+        Object.fromEntries(networkIdsToActivate.map((networkId) => [networkId, true]))
       )
     } catch (err) {
       log.error("[AssetDiscovery] Failed to automatically enable discovered assets", {

--- a/apps/extension/src/core/domains/assetDiscovery/scanner.ts
+++ b/apps/extension/src/core/domains/assetDiscovery/scanner.ts
@@ -11,7 +11,7 @@ import {
 } from "@talismn/chaindata-provider"
 import { isEthereumAddress } from "@talismn/crypto"
 import { isAccountNotContact, isAccountPlatformEthereum } from "@talismn/keyring"
-import { isTruthy, sleep, throwAfter } from "@talismn/util"
+import { isTruthy, throwAfter } from "@talismn/util"
 import { chunk, groupBy, isEqual, sortBy, uniq } from "lodash-es"
 import {
   combineLatest,
@@ -50,6 +50,14 @@ const IGNORED_COINGECKO_IDS = [
 
 const MANUAL_SCAN_MAX_CONCURRENT_NETWORK = 4
 const BALANCES_FETCH_CHUNK_SIZE = 50
+/**
+ * Scan progress (cursors + percent) is persisted at most once per this interval:
+ * each store write fans out to storage IPC and to every subscriber (including the
+ * UI progress stream), and chunks complete several times per second across
+ * concurrent networks. Worst case on service-worker death, the resume cursor is
+ * one interval stale and a few chunks get re-checked.
+ */
+const SCAN_STATE_FLUSH_INTERVAL_MS = 1_000
 const NETWORK_BALANCES_FETCH_CHUNK_SIZE: Record<string, number> = {
   "1": 200,
 }
@@ -69,7 +77,12 @@ const getSortableIdentifier = (tokenId: TokenId, address: string, tokens: TokenL
 
 class AssetDiscoveryScanner {
   #isBusy = false
-  #preventAutoStart = false
+  /**
+   * Network ids activated by enableDiscoveredTokens itself. watchEnabledNetworks
+   * consumes (and ignores) these so discovery's own writes can't re-trigger a
+   * full scan of the networks it just scanned.
+   */
+  #selfActivatedNetworkIds = new Set<string>()
 
   constructor() {
     this.watchNewAccounts()
@@ -95,7 +108,7 @@ class AssetDiscoveryScanner {
       )
       .subscribe(async (allAddresses) => {
         try {
-          if (prevAllAddresses && !this.#preventAutoStart) {
+          if (prevAllAddresses) {
             const addresses = allAddresses.filter(
               (k) => !(prevAllAddresses as string[]).includes(k)
             )
@@ -139,10 +152,13 @@ class AssetDiscoveryScanner {
       )
       .subscribe(async (allActiveNetworkIds) => {
         try {
-          if (prevAllActiveNetworkIds && !this.#preventAutoStart) {
-            const networkIds = allActiveNetworkIds.filter(
-              (k) => !(prevAllActiveNetworkIds as string[]).includes(k)
-            )
+          if (prevAllActiveNetworkIds) {
+            const networkIds = allActiveNetworkIds
+              .filter((k) => !(prevAllActiveNetworkIds as string[]).includes(k))
+              // ignore (and consume) activations written by enableDiscoveredTokens:
+              // those networks were just scanned, re-scanning them would fire
+              // thousands of redundant RPC calls
+              .filter((k) => !this.#selfActivatedNetworkIds.delete(k))
 
             if (networkIds.length) {
               const accounts = await keyringStore.getAccounts()
@@ -413,6 +429,41 @@ class AssetDiscoveryScanner {
 
       const stop = log.timer("[AssetDiscovery] Scan completed")
 
+      // in-memory scan state, flushed to the store at most once per
+      // SCAN_STATE_FLUSH_INTERVAL_MS (see constant for rationale)
+      const localCursors: AssetDiscoveryScanState["currentScanCursors"] = { ...cursors }
+      let lastFlushedAt = 0
+      const flushScanState = async (force = false) => {
+        if (abortController.signal.aborted) return
+        if (!force && Date.now() - lastFlushedAt < SCAN_STATE_FLUSH_INTERVAL_MS) return
+        lastFlushedAt = Date.now()
+
+        await assetDiscoveryStore.mutate((prev) => {
+          if (abortController.signal.aborted) return prev
+
+          // Update progress
+          // in case of full scan it takes longer to scan networks
+          // in case of active scan it takes longer to scan tokens
+          // => use the min of both ratios as current progress
+          const totalScanned = Object.values(localCursors).reduce(
+            (acc, cur) => acc + cur.scanned,
+            0
+          )
+          const tokensProgress = Math.round((100 * totalScanned) / totalChecks)
+          const networksProgress = Math.round(
+            (100 * Object.keys(localCursors).length) / Object.keys(tokensByNetwork).length
+          )
+          const currentScanProgressPercent = Math.min(tokensProgress, networksProgress)
+
+          return {
+            ...prev,
+            currentScanCursors: { ...localCursors },
+            currentScanProgressPercent,
+            currentScanTokensCount: totalTokens,
+          }
+        })
+      }
+
       // process multiple networks at a time
       await PromisePool.withConcurrency(MANUAL_SCAN_MAX_CONCURRENT_NETWORK)
         .for(Object.keys(tokensByNetwork).sort((a, b) => Number(a) - Number(b)))
@@ -478,40 +529,12 @@ class AssetDiscoveryScanner {
                   balance: res,
                 }))
 
-              await assetDiscoveryStore.mutate((prev) => {
-                if (abortController.signal.aborted) return prev
-
-                const currentScanCursors = {
-                  ...prev.currentScanCursors,
-                  [networkId]: {
-                    address: checks[checks.length - 1].address,
-                    tokenId: checks[checks.length - 1].tokenId,
-                    scanned: (prev.currentScanCursors[networkId]?.scanned ?? 0) + checks.length,
-                  },
-                }
-
-                // Update progress
-                // in case of full scan it takes longer to scan networks
-                // in case of active scan it takes longer to scan tokens
-                // => use the min of both ratios as current progress
-                const totalScanned = Object.values(currentScanCursors).reduce(
-                  (acc, cur) => acc + cur.scanned,
-                  0
-                )
-                const tokensProgress = Math.round((100 * totalScanned) / totalChecks)
-                const networksProgress = Math.round(
-                  (100 * Object.keys(currentScanCursors).length) /
-                    Object.keys(tokensByNetwork).length
-                )
-                const currentScanProgressPercent = Math.min(tokensProgress, networksProgress)
-
-                return {
-                  ...prev,
-                  currentScanCursors,
-                  currentScanProgressPercent,
-                  currentScanTokensCount: totalTokens,
-                }
-              })
+              localCursors[networkId] = {
+                address: checks[checks.length - 1].address,
+                tokenId: checks[checks.length - 1].tokenId,
+                scanned: (localCursors[networkId]?.scanned ?? 0) + checks.length,
+              }
+              await flushScanState()
 
               if (abortController.signal.aborted) return
 
@@ -523,6 +546,10 @@ class AssetDiscoveryScanner {
             log.warn(`[AssetDiscovery] Could not scan network ${networkId}`, { err })
           }
         })
+
+      // persist the final cursors before closing the scan, so an abort arriving
+      // between the two writes can still resume from up-to-date state
+      await flushScanState(true)
 
       await assetDiscoveryStore.mutate((prev): AssetDiscoveryScanState => {
         if (abortController.signal.aborted) return prev
@@ -584,8 +611,6 @@ class AssetDiscoveryScanner {
   }
 
   private async enableDiscoveredTokens(): Promise<void> {
-    this.#preventAutoStart = true
-
     try {
       const [discoveredBalances] = await Promise.all([db.assetDiscovery.toArray()])
 
@@ -595,19 +620,19 @@ class AssetDiscoveryScanner {
       ).filter(isTokenEth)
       await activeTokensStore.set(Object.fromEntries(tokens.map((t) => [t.id, true])))
 
-      const evmNetworkIds = uniq(tokens.map((token) => token.networkId))
+      const evmNetworkIds = uniq(tokens.map((token) => token.networkId)).filter(
+        (id): id is string => !!id
+      )
+      // mark before writing so watchEnabledNetworks can't race us into a redundant scan
+      for (const networkId of evmNetworkIds) this.#selfActivatedNetworkIds.add(networkId)
       await activeNetworksStore.set(
         Object.fromEntries(evmNetworkIds.map((networkId) => [networkId, true]))
       )
-
-      await sleep(100) // pause to ensure local storage observables fires before we exit, to prevent unnecessary scans to be triggered (see watchEnabledNetworks up top)
     } catch (err) {
       log.error("[AssetDiscovery] Failed to automatically enable discovered assets", {
         err,
       })
     }
-
-    this.#preventAutoStart = false
   }
 }
 

--- a/apps/extension/src/core/domains/assetDiscovery/substrate.ts
+++ b/apps/extension/src/core/domains/assetDiscovery/substrate.ts
@@ -33,6 +33,13 @@ const PROBE_TIMEOUT_MS = 15_000
 /** Debounce for the "wallet is ready" trigger. */
 const WALLET_READY_DEBOUNCE_MS = 10_000
 
+/**
+ * Max time a probe result may sit in the pending buffer before being flushed.
+ * Bounds both activation latency during long probe queues and the amount of
+ * probe work lost if the service worker is killed before a flush.
+ */
+const PENDING_FLUSH_MAX_DELAY_MS = 10_000
+
 // ---------------------------------------------------------------------------
 // Storage key helpers
 // ---------------------------------------------------------------------------
@@ -292,6 +299,71 @@ const isFresh = (timestamp: number | undefined): boolean => {
   return Date.now() - timestamp < RESCAN_TTL_MS
 }
 
+/**
+ * Successful probes of live networks are buffered here instead of being
+ * activated one by one: every activeNetworks write restarts the balances
+ * aggregation pipeline downstream, so a probe storm (fresh install, new
+ * account) must collapse into as few writes as possible.
+ *
+ * Crash safety: a pending entry has NO timestamp in substrateAssetDiscoveryStore
+ * yet (the entry was cleared before probing). If the service worker dies before
+ * the flush, the network is simply re-probed on next startup.
+ */
+const pendingProbeResults = new Map<string, { alive: boolean; enqueueGen: number }>()
+let pendingFlushTimer: ReturnType<typeof setTimeout> | null = null
+
+const schedulePendingFlush = () => {
+  if (pendingFlushTimer) return
+  pendingFlushTimer = setTimeout(() => {
+    flushPendingProbeResults().catch((err) =>
+      log.error("[substrateDiscovery] Failed to flush pending probe results", err)
+    )
+  }, PENDING_FLUSH_MAX_DELAY_MS)
+}
+
+/**
+ * Applies buffered probe results in one batch: a single activeNetworks write
+ * for all live networks, then the probe timestamps. Ordering matters — if the
+ * process dies between the two writes, the networks are active but unstamped,
+ * and `getProbeCandidates` already excludes active networks from re-probing.
+ */
+const flushPendingProbeResults = async (): Promise<void> => {
+  if (pendingFlushTimer) {
+    clearTimeout(pendingFlushTimer)
+    pendingFlushTimer = null
+  }
+
+  if (!pendingProbeResults.size) return
+  const pending = new Map(pendingProbeResults)
+  pendingProbeResults.clear()
+
+  const activeNetworks = await activeNetworksStore.get()
+
+  // Drop results whose generation was bumped while buffered (new accounts arrived —
+  // a re-probe with the full address set is already queued) and networks the user
+  // explicitly toggled in the meantime.
+  const applicable = [...pending.entries()].filter(
+    ([networkId, { enqueueGen }]) =>
+      (probeGeneration.get(networkId) ?? 0) === enqueueGen &&
+      activeNetworks[networkId] === undefined
+  )
+  if (!applicable.length) return
+
+  const aliveNetworkIds = applicable.filter(([, { alive }]) => alive).map(([id]) => id)
+  if (aliveNetworkIds.length) {
+    log.debug(
+      `[substrateDiscovery] found live account(s) on ${aliveNetworkIds.length} network(s) — auto-activating`,
+      aliveNetworkIds
+    )
+    await activeNetworksStore.set(Object.fromEntries(aliveNetworkIds.map((id) => [id, true])))
+  }
+
+  const now = Date.now()
+  await substrateAssetDiscoveryStore.set(
+    Object.fromEntries(applicable.map(([networkId]) => [networkId, now]))
+  )
+}
+
 const probeAndActivate = async (
   candidate: NetworkProbeCandidate,
   enqueueGen: number
@@ -323,26 +395,21 @@ const probeAndActivate = async (
   try {
     const result = await probeNetworkRpcs(network.rpcs, storageKeys, abortController.signal)
 
-    // Re-check activeNetworks before activating: the user may have explicitly
-    // disabled this network while the probe was in flight.
-    const currentActiveNetworks = await activeNetworksStore.get()
-    if (currentActiveNetworks[network.id] !== undefined) return
-
     const alive = result.changes.some(([, value]) => value !== null && value !== undefined)
-    if (alive) {
-      log.debug(`[substrateDiscovery] found live account(s) on ${network.id} — auto-activating`)
-      await activeNetworksStore.setActive(network.id, true)
-    } else {
-      log.debug(`[substrateDiscovery] no accounts alive on ${network.id}`)
-    }
+    log.debug(
+      alive
+        ? `[substrateDiscovery] found live account(s) on ${network.id} — queuing activation`
+        : `[substrateDiscovery] no accounts alive on ${network.id}`
+    )
 
-    // Only record the timestamp if the generation hasn't been bumped
-    // (i.e. no new accounts invalidated our result while we were probing).
-    if ((probeGeneration.get(network.id) ?? 0) === enqueueGen) {
-      await substrateAssetDiscoveryStore.set({ [network.id]: Date.now() })
-    }
+    // Buffer instead of writing: activation and timestamp are applied together
+    // by flushPendingProbeResults (queue idle, or PENDING_FLUSH_MAX_DELAY_MS).
+    pendingProbeResults.set(network.id, { alive, enqueueGen })
+    schedulePendingFlush()
   } catch (err) {
     log.debug(`[substrateDiscovery] probe failed on ${network.id}`, err)
+    // Failures don't trigger downstream work, so the retry timestamp is written
+    // immediately — no need to buffer it.
     if ((probeGeneration.get(network.id) ?? 0) === enqueueGen) {
       await substrateAssetDiscoveryStore.set({
         [network.id]: Date.now() - (RESCAN_TTL_MS - FAILURE_TTL_MS),
@@ -378,6 +445,13 @@ const discoverSubstrateAssets = async (): Promise<void> => {
           log.warn(`[substrateDiscovery] queued probe failed for ${candidate.network.id}`, err)
         })
     }
+
+    // Flush buffered results as soon as the whole queue drains (long queues also
+    // flush every PENDING_FLUSH_MAX_DELAY_MS, see schedulePendingFlush).
+    probeQueue.onIdle().then(
+      () => flushPendingProbeResults(),
+      (err) => log.error("[substrateDiscovery] Failed to flush after queue idle", err)
+    )
   } catch (err) {
     log.error("[substrateDiscovery] Failed to enqueue substrate asset discovery", err)
   }
@@ -412,9 +486,11 @@ const clearEntriesForAccounts = async (newAccounts: Account[]): Promise<void> =>
   log.debug(`[substrateDiscovery] clearing ${networkIdsToClear.length} entries for new accounts`)
 
   // Bump generation for each cleared network so in-flight probes know their
-  // result is stale and won't overwrite the cleared entry.
+  // result is stale and won't overwrite the cleared entry. Buffered results for
+  // these networks are stale too — drop them so they can't be flushed.
   for (const id of networkIdsToClear) {
     probeGeneration.set(id, (probeGeneration.get(id) ?? 0) + 1)
+    pendingProbeResults.delete(id)
   }
 
   await substrateAssetDiscoveryStore.mutate((state) => {
@@ -481,4 +557,6 @@ export const __internal = {
   probeAndActivate,
   probeQueue,
   clearEntriesForAccounts,
+  pendingProbeResults,
+  flushPendingProbeResults,
 }

--- a/apps/extension/src/core/domains/assetDiscovery/substrate.ts
+++ b/apps/extension/src/core/domains/assetDiscovery/substrate.ts
@@ -448,10 +448,10 @@ const discoverSubstrateAssets = async (): Promise<void> => {
 
     // Flush buffered results as soon as the whole queue drains (long queues also
     // flush every PENDING_FLUSH_MAX_DELAY_MS, see schedulePendingFlush).
-    probeQueue.onIdle().then(
-      () => flushPendingProbeResults(),
-      (err) => log.error("[substrateDiscovery] Failed to flush after queue idle", err)
-    )
+    probeQueue
+      .onIdle()
+      .then(() => flushPendingProbeResults())
+      .catch((err) => log.error("[substrateDiscovery] Failed to flush after queue idle", err))
   } catch (err) {
     log.error("[substrateDiscovery] Failed to enqueue substrate asset discovery", err)
   }

--- a/apps/extension/src/core/domains/balances/walletBalances.ts
+++ b/apps/extension/src/core/domains/balances/walletBalances.ts
@@ -58,6 +58,11 @@ export const walletBalances$ = settingsStore.observable.pipe(
     }
 
     return walletAddressesByTokenId$.pipe(
+      // coalesce bursts of scope changes (asset-discovery activations, dynamic-token
+      // sync, chaindata updates): every emission below restarts the whole balances
+      // aggregation, so a burst must collapse into a single restart. First emission
+      // passes through untouched to keep startup instant.
+      firstThenDebounce(1_000),
       switchMap((addressesByTokenId) => balancesProvider.getBalances$(addressesByTokenId)),
       firstThenDebounce(500),
       tap({

--- a/apps/extension/src/ui/state/assetDiscovery.ts
+++ b/apps/extension/src/ui/state/assetDiscovery.ts
@@ -3,8 +3,9 @@ import { assetDiscoveryStore } from "@core/domains/assetDiscovery/store"
 import { bind } from "@react-rxjs/core"
 import { liveQuery } from "dexie"
 import groupBy from "lodash-es/groupBy"
+import isEqual from "lodash-es/isEqual"
 import sortBy from "lodash-es/sortBy"
-import { combineLatest, from, map, shareReplay, throttleTime } from "rxjs"
+import { combineLatest, distinctUntilChanged, from, map, shareReplay, throttleTime } from "rxjs"
 
 import { getTokensMap$ } from "./chaindata"
 
@@ -15,18 +16,56 @@ const assetDiscoveryBalances$ = from(liveQuery(() => db.assetDiscovery.toArray()
 )
 
 const assetDiscoveryScan$ = assetDiscoveryStore.observable.pipe(
-  throttleTime(100, undefined, { leading: true, trailing: true })
+  throttleTime(500, undefined, { leading: true, trailing: true })
 )
 
 export const [useAssetDiscoveryScan] = bind(assetDiscoveryScan$)
 
+// The store's hot fields (cursors, progress) are rewritten throughout a scan, while
+// the aggregation of discovered balances is the expensive part of this stream — so
+// the two are split: scan meta re-emits only when the fields the UI displays
+// actually change, and the aggregation below recomputes only when the discovered
+// balances or the tokens map change, never on a progress tick.
+const assetDiscoveryScanMeta$ = assetDiscoveryScan$.pipe(
+  map(
+    ({
+      currentScanScope,
+      currentScanProgressPercent,
+      currentScanTokensCount,
+      lastScanAccounts,
+      lastScanNetworks,
+      lastScanTokensCount,
+    }) => ({
+      currentScanScope,
+      currentScanProgressPercent,
+      currentScanTokensCount,
+      lastScanAccounts,
+      lastScanNetworks,
+      lastScanTokensCount,
+    })
+  ),
+  distinctUntilChanged(isEqual)
+)
+
+const discoveredBalancesAggregate$ = combineLatest([
+  assetDiscoveryBalances$,
+  getTokensMap$({ activeOnly: false, includeTestnets: true }),
+]).pipe(
+  map(([balances, tokensMap]) => {
+    const balancesByTokenId = groupBy(balances, (a) => a.tokenId)
+    const tokenIds = sortBy(
+      Object.keys(balancesByTokenId).filter((id) => !!tokensMap[id]), // some tokens may have been deleted since the scan finished
+      (tokenId) => Number(tokensMap[tokenId]?.networkId ?? 0),
+      (tokenId) => tokensMap[tokenId]?.symbol
+    )
+    return { balances, balancesByTokenId, tokenIds }
+  }),
+  shareReplay(1)
+)
+
 export const [useAssetDiscoveryScanProgress, assetDiscoveryScanProgress$] = bind(
-  combineLatest([
-    assetDiscoveryScan$,
-    assetDiscoveryBalances$,
-    getTokensMap$({ activeOnly: false, includeTestnets: true }),
-  ]).pipe(
-    map(([scan, balances, tokensMap]) => {
+  combineLatest([assetDiscoveryScanMeta$, discoveredBalancesAggregate$]).pipe(
+    map(([scan, { balances, balancesByTokenId, tokenIds }]) => {
       const {
         currentScanScope,
         currentScanProgressPercent: percent,
@@ -35,13 +74,6 @@ export const [useAssetDiscoveryScanProgress, assetDiscoveryScanProgress$] = bind
         lastScanNetworks,
         lastScanTokensCount,
       } = scan
-
-      const balancesByTokenId = groupBy(balances, (a) => a.tokenId)
-      const tokenIds = sortBy(
-        Object.keys(balancesByTokenId).filter((id) => !!tokensMap[id]), // some tokens may have been deleted since the scan finished
-        (tokenId) => Number(tokensMap[tokenId]?.networkId ?? 0),
-        (tokenId) => tokensMap[tokenId]?.symbol
-      )
 
       const isInProgress = !!currentScanScope
 


### PR DESCRIPTION
Reduces UI freezes caused by the asset-discovery activation cascade (most visible when adding a substrate account or restoring a wallet with assets on many inactive networks).

## Changes

1. **Batch substrate auto-activations** (`assetDiscovery/substrate.ts`) — successful probe results are buffered and flushed in one batch (on probe-queue idle, at most every 10s): a single `activeNetworks` write for all live networks instead of one write per network. Probe timestamps are written at flush time, atomically with the activation, so a service worker killed before the flush simply re-probes those networks on next startup — a network can never end up stamped-but-not-activated.
2. **Debounce balances pipeline restarts** (`balances/walletBalances.ts`) — `firstThenDebounce(1_000)` on scope changes before the `switchMap`: the first emission passes through instantly (startup unaffected), bursts of activations collapse into a single pipeline restart.
3. **Split hot/cold discovery state in the UI** (`ui/state/assetDiscovery.ts`) — scan meta (progress/scope) re-emits only when the displayed fields actually change, and the `groupBy`/`sortBy` aggregation of discovered balances recomputes only when balances or the tokens map change — never on a progress tick.
4. **Rate-limit scanner store writes** (`assetDiscovery/scanner.ts`) — scan cursors/progress are kept in memory and persisted at most once per second (previously: one storage write per 50-token chunk across 4 concurrent networks). Worst case on service-worker death, the resume cursor is 1s stale and a few chunks get re-checked.
5. **Remove the `#preventAutoStart` race** (`assetDiscovery/scanner.ts`) — `enableDiscoveredTokens` marks the network ids it activates (only ids not already active, so no stale entries linger) and `watchEnabledNetworks` consumes/ignores them, replacing the `sleep(100)` flag window that could let discovery's own writes re-trigger a full scan of freshly scanned networks.

## Measurements

A/B on identical fresh installs restoring the same wallet backup (accounts live on ~35 non-default substrate networks — worst-case activation storm), dashboard open on the portfolio, 300s window starting at unlock. Long tasks measured with `PerformanceObserver({type:"longtask"})` in the dashboard renderer; store writes counted via `chrome.storage.onChanged` in the service worker. Measured at the final commit of this branch.

| 300s discovery-storm window | dev | this PR |
|---|---|---|
| UI-blocked time (long-task total) | **121.8s (40% of window)** | **50.2s (17%)** |
| Long tasks ≥50ms | 152 | 95 |
| Long tasks ≥500ms (visible freezes) | 90 | 28 |
| Worst single stall | 2.01s | 1.97s |
| Balances pipeline restarts (`activeNetworks` writes) | 36 | 7 |
| Discovery bookkeeping writes | 70 | 8 |
| Renderer RSS growth over window | +432 MB | +261 MB |
| Dashboard V8 heap reserved at end | 660 MB | 454 MB |

Both runs ended with the dashboard alive and the full portfolio rendered.
