### PR TITLE
⚡️ non-blocking scrypt for json import

### DIFF
--- a/.changeset/crypto-async-keystore-decrypt.md
+++ b/.changeset/crypto-async-keystore-decrypt.md
@@ -1,0 +1,5 @@
+---
+"@talismn/crypto": minor
+---
+
+Add `decryptPjsKeystoreAsync` (non-blocking scrypt derivation for UI threads)

--- a/apps/extension/src/core/domains/keyring/pjsKeystore.spec.ts
+++ b/apps/extension/src/core/domains/keyring/pjsKeystore.spec.ts
@@ -47,10 +47,10 @@ describe("encodePjsKeyringPairJson (export/import round-trip)", () => {
   )
 
   for (const fixture of byCurve) {
-    it(`round-trips a ${fixture.curve} account`, () => {
+    it(`round-trips a ${fixture.curve} account`, async () => {
       // recover the reference secret key from the polkadot-js generated fixture
       const source = createPairFromJson(fixture.json)
-      unlockPair(source, FIXTURES.password)
+      await unlockPair(source, FIXTURES.password)
 
       const exported = encodePjsKeyringPairJson(
         { address: source.address, name: `roundtrip ${fixture.curve}`, curve: fixture.curve },
@@ -65,14 +65,14 @@ describe("encodePjsKeyringPairJson (export/import round-trip)", () => {
       })
 
       const imported = createPairFromJson(exported)
-      unlockPair(imported, EXPORT_PASSWORD)
+      await unlockPair(imported, EXPORT_PASSWORD)
 
       expect(imported.secretKey).toEqual(source.secretKey)
       expect(imported.publicKey).toEqual(hexToU8a(fixture.expected.publicKey))
       expect(normalizeAddress(imported.address)).toBe(normalizeAddress(fixture.expected.address))
 
       const locked = createPairFromJson(exported)
-      expect(() => unlockPair(locked, "wrong-password")).toThrow()
+      await expect(unlockPair(locked, "wrong-password")).rejects.toThrow()
     })
   }
 })

--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddJson/context.ts
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddJson/context.ts
@@ -128,35 +128,24 @@ const useJsonAccountImportProvider = () => {
     async (password: string) => {
       if (!file) return
 
-      // hangs UI, do asynchronously
-      await new Promise<void>((resolve, reject) => {
-        setTimeout(() => {
-          try {
-            if (file.type === "single") {
-              const pair = createPairFromJson(file.content)
-              unlockPair(pair, password)
+      if (file.type === "single") {
+        const pair = createPairFromJson(file.content)
+        await unlockPair(pair, password)
 
-              setPairs([pair])
+        setPairs([pair])
 
-              if (
-                !existingAccounts.some((a) => isAddressEqual(a.address, pair.address)) &&
-                !pair.meta.isHardware &&
-                !pair.meta.isExternal
-              )
-                setSelectedAccounts([pair.address])
-            } else if (file.type === "multi") {
-              const accounts = unlockMultiAccountsJson(file.content, password)
-              const pairs = accounts.map(createPairFromJson)
+        if (
+          !existingAccounts.some((a) => isAddressEqual(a.address, pair.address)) &&
+          !pair.meta.isHardware &&
+          !pair.meta.isExternal
+        )
+          setSelectedAccounts([pair.address])
+      } else if (file.type === "multi") {
+        const accounts = await unlockMultiAccountsJson(file.content, password)
+        const pairs = accounts.map(createPairFromJson)
 
-              setPairs(pairs)
-            } else throw new Error("Invalid file type")
-
-            resolve()
-          } catch (err) {
-            reject(err)
-          }
-        }, 1)
-      })
+        setPairs(pairs)
+      } else throw new Error("Invalid file type")
     },
     [existingAccounts, file]
   )
@@ -248,20 +237,10 @@ const useJsonAccountImportProvider = () => {
         const pair = pairs.find((p) => p.address === account.id)
         if (!pair) continue
 
-        const unlocked = await new Promise((resolve) => {
-          setTimeout(() => {
-            let success = false
-
-            try {
-              unlockPair(pair, password)
-              success = true
-            } catch {
-              // ignore
-            }
-
-            resolve(success)
-          }, 50)
-        })
+        const unlocked = await unlockPair(pair, password).then(
+          () => true,
+          () => false // wrong password for this pair - leave it locked
+        )
 
         if (unlocked) {
           setPairs([...pairs])

--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddJson/pjsImportPairs.spec.ts
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddJson/pjsImportPairs.spec.ts
@@ -73,14 +73,14 @@ const expectSignatureParity = (
 
 describe("pjs json import (polkadot-js parity fixtures)", () => {
   for (const fixture of FIXTURES.singles) {
-    it(fixture.name, () => {
+    it(fixture.name, async () => {
       const pair = createPairFromJson(fixture.json)
 
       // address must resolve identically to the polkadot-js pair address
       expect(normalizeAddress(pair.address)).toBe(normalizeAddress(fixture.expected.address))
       expect(pair.type).toBe(fixture.curve)
 
-      unlockPair(pair, FIXTURES.password)
+      await unlockPair(pair, FIXTURES.password)
       expect(pair.isLocked).toBe(false)
       expect(pair.publicKey).toEqual(hexToU8a(fixture.expected.publicKey))
 
@@ -93,21 +93,21 @@ describe("pjs json import (polkadot-js parity fixtures)", () => {
 
       // the re-encoded unencrypted keystore sent to the backend must decode back to the same keys
       const roundtrip = createPairFromJson(toUnencryptedPjsJson(pair))
-      unlockPair(roundtrip, "")
+      await unlockPair(roundtrip, "")
       expect(roundtrip.secretKey).toEqual(pair.secretKey)
       expect(roundtrip.publicKey).toEqual(pair.publicKey)
       expect(normalizeAddress(roundtrip.address)).toBe(normalizeAddress(fixture.expected.address))
     })
 
-    it(`${fixture.name} - rejects a wrong password`, () => {
+    it(`${fixture.name} - rejects a wrong password`, async () => {
       const pair = createPairFromJson(fixture.json)
-      expect(() => unlockPair(pair, "wrong-password")).toThrow()
+      await expect(unlockPair(pair, "wrong-password")).rejects.toThrow()
       expect(pair.isLocked).toBe(true)
     })
   }
 
-  it("batch file with all curves", () => {
-    const inner = unlockMultiAccountsJson(FIXTURES.batch.json, FIXTURES.password)
+  it("batch file with all curves", async () => {
+    const inner = await unlockMultiAccountsJson(FIXTURES.batch.json, FIXTURES.password)
     expect(inner).toHaveLength(FIXTURES.batch.accounts.length)
 
     for (const [i, expected] of FIXTURES.batch.accounts.entries()) {
@@ -115,13 +115,13 @@ describe("pjs json import (polkadot-js parity fixtures)", () => {
       expect(normalizeAddress(pair.address)).toBe(normalizeAddress(expected.address))
       expect(pair.type).toBe(expected.curve)
 
-      unlockPair(pair, FIXTURES.password)
+      await unlockPair(pair, FIXTURES.password)
       expect(pair.publicKey).toEqual(hexToU8a(expected.publicKey))
       expectSignatureParity(expected.curve, pair.secretKey!, pair.publicKey!, expected.signature)
     }
   })
 
-  it("batch file rejects a wrong password", () => {
-    expect(() => unlockMultiAccountsJson(FIXTURES.batch.json, "wrong-password")).toThrow()
+  it("batch file rejects a wrong password", async () => {
+    await expect(unlockMultiAccountsJson(FIXTURES.batch.json, "wrong-password")).rejects.toThrow()
   })
 })

--- a/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddJson/pjsImportPairs.ts
+++ b/apps/extension/src/ui/domains/Account/AccountAdd/AccountAddJson/pjsImportPairs.ts
@@ -4,7 +4,7 @@ import {
   base64,
   checksumEthereumAddress,
   decodeSs58Address,
-  decryptPjsKeystore,
+  decryptPjsKeystoreAsync,
   encodeAddressEthereum,
   encodeAddressSs58,
 } from "@talismn/crypto"
@@ -99,13 +99,15 @@ export const createPairFromJson = (json: PjsKeyringPairJson): JsonImportPair => 
   }
 }
 
-export const unlockPair = (pair: JsonImportPair, password: string) => {
+// async: scrypt derivation yields to the event loop so the UI keeps rendering (a sync
+// derivation freezes the page for the whole run, once per keystore)
+export const unlockPair = async (pair: JsonImportPair, password: string) => {
   const { encoded, encoding } = pair.json
 
   // pjs also supports hex-encoded keystores - normalize to base64 for the decrypt helper
   const encodedB64 = isHexString(encoded) ? base64.encode(hexToU8a(encoded)) : encoded
 
-  const decrypted = decryptPjsKeystore(
+  const decrypted = await decryptPjsKeystoreAsync(
     { encoded: encodedB64, encoding: normalizeEncoding(encoding) },
     password
   )
@@ -117,11 +119,14 @@ export const unlockPair = (pair: JsonImportPair, password: string) => {
 }
 
 /** decrypts a multi-account ("batch-pkcs8") file into its inner account keystores */
-export const unlockMultiAccountsJson = (
+export const unlockMultiAccountsJson = async (
   { encoded, encoding }: PjsKeyringPairsJson,
   password: string
-): PjsKeyringPairJson[] => {
-  const data = decryptPjsKeystore({ encoded, encoding: normalizeEncoding(encoding) }, password)
+): Promise<PjsKeyringPairJson[]> => {
+  const data = await decryptPjsKeystoreAsync(
+    { encoded, encoding: normalizeEncoding(encoding) },
+    password
+  )
   return JSON.parse(u8aToString(data)) as PjsKeyringPairJson[]
 }
 

--- a/packages/crypto/src/keystore/index.test.ts
+++ b/packages/crypto/src/keystore/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { decryptPjsKeystore, encryptPjsKeystore } from "."
+import { decryptPjsKeystore, decryptPjsKeystoreAsync, encryptPjsKeystore } from "."
 
 // generated with @polkadot/util-crypto 14.0.3 jsonEncrypt:
 //   jsonEncrypt(Uint8Array 0..63, ["pkcs8","sr25519"], "talisman-test-password")
@@ -57,5 +57,34 @@ describe("pjs keystore (polkadot-js parity)", () => {
     const keystore = encryptPjsKeystore(SECRET, ["pkcs8", "sr25519"], PASSWORD)
     expect(keystore.encoding).toEqual(PJS_VECTOR.encoding)
     expect(decryptPjsKeystore(keystore, PASSWORD)).toEqual(SECRET)
+  })
+})
+
+describe("decryptPjsKeystoreAsync (parity with sync variant)", () => {
+  it("decrypts a polkadot-js generated keystore", async () => {
+    expect(await decryptPjsKeystoreAsync(PJS_VECTOR, PASSWORD)).toEqual(SECRET)
+  })
+
+  it("decrypts a keystore using legacy scrypt params", async () => {
+    expect(await decryptPjsKeystoreAsync(PJS_LEGACY_PARAMS_VECTOR, PASSWORD)).toEqual(SECRET)
+  })
+
+  it("rejects a wrong password", async () => {
+    await expect(decryptPjsKeystoreAsync(PJS_VECTOR, "wrong")).rejects.toThrow()
+  })
+
+  it("rejects disallowed scrypt params", async () => {
+    const bytes = Uint8Array.from(atob(PJS_VECTOR.encoded), (c) => c.charCodeAt(0))
+    bytes[32] = 0
+    bytes[33] = 4 // N = 1024
+    const tampered = { ...PJS_VECTOR, encoded: btoa(String.fromCharCode(...bytes)) }
+    await expect(decryptPjsKeystoreAsync(tampered, PASSWORD)).rejects.toThrow(
+      "Invalid injected scrypt params found"
+    )
+  })
+
+  it("round-trips encrypt + decrypt", async () => {
+    const keystore = encryptPjsKeystore(SECRET, ["pkcs8", "sr25519"], PASSWORD)
+    expect(await decryptPjsKeystoreAsync(keystore, PASSWORD)).toEqual(SECRET)
   })
 })

--- a/packages/crypto/src/keystore/index.ts
+++ b/packages/crypto/src/keystore/index.ts
@@ -1,5 +1,5 @@
 import { xsalsa20poly1305 } from "@noble/ciphers/salsa.js"
-import { scrypt } from "@noble/hashes/scrypt.js"
+import { scrypt, scryptAsync } from "@noble/hashes/scrypt.js"
 import { base64 } from "@scure/base"
 
 /**
@@ -50,30 +50,43 @@ const readU32LE = (bytes: Uint8Array, offset: number) =>
 const writeU32LE = (value: number) =>
   new Uint8Array([value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, (value >> 24) & 0xff])
 
-const deriveKey = (
-  password: string,
-  salt: Uint8Array,
-  params: { N: number; p: number; r: number }
-): Uint8Array =>
+type ScryptParams = { N: number; p: number; r: number }
+
+const deriveKey = (password: string, salt: Uint8Array, params: ScryptParams): Uint8Array =>
   scrypt(new TextEncoder().encode(password), salt, { ...params, dkLen: 64 }).subarray(0, 32)
 
-/** Decrypts a polkadot-js encrypted keystore (`jsonDecrypt` equivalent) */
-export const decryptPjsKeystore = (
-  { encoded, encoding }: PjsKeystore,
-  password: string
-): Uint8Array => {
+// scryptAsync yields to the event loop between blocks: same result, but callers on a UI
+// thread stay responsive during the derivation
+const deriveKeyAsync = async (
+  password: string,
+  salt: Uint8Array,
+  params: ScryptParams
+): Promise<Uint8Array> =>
+  (await scryptAsync(new TextEncoder().encode(password), salt, { ...params, dkLen: 64 })).subarray(
+    0,
+    32
+  )
+
+type ParsedKeystore =
+  | { plaintext: Uint8Array }
+  | {
+      nonce: Uint8Array
+      ciphertext: Uint8Array
+      /** null for legacy keystores whose key is the raw password padded to 32 bytes */
+      scryptParams: (ScryptParams & { salt: Uint8Array }) | null
+    }
+
+const parseKeystore = ({ encoded, encoding }: PjsKeystore): ParsedKeystore => {
   if (!encoded) throw new Error("No encrypted data available to decode")
 
   const bytes = base64.decode(encoded)
 
   // unencrypted keystores (e.g. in-memory transfers) pass their payload through as-is
   if (!encoding.type.includes("xsalsa20-poly1305")) {
-    if (encoding.type.includes("none")) return bytes
+    if (encoding.type.includes("none")) return { plaintext: bytes }
     throw new Error(`Unsupported keystore encoding: ${encoding.type.join("/")}`)
   }
 
-  let offset = 0
-  let key: Uint8Array
   if (encoding.type.includes("scrypt")) {
     const salt = bytes.subarray(0, SALT_LENGTH)
     const N = readU32LE(bytes, SALT_LENGTH)
@@ -82,19 +95,57 @@ export const decryptPjsKeystore = (
     // just a safeguard against DoS by malicious params, same as polkadot-js
     if (!ALLOWED_SCRYPT_PARAMS.some((preset) => preset.N === N && preset.p === p && preset.r === r))
       throw new Error("Invalid injected scrypt params found")
-    key = deriveKey(password, salt, { N, p, r })
-    offset = SALT_LENGTH + SCRYPT_PARAMS_LENGTH
-  } else {
-    // legacy non-scrypt keystores use the raw password padded to 32 bytes
-    const padded = new Uint8Array(32)
-    padded.set(new TextEncoder().encode(password).subarray(0, 32))
-    key = padded
+
+    const offset = SALT_LENGTH + SCRYPT_PARAMS_LENGTH
+    return {
+      scryptParams: { salt, N, p, r },
+      nonce: bytes.subarray(offset, offset + NONCE_LENGTH),
+      ciphertext: bytes.subarray(offset + NONCE_LENGTH),
+    }
   }
 
-  const nonce = bytes.subarray(offset, offset + NONCE_LENGTH)
-  const ciphertext = bytes.subarray(offset + NONCE_LENGTH)
+  return {
+    scryptParams: null,
+    nonce: bytes.subarray(0, NONCE_LENGTH),
+    ciphertext: bytes.subarray(NONCE_LENGTH),
+  }
+}
 
-  return xsalsa20poly1305(key, nonce).decrypt(ciphertext)
+// legacy non-scrypt keystores use the raw password padded to 32 bytes
+const legacyPaddedKey = (password: string): Uint8Array => {
+  const padded = new Uint8Array(32)
+  padded.set(new TextEncoder().encode(password).subarray(0, 32))
+  return padded
+}
+
+/** Decrypts a polkadot-js encrypted keystore (`jsonDecrypt` equivalent) */
+export const decryptPjsKeystore = (keystore: PjsKeystore, password: string): Uint8Array => {
+  const parsed = parseKeystore(keystore)
+  if ("plaintext" in parsed) return parsed.plaintext
+
+  const key = parsed.scryptParams
+    ? deriveKey(password, parsed.scryptParams.salt, parsed.scryptParams)
+    : legacyPaddedKey(password)
+
+  return xsalsa20poly1305(key, parsed.nonce).decrypt(parsed.ciphertext)
+}
+
+/**
+ * Same as `decryptPjsKeystore` but with a non-blocking scrypt derivation — use from UI
+ * threads, where the sync variant freezes rendering for the whole derivation
+ */
+export const decryptPjsKeystoreAsync = async (
+  keystore: PjsKeystore,
+  password: string
+): Promise<Uint8Array> => {
+  const parsed = parseKeystore(keystore)
+  if ("plaintext" in parsed) return parsed.plaintext
+
+  const key = parsed.scryptParams
+    ? await deriveKeyAsync(password, parsed.scryptParams.salt, parsed.scryptParams)
+    : legacyPaddedKey(password)
+
+  return xsalsa20poly1305(key, parsed.nonce).decrypt(parsed.ciphertext)
 }
 
 /** Encrypts data as a polkadot-js keystore (`jsonEncrypt` equivalent, always scrypt + v3) */


### PR DESCRIPTION
JSON account import runs one scrypt key derivation per keystore (N=2^17, pure JS) synchronously on the UI thread — the page freezes for the whole derivation, once for the file password and once per selected account (sequentially). The existing `setTimeout` wrappers only deferred the freeze, they didn't remove it.

## Changes

- `packages/crypto`: new `decryptPjsKeystoreAsync`, identical to `decryptPjsKeystore` but using `scryptAsync` from @noble/hashes, which yields to the event loop between blocks — same output, UI keeps painting. The keystore parsing/validation is factored into a shared `parseKeystore` so both variants stay byte-compatible. Sync variant untouched (background callers keep it).
- JSON import UI (`pjsImportPairs.ts`): `unlockPair` and `unlockMultiAccountsJson` are now async and use the async decrypt.
- `AccountAddJson/context.ts`: dropped the `setTimeout` wrappers (including the `// hangs UI` one) in `unlockFile` / `unlockAccounts`; the unlock progress bar can now actually animate between per-account derivations.
