### PR TITLE
🐛 serialize dynamic token registrations

### DIFF
--- a/.changeset/dynamic-tokens-write-serialization.md
+++ b/.changeset/dynamic-tokens-write-serialization.md
@@ -1,0 +1,5 @@
+---
+"@talismn/chaindata-provider": patch
+---
+
+Serialize dynamic-token writes: concurrent `registerDynamicTokens`/`syncDynamicTokens` calls interleaved their read-merge-write cycles, so a later write could silently drop tokens the earlier one just added — visible as dTAO (and SPL) balances flickering in and out of the portfolio while balance modules register tokens concurrently (e.g. during the post-restore discovery storm).

--- a/packages/chaindata-provider/src/provider/ChaindataProvider.test.ts
+++ b/packages/chaindata-provider/src/provider/ChaindataProvider.test.ts
@@ -319,7 +319,11 @@ describe("ChaindataProvider", () => {
       const data = makeChaindata({
         tokens: [...makeChaindata().tokens, curatedToken],
       })
-      const provider = new ChaindataProvider({ persistedStorage: data })
+      // observe the dynamic tokens list directly: without serialization, whichever
+      // write lands last silently reverts the other one's effect
+      const dynamicTokens$ = new ReplaySubject<Token[]>(1)
+      dynamicTokens$.next([])
+      const provider = new ChaindataProvider({ persistedStorage: data, dynamicTokens$ })
       await provider.registerDynamicTokens([dynamicToken])
 
       const newToken = makeEvmNativeToken({
@@ -329,8 +333,11 @@ describe("ChaindataProvider", () => {
       })
       await Promise.all([provider.syncDynamicTokens(), provider.registerDynamicTokens([newToken])])
 
-      const tokens = await firstValueFrom(provider.tokens$)
-      expect(tokens.some((t) => t.id === "42161-evm-native")).toBe(true)
+      // both effects must hold: the new registration survived the sync rewrite,
+      // and the sync's drop of the curated duplicate survived the registration
+      const dynamicTokens = await firstValueFrom(dynamicTokens$)
+      expect(dynamicTokens.some((t) => t.id === "42161-evm-native")).toBe(true)
+      expect(dynamicTokens.some((t) => t.id === SOL_SPL_DYNAMIC_ID)).toBe(false)
     })
   })
 

--- a/packages/chaindata-provider/src/provider/ChaindataProvider.test.ts
+++ b/packages/chaindata-provider/src/provider/ChaindataProvider.test.ts
@@ -208,6 +208,33 @@ describe("ChaindataProvider", () => {
       expect(tokens.some((t) => t.id === "42161-evm-native")).toBe(true)
       expect(tokens.some((t) => t.id === "10-evm-native")).toBe(true)
     })
+
+    it("does not drop tokens when registrations from concurrent module pipelines interleave", async () => {
+      const data = makeChaindata()
+      const provider = new ChaindataProvider({ persistedStorage: data })
+
+      const token1 = makeEvmNativeToken({
+        id: "42161-evm-native",
+        networkId: "42161",
+        symbol: "ETH",
+      })
+      const token2 = makeEvmNativeToken({
+        id: "10-evm-native",
+        networkId: "10",
+        symbol: "ETH",
+      })
+
+      // no await between the calls: both read-merge-write cycles are in flight together
+      // (this is how balance module pipelines call it — fire-and-forget from a tap)
+      await Promise.all([
+        provider.registerDynamicTokens([token1]),
+        provider.registerDynamicTokens([token2]),
+      ])
+
+      const tokens = await firstValueFrom(provider.tokens$)
+      expect(tokens.some((t) => t.id === "42161-evm-native")).toBe(true)
+      expect(tokens.some((t) => t.id === "10-evm-native")).toBe(true)
+    })
   })
 
   describe("syncDynamicTokens", () => {
@@ -283,6 +310,27 @@ describe("ChaindataProvider", () => {
     it("does nothing when there are no dynamic tokens", async () => {
       const provider = new ChaindataProvider({ persistedStorage: makeChaindata() })
       await expect(provider.syncDynamicTokens()).resolves.toBeUndefined()
+    })
+
+    it("does not drop a registration racing with a syncDynamicTokens rewrite", async () => {
+      // a curated duplicate of the dynamic token forces syncDynamicTokens to write
+      const dynamicToken = makeSolSplDynamicToken({ symbol: "DYN" })
+      const curatedToken = makeSolSplDynamicToken({ symbol: "WSOL" })
+      const data = makeChaindata({
+        tokens: [...makeChaindata().tokens, curatedToken],
+      })
+      const provider = new ChaindataProvider({ persistedStorage: data })
+      await provider.registerDynamicTokens([dynamicToken])
+
+      const newToken = makeEvmNativeToken({
+        id: "42161-evm-native",
+        networkId: "42161",
+        symbol: "ETH",
+      })
+      await Promise.all([provider.syncDynamicTokens(), provider.registerDynamicTokens([newToken])])
+
+      const tokens = await firstValueFrom(provider.tokens$)
+      expect(tokens.some((t) => t.id === "42161-evm-native")).toBe(true)
     })
   })
 

--- a/packages/chaindata-provider/src/provider/ChaindataProvider.ts
+++ b/packages/chaindata-provider/src/provider/ChaindataProvider.ts
@@ -67,6 +67,7 @@ export class ChaindataProvider implements IChaindataProvider {
   #storage$: ReplaySubject<ChaindataStorage>
   #chaindata$: Observable<Chaindata>
   #dynamicTokens$: ReplaySubject<Token[]>
+  #dynamicTokensWriteQueue: Promise<unknown> = Promise.resolve()
 
   constructor({
     persistedStorage,
@@ -213,6 +214,18 @@ export class ChaindataProvider implements IChaindataProvider {
   }
 
   /**
+   * Serializes read-merge-write cycles on #dynamicTokens$: registrations come concurrently
+   * from independent balance module pipelines (and syncDynamicTokens), and the cycles span
+   * multiple awaits — interleaved cycles would both read the same snapshot and the later
+   * write would silently drop the earlier one's newly added tokens.
+   */
+  #enqueueDynamicTokensWrite<T>(task: () => Promise<T>): Promise<T> {
+    const result = this.#dynamicTokensWriteQueue.then(task)
+    this.#dynamicTokensWriteQueue = result.catch(() => undefined)
+    return result
+  }
+
+  /**
    * Registers token dynamically a runtime. used for SPL and dTAO tokens.
    * @param tokens
    */
@@ -222,17 +235,19 @@ export class ChaindataProvider implements IChaindataProvider {
     // check schema (chunked — yields the thread between time slices, throws on invalid)
     await forEachWithYield(tokens, (t) => void TokenSchema.parse(t))
 
-    const currentStorage = await firstValueFrom(this.#dynamicTokens$)
-    const currentById = keyBy<Token>(currentStorage, (t) => t.id)
-    const newById = keyBy<Token>(tokens, (t) => t.id)
-    const dynamicTokens = values<Token>({ ...currentById, ...newById }).sort((a, b) =>
-      a.id.localeCompare(b.id)
-    )
+    await this.#enqueueDynamicTokensWrite(async () => {
+      const currentStorage = await firstValueFrom(this.#dynamicTokens$)
+      const currentById = keyBy<Token>(currentStorage, (t) => t.id)
+      const newById = keyBy<Token>(tokens, (t) => t.id)
+      const dynamicTokens = values<Token>({ ...currentById, ...newById }).sort((a, b) =>
+        a.id.localeCompare(b.id)
+      )
 
-    // update only if necessary
-    if (!(await arrayItemsEqualWithYield(currentStorage, dynamicTokens))) {
-      this.#dynamicTokens$.next(dynamicTokens)
-    }
+      // update only if necessary
+      if (!(await arrayItemsEqualWithYield(currentStorage, dynamicTokens))) {
+        this.#dynamicTokens$.next(dynamicTokens)
+      }
+    })
   }
 
   /**
@@ -241,55 +256,57 @@ export class ChaindataProvider implements IChaindataProvider {
    * and removes dynamic entries that have since been curated into the default chaindata.
    */
   async syncDynamicTokens() {
-    const dynamicTokens = await firstValueFrom(this.#dynamicTokens$)
-    if (!dynamicTokens.length) return
+    await this.#enqueueDynamicTokensWrite(async () => {
+      const dynamicTokens = await firstValueFrom(this.#dynamicTokens$)
+      if (!dynamicTokens.length) return
 
-    // ids present in the default (curated) chaindata — used to drop dynamic
-    // duplicates so curated metadata wins (combined chaindata applies last-wins
-    // by id, so leaving a dynamic entry in place would shadow the curated one).
-    const defaultStorage = await firstValueFrom(this.#storage$)
-    const defaultTokenIds = new Set(defaultStorage.tokens.map((t) => t.id))
+      // ids present in the default (curated) chaindata — used to drop dynamic
+      // duplicates so curated metadata wins (combined chaindata applies last-wins
+      // by id, so leaving a dynamic entry in place would shadow the curated one).
+      const defaultStorage = await firstValueFrom(this.#storage$)
+      const defaultTokenIds = new Set(defaultStorage.tokens.map((t) => t.id))
 
-    const next: Token[] = []
-    let changed = false
+      const next: Token[] = []
+      let changed = false
 
-    for (const token of dynamicTokens) {
-      // drop dynamic tokens whose ids are now curated by default chaindata
-      if (
-        (token.type === "sol-spl" || token.type === "sol-token2022") &&
-        defaultTokenIds.has(token.id)
-      ) {
-        changed = true
-        continue
-      }
+      for (const token of dynamicTokens) {
+        // drop dynamic tokens whose ids are now curated by default chaindata
+        if (
+          (token.type === "sol-spl" || token.type === "sol-token2022") &&
+          defaultTokenIds.has(token.id)
+        ) {
+          changed = true
+          continue
+        }
 
-      if (token.type === "substrate-dtao") {
-        const templateTokenId = subDTaoTokenId(token.networkId, token.netuid)
-        const templateToken = await this.getTokenById(templateTokenId, "substrate-dtao")
-        if (templateToken) {
-          const updatedToken: SubDTaoToken = {
-            ...token,
-            symbol: templateToken.symbol,
-            name: templateToken.name,
-            logo: templateToken.logo,
-            subnetName: templateToken.subnetName,
-          }
-          if (!isEqual(token, updatedToken)) {
-            changed = true
-            next.push(updatedToken)
-            continue
+        if (token.type === "substrate-dtao") {
+          const templateTokenId = subDTaoTokenId(token.networkId, token.netuid)
+          const templateToken = await this.getTokenById(templateTokenId, "substrate-dtao")
+          if (templateToken) {
+            const updatedToken: SubDTaoToken = {
+              ...token,
+              symbol: templateToken.symbol,
+              name: templateToken.name,
+              logo: templateToken.logo,
+              subnetName: templateToken.subnetName,
+            }
+            if (!isEqual(token, updatedToken)) {
+              changed = true
+              next.push(updatedToken)
+              continue
+            }
           }
         }
+
+        next.push(token)
       }
 
-      next.push(token)
-    }
-
-    if (changed) {
-      log.debug("[ChaindataProvider] syncDynamicTokens: updating dynamic tokens", next)
-      const sorted = next.slice().sort((a, b) => a.id.localeCompare(b.id))
-      this.#dynamicTokens$.next(sorted)
-    }
+      if (changed) {
+        log.debug("[ChaindataProvider] syncDynamicTokens: updating dynamic tokens", next)
+        const sorted = next.slice().sort((a, b) => a.id.localeCompare(b.id))
+        this.#dynamicTokens$.next(sorted)
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
## Problem

Balances of dynamic tokens (dTAO per-hotkey positions, SPL) flicker in and out of the portfolio for the first few minutes after a backup restore.

`registerDynamicTokens` and `syncDynamicTokens` each do read → merge → write on `#dynamicTokens$`, with awaits in between. During the post-restore discovery storm, multiple balance module pipelines call them concurrently: two in-flight calls read the same stale snapshot, and the later write drops the tokens the earlier one just added. The dropped token disappears from the portfolio, gets re-registered on the next poll, and the drop/re-add can ping-pong for minutes.

## Solution

Serialize all `#dynamicTokens$` mutations through a promise queue, making each read-merge-write cycle atomic. Schema validation stays outside the queue. Added a regression test that reproduced the race deterministically before the fix.
