### PR TITLE
Preserve live balances across pipeline restarts

### DIFF
--- a/.changeset/balances-restart-live-seeds.md
+++ b/.changeset/balances-restart-live-seeds.md
@@ -2,4 +2,4 @@
 "@talismn/balances": patch
 ---
 
-Preserve live status across balance pipeline restarts: seeds re-emit previously-live balances with their exact last live result instead of downgrading the snapshot to cache and back.
+Preserve live status across balance pipeline restarts: seeds re-emit previously-live balances with their exact last live result instead of downgrading the snapshot to cache and back. Seeded live status expires after 5 minutes without a confirming module emission, and the periodic stale sweep downgrades seeded balances whose module never reconnects.

--- a/.changeset/balances-restart-live-seeds.md
+++ b/.changeset/balances-restart-live-seeds.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": patch
+---
+
+Preserve live status across balance pipeline restarts: seeds re-emit previously-live balances with their exact last live result instead of downgrading the snapshot to cache and back.

--- a/apps/extension/src/ui/state/balances.ts
+++ b/apps/extension/src/ui/state/balances.ts
@@ -2,7 +2,14 @@ import { log } from "@common/log"
 import { isAccountCompatibleWithNetwork } from "@core/domains/accounts/helpers"
 import type { BalanceSubscriptionResponse } from "@core/domains/balances/types"
 import { bind } from "@react-rxjs/core"
-import { type Address, Balance, Balances, getBalanceId, type IBalance } from "@talismn/balances"
+import {
+  type Address,
+  Balance,
+  Balances,
+  getBalanceId,
+  type HydrateDb,
+  type IBalance,
+} from "@talismn/balances"
 import type { TokenId } from "@talismn/chaindata-provider"
 import { api } from "@ui/api"
 import isEqual from "lodash-es/isEqual"
@@ -108,6 +115,33 @@ const stabilizeBalanceInstances = () => {
 
 const stabilize = stabilizeBalanceInstances()
 
+/**
+ * Reuses the previous `Balances` wrapper when an emission leaves every stabilized
+ * instance and the hydrate untouched — e.g. the background pipeline restarting after an
+ * account add re-streams a content-identical snapshot. Combined with the reference
+ * `distinctUntilChanged` below, such emissions are dropped before they can trigger a
+ * portfolio recompute.
+ */
+const reuseUnchangedBalances = () => {
+  let prev: { balances: Balance[]; hydrate: HydrateDb; wrapper: Balances } | undefined
+
+  return (balances: Balance[], hydrate: HydrateDb): Balances => {
+    if (
+      prev &&
+      prev.hydrate === hydrate &&
+      prev.balances.length === balances.length &&
+      prev.balances.every((b, i) => b === balances[i])
+    )
+      return prev.wrapper
+
+    const wrapper = new Balances(balances, hydrate)
+    prev = { balances, hydrate, wrapper }
+    return wrapper
+  }
+}
+
+const reuseUnchanged = reuseUnchangedBalances()
+
 const allBalances$ = combineLatest([
   getTokensMap$(BALANCES_CHAINDATA_QUERY),
   getNetworksMapById$(BALANCES_CHAINDATA_QUERY),
@@ -125,8 +159,9 @@ const allBalances$ = combineLatest([
 
       return isAccountCompatibleWithNetwork(network, account)
     })
-    return new Balances(stabilize(validBalances), hydrate)
+    return reuseUnchanged(stabilize(validBalances), hydrate)
   }),
+  distinctUntilChanged(),
   shareReplay({ bufferSize: 1, refCount: true })
 )
 

--- a/packages/balances/src/BalancesProvider.test.ts
+++ b/packages/balances/src/BalancesProvider.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest"
+
+import { BalancesProvider, type BalancesResult } from "./BalancesProvider"
+import { getBalanceId, type IBalance } from "./types"
+
+const makeBalance = (partial: Partial<IBalance> & Record<string, unknown> = {}): IBalance =>
+  ({
+    address: "0x01",
+    tokenId: "test-token",
+    networkId: "test-network",
+    source: "substrate-native",
+    status: "live",
+    values: [{ type: "free", label: "free", amount: "1000" }],
+    ...partial,
+  }) as IBalance
+
+const makeResult = (partial: Partial<BalancesResult> = {}): BalancesResult => ({
+  status: "live",
+  balances: [],
+  failedBalanceIds: [],
+  ...partial,
+})
+
+// the provider constructor only stores its dependencies, none are exercised by the
+// storage/seed paths under test
+const makeProvider = () =>
+  new BalancesProvider(
+    {} as ConstructorParameters<typeof BalancesProvider>[0],
+    {} as ConstructorParameters<typeof BalancesProvider>[1]
+  )
+
+type ProviderInternals = {
+  updateStorage$: (balanceIds: string[], result: BalancesResult) => void
+  getStoredBalances: (addressesByToken: Record<string, string[]>) => IBalance[]
+}
+
+const internals = (provider: BalancesProvider) => provider as unknown as ProviderInternals
+
+describe("BalancesProvider restart seeds", () => {
+  it("seeds previously-live balances with status live and stored content", () => {
+    const provider = makeProvider()
+    const balance = makeBalance()
+    const balanceId = getBalanceId(balance)
+
+    internals(provider).updateStorage$([balanceId], makeResult({ balances: [balance] }))
+
+    const seed = internals(provider).getStoredBalances({ [balance.tokenId]: [balance.address] })
+    expect(seed).toHaveLength(1)
+    expect(seed[0].status).toBe("live")
+    expect({ ...seed[0], status: undefined }).toEqual({ ...balance, status: undefined })
+  })
+
+  it("returns a reference-stable live variant across repeated seeds", () => {
+    const provider = makeProvider()
+    const balance = makeBalance()
+    const balanceId = getBalanceId(balance)
+
+    internals(provider).updateStorage$([balanceId], makeResult({ balances: [balance] }))
+
+    const scope = { [balance.tokenId]: [balance.address] }
+    const first = internals(provider).getStoredBalances(scope)
+    const second = internals(provider).getStoredBalances(scope)
+    expect(first[0]).toBe(second[0])
+  })
+
+  it("keeps status cache for balances never confirmed live (cold start)", () => {
+    const balance = makeBalance()
+
+    // no updateStorage$ call: simulates a provider constructed from persisted storage
+    const cold = new BalancesProvider(
+      {} as ConstructorParameters<typeof BalancesProvider>[0],
+      {} as ConstructorParameters<typeof BalancesProvider>[1],
+      { balances: [{ ...balance, status: "cache" } as IBalance], miniMetadatas: [] }
+    )
+
+    const seed = internals(cold).getStoredBalances({ [balance.tokenId]: [balance.address] })
+    expect(seed).toHaveLength(1)
+    expect(seed[0].status).toBe("cache")
+  })
+
+  it("downgrades a balance whose fetch later fails: stale in storage, not live in seeds", () => {
+    const provider = makeProvider()
+    const balance = makeBalance()
+    const balanceId = getBalanceId(balance)
+
+    internals(provider).updateStorage$([balanceId], makeResult({ balances: [balance] }))
+    internals(provider).updateStorage$([balanceId], makeResult({ failedBalanceIds: [balanceId] }))
+
+    const seed = internals(provider).getStoredBalances({ [balance.tokenId]: [balance.address] })
+    expect(seed).toHaveLength(1)
+    expect(seed[0].status).toBe("stale")
+  })
+
+  it("drops live status for balances that disappear from the result set", () => {
+    const provider = makeProvider()
+    const balance = makeBalance()
+    const balanceId = getBalanceId(balance)
+
+    internals(provider).updateStorage$([balanceId], makeResult({ balances: [balance] }))
+    // next emission: balance expected but absent and not failed = now empty, removed
+    internals(provider).updateStorage$([balanceId], makeResult())
+
+    const seed = internals(provider).getStoredBalances({ [balance.tokenId]: [balance.address] })
+    expect(seed).toHaveLength(0)
+  })
+
+  it("still confirms live status on a content-identical (no-op) emission", () => {
+    const balance = makeBalance()
+    const balanceId = getBalanceId(balance)
+
+    // provider restored from persisted storage holding this balance as cache
+    const restored = new BalancesProvider(
+      {} as ConstructorParameters<typeof BalancesProvider>[0],
+      {} as ConstructorParameters<typeof BalancesProvider>[1],
+      { balances: [{ ...balance, status: "cache" } as IBalance], miniMetadatas: [] }
+    )
+
+    // first live emission is content-identical to storage: the storage merge no-ops,
+    // but the live set must still learn about the balance
+    internals(restored).updateStorage$([balanceId], makeResult({ balances: [balance] }))
+
+    const seed = internals(restored).getStoredBalances({ [balance.tokenId]: [balance.address] })
+    expect(seed).toHaveLength(1)
+    expect(seed[0].status).toBe("live")
+  })
+})

--- a/packages/balances/src/BalancesProvider.test.ts
+++ b/packages/balances/src/BalancesProvider.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
-import { BalancesProvider, type BalancesResult } from "./BalancesProvider"
+import { BalancesProvider, type BalancesResult, getSweepStaleVariant } from "./BalancesProvider"
 import { getBalanceId, type IBalance } from "./types"
 
 const makeBalance = (partial: Partial<IBalance> & Record<string, unknown> = {}): IBalance =>
@@ -122,5 +122,47 @@ describe("BalancesProvider restart seeds", () => {
     const seed = internals(restored).getStoredBalances({ [balance.tokenId]: [balance.address] })
     expect(seed).toHaveLength(1)
     expect(seed[0].status).toBe("live")
+  })
+
+  it("expires live status for balances not confirmed recently", () => {
+    vi.useFakeTimers()
+    try {
+      const provider = makeProvider()
+      const balance = makeBalance()
+      const balanceId = getBalanceId(balance)
+      const scope = { [balance.tokenId]: [balance.address] }
+
+      internals(provider).updateStorage$([balanceId], makeResult({ balances: [balance] }))
+
+      vi.advanceTimersByTime(4 * 60_000)
+      expect(internals(provider).getStoredBalances(scope)[0].status).toBe("live")
+
+      // a content-identical emission refreshes the confirmation
+      internals(provider).updateStorage$([balanceId], makeResult({ balances: [balance] }))
+      vi.advanceTimersByTime(4 * 60_000)
+      expect(internals(provider).getStoredBalances(scope)[0].status).toBe("live")
+
+      // no emission for longer than the window: the scope left the subscription
+      vi.advanceTimersByTime(2 * 60_000)
+      expect(internals(provider).getStoredBalances(scope)[0].status).toBe("cache")
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("stale sweep downgrades seeded live variants but not module-confirmed ones", () => {
+    const provider = makeProvider()
+    const balance = makeBalance()
+    const balanceId = getBalanceId(balance)
+
+    internals(provider).updateStorage$([balanceId], makeResult({ balances: [balance] }))
+    const [seed] = internals(provider).getStoredBalances({ [balance.tokenId]: [balance.address] })
+
+    // seeded live status is inherited, not confirmed on the current subscription
+    expect(seed.status).toBe("live")
+    expect(getSweepStaleVariant(seed).status).toBe("stale")
+
+    // a balance emitted live by a module passes through untouched
+    expect(getSweepStaleVariant(balance)).toBe(balance)
   })
 })

--- a/packages/balances/src/BalancesProvider.ts
+++ b/packages/balances/src/BalancesProvider.ts
@@ -105,6 +105,11 @@ export class BalancesProvider {
   #storage: ReplaySubject<ProviderBalancesStorage>
   #storageValue: ProviderBalancesStorage
   #storage$: Observable<BalancesStorage>
+  // balance ids whose most recent module emission was live. Stored content always
+  // mirrors the last live emission (see updateStorage$), so on a pipeline restart the
+  // seed can re-emit these with their "live" status intact instead of downgrading the
+  // whole snapshot to "cache" and flipping it back once modules reconnect
+  #liveBalanceIds = new Set<string>()
 
   constructor(
     chaindataProvider: ChaindataProvider,
@@ -604,6 +609,15 @@ export class BalancesProvider {
       balancesResult.balances.map((b) => [getBalanceIdCached(b), b] as const)
     )
 
+    // live-status bookkeeping runs before (and regardless of) the no-op detection: a
+    // content-identical emission still confirms these balances as live
+    for (const balanceId of incomingById.keys()) this.#liveBalanceIds.add(balanceId)
+    for (const balanceId of balanceIds) {
+      if (!incomingById.has(balanceId) && !failedIds.has(balanceId))
+        this.#liveBalanceIds.delete(balanceId)
+    }
+    for (const balanceId of failedIds) this.#liveBalanceIds.delete(balanceId)
+
     // no-op detection: on quiet blocks nothing changed — skip the merge, the storage$
     // re-projection/sort and the host's downstream persistence entirely.
     // fingerprints are status-agnostic (stored entries carry "cache", results "live"),
@@ -791,7 +805,14 @@ export class BalancesProvider {
     )
 
     return balanceDefs
-      .map(([tokenId, address]) => this.#storageValue.balances[getBalanceId({ address, tokenId })])
+      .map(([tokenId, address]) => {
+        const balanceId = getBalanceId({ address, tokenId })
+        const stored = this.#storageValue.balances[balanceId]
+        if (!stored) return stored
+        // balances that were live before a restart seed with their exact last live
+        // result — downstream fingerprints match and the UI keeps its Balance instances
+        return this.#liveBalanceIds.has(balanceId) ? getLiveVariant(stored) : stored
+      })
       .filter(isNotNil)
       .sort(sortByBalanceId) as IBalance[]
   }
@@ -886,6 +907,20 @@ const getStaleVariant = (balance: IBalance): IBalance => {
   if (variant === undefined) {
     variant = { ...balance, status: "stale" } as IBalance
     staleVariants.set(balance, variant)
+  }
+  return variant
+}
+
+// memoized `{ ...b, status: "live" }`: seeds re-emit on every pipeline restart, and a
+// reference-stable variant lets downstream fingerprint caches and === compares treat
+// repeated seeds of the same stored entry as unchanged
+const liveVariants = new WeakMap<IBalance, IBalance>()
+const getLiveVariant = (balance: IBalance): IBalance => {
+  if (balance.status === "live") return balance
+  let variant = liveVariants.get(balance)
+  if (variant === undefined) {
+    variant = { ...balance, status: "live" } as IBalance
+    liveVariants.set(balance, variant)
   }
   return variant
 }

--- a/packages/balances/src/BalancesProvider.ts
+++ b/packages/balances/src/BalancesProvider.ts
@@ -105,11 +105,12 @@ export class BalancesProvider {
   #storage: ReplaySubject<ProviderBalancesStorage>
   #storageValue: ProviderBalancesStorage
   #storage$: Observable<BalancesStorage>
-  // balance ids whose most recent module emission was live. Stored content always
-  // mirrors the last live emission (see updateStorage$), so on a pipeline restart the
-  // seed can re-emit these with their "live" status intact instead of downgrading the
-  // whole snapshot to "cache" and flipping it back once modules reconnect
-  #liveBalanceIds = new Set<string>()
+  // balance ids whose most recent module emission was live, by confirmation time. Stored
+  // content always mirrors the last live emission (see updateStorage$), so on a pipeline
+  // restart the seed can re-emit recently-confirmed entries with their "live" status
+  // intact instead of downgrading the whole snapshot to "cache" and flipping it back
+  // once modules reconnect
+  #lastLiveAt = new Map<string, number>()
 
   constructor(
     chaindataProvider: ChaindataProvider,
@@ -203,12 +204,7 @@ export class BalancesProvider {
         async ({ isStale, results }, { slicer }): Promise<BalancesResult> => {
           const balanceArrays = await mapWithYield(
             results,
-            (result) =>
-              isStale
-                ? result.balances.map(
-                    (b): IBalance => (b.status !== "live" ? getStaleVariant(b) : b)
-                  )
-                : result.balances,
+            (result) => (isStale ? result.balances.map(getSweepStaleVariant) : result.balances),
             { slicer }
           )
 
@@ -611,12 +607,13 @@ export class BalancesProvider {
 
     // live-status bookkeeping runs before (and regardless of) the no-op detection: a
     // content-identical emission still confirms these balances as live
-    for (const balanceId of incomingById.keys()) this.#liveBalanceIds.add(balanceId)
+    const now = Date.now()
+    for (const balanceId of incomingById.keys()) this.#lastLiveAt.set(balanceId, now)
     for (const balanceId of balanceIds) {
       if (!incomingById.has(balanceId) && !failedIds.has(balanceId))
-        this.#liveBalanceIds.delete(balanceId)
+        this.#lastLiveAt.delete(balanceId)
     }
-    for (const balanceId of failedIds) this.#liveBalanceIds.delete(balanceId)
+    for (const balanceId of failedIds) this.#lastLiveAt.delete(balanceId)
 
     // no-op detection: on quiet blocks nothing changed — skip the merge, the storage$
     // re-projection/sort and the host's downstream persistence entirely.
@@ -804,14 +801,21 @@ export class BalancesProvider {
       addresses.map((address) => [tokenId, address] as [TokenId, Address])
     )
 
+    const now = Date.now()
     return balanceDefs
       .map(([tokenId, address]) => {
         const balanceId = getBalanceId({ address, tokenId })
         const stored = this.#storageValue.balances[balanceId]
         if (!stored) return stored
-        // balances that were live before a restart seed with their exact last live
-        // result — downstream fingerprints match and the UI keeps its Balance instances
-        return this.#liveBalanceIds.has(balanceId) ? getLiveVariant(stored) : stored
+        // balances confirmed live recently enough seed with their exact last live result
+        // — downstream fingerprints match and the UI keeps its Balance instances. Older
+        // confirmations mean the balance's scope left the subscription for a while
+        // (network/token deactivated, account removed, machine slept): that data is
+        // genuinely old, and the cache status with its loading state is the honest signal
+        const lastLiveAt = this.#lastLiveAt.get(balanceId)
+        return lastLiveAt !== undefined && now - lastLiveAt < LIVE_SEED_MAX_AGE_MS
+          ? getLiveVariant(stored)
+          : stored
       })
       .filter(isNotNil)
       .sort(sortByBalanceId) as IBalance[]
@@ -911,19 +915,34 @@ const getStaleVariant = (balance: IBalance): IBalance => {
   return variant
 }
 
+// seeds only re-emit "live" for balances confirmed live this recently. Connected module
+// subscriptions refresh their timestamps on every emission (~6s polls, per-block
+// substrate), so the window only expires when a balance's scope left the subscription
+// (network/token deactivated, account removed) or the machine slept
+const LIVE_SEED_MAX_AGE_MS = 5 * 60_000
+
 // memoized `{ ...b, status: "live" }`: seeds re-emit on every pipeline restart, and a
 // reference-stable variant lets downstream fingerprint caches and === compares treat
 // repeated seeds of the same stored entry as unchanged
 const liveVariants = new WeakMap<IBalance, IBalance>()
+const seededLiveVariants = new WeakSet<IBalance>()
 const getLiveVariant = (balance: IBalance): IBalance => {
   if (balance.status === "live") return balance
   let variant = liveVariants.get(balance)
   if (variant === undefined) {
     variant = { ...balance, status: "live" } as IBalance
     liveVariants.set(balance, variant)
+    seededLiveVariants.add(variant)
   }
   return variant
 }
+
+// the periodic stale sweep must also downgrade seeded live variants: their status is
+// inherited from before a restart, not confirmed by a module emission on the current
+// subscription — a module that never re-emits (dead RPC) would otherwise leave seed
+// content labelled live forever. Exported for tests
+export const getSweepStaleVariant = (balance: IBalance): IBalance =>
+  balance.status !== "live" || seededLiveVariants.has(balance) ? getStaleVariant(balance) : balance
 
 const mergeTwoSortedBalanceArrays = async (
   a: IBalance[],


### PR DESCRIPTION
Account adds, token/network activations and discovery flushes restart the whole balances pipeline; each restart re-seeded the UI with the stored snapshot marked \`cache\`, then flipped it back to \`live\` — rebuilding every cached Balance instance twice for identical data.

- provider remembers which balances were live and seeds restarts with their exact last live result (stored content already mirrors it), so restart re-streams are content-identical
- UI reuses the previous \`Balances\` wrapper and drops the emission when nothing changed

Measured on the scripted DOT+ETH add scenario (2 runs per variant): worst stall 276–305ms → 217–220ms, stalls ≥250ms eliminated.

Note: rows no longer flash to their loading state during a restart — previously-live balances stay rendered as live.

Safety bounds: seeded live status expires after 5 minutes without a confirming module emission, and the 30s stale sweep downgrades seeded balances whose module never reconnects (dead RPC).
