### PR TITLE
🐛 Fix dtao balance rows flapping on transient RPC failures

### DIFF
--- a/.changeset/dtao-transient-failures-stale.md
+++ b/.changeset/dtao-transient-failures-stale.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": patch
+---
+
+Fail dtao polls on transient RPC errors instead of resolving empty: conviction-lock and root-claim fetch failures previously read as "balance no longer exists", deleting the stored balance and making lock-only/claim-only rows (e.g. SN128) flap in and out of the portfolio on every other poll. Failed polls now mark balances stale, keeping rows rendered.

--- a/.changeset/dtao-transient-failures-stale.md
+++ b/.changeset/dtao-transient-failures-stale.md
@@ -2,4 +2,4 @@
 "@talismn/balances": patch
 ---
 
-Fail dtao polls on transient RPC errors instead of resolving empty: conviction-lock and root-claim fetch failures previously read as "balance no longer exists", deleting the stored balance and making lock-only/claim-only rows (e.g. SN128) flap in and out of the portfolio on every other poll. Failed polls now mark balances stale, keeping rows rendered.
+Fail dtao polls on transient RPC errors instead of resolving empty: conviction-lock and root-claim fetch failures previously read as "balance no longer exists", deleting the stored balance and making lock-only/claim-only rows (e.g. SN128) flap in and out of the portfolio on every other poll. Failed polls now mark balances stale, keeping rows rendered. Storage key encode failures (metadata drift) fail the poll the same way instead of reading as absent values.

--- a/.changeset/rpc-query-pack-empty-response.md
+++ b/.changeset/rpc-query-pack-empty-response.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": patch
+---
+
+Fail storage query packs on an empty state_queryStorageAt response instead of decoding every key as absent

--- a/.changeset/token-id-type-guards.md
+++ b/.changeset/token-id-type-guards.md
@@ -1,0 +1,5 @@
+---
+"@talismn/chaindata-provider": patch
+---
+
+Add throw-safe isTokenIdOfType / isTokenIdInTypes token id type checks

--- a/apps/extension/src/core/domains/tokenRates/store.ts
+++ b/apps/extension/src/core/domains/tokenRates/store.ts
@@ -1,6 +1,11 @@
 import { COINS_API_URL } from "@common/constants"
 import { log } from "@common/log"
-import type { Network, TokenId, TokenList } from "@talismn/chaindata-provider"
+import {
+  type Network,
+  parseTokenId,
+  type TokenId,
+  type TokenList,
+} from "@talismn/chaindata-provider"
 import {
   fetchTokenRates,
   type TokenRateCurrency,
@@ -248,11 +253,16 @@ export class TokenRatesStore {
 
       // publish the fresh rates immediately — the dtao fetch below (bittensor RPC + tao-data
       // api) must not delay rates for the rest of the wallet. previous dtao entries are
-      // carried over so alpha fiat values don't flicker until the merge lands
+      // carried over so alpha fiat values don't flicker until the merge lands.
+      // carry is keyed on the token ID shape, NOT on membership in `tokens`: during startup
+      // the active token list re-emits repeatedly (dynamic token registration, chaindata
+      // hydration) and a dtao id transiently missing from it must not lose its rate — a
+      // published rates set without it zeroes the row's fiat and the row falls out of the
+      // portfolio's rendered range for a beat (visible flap)
       const previous = await firstValueFrom(this.#storage$)
       const previousDTaoRates = Object.fromEntries(
         Object.entries(previous.tokenRates).filter(
-          ([tokenId]) => tokens[tokenId]?.type === "substrate-dtao" && !tokenRates[tokenId]
+          ([tokenId]) => parseTokenId(tokenId).type === "substrate-dtao" && !tokenRates[tokenId]
         )
       )
       if (generation !== this.#updateGeneration) return
@@ -262,8 +272,11 @@ export class TokenRatesStore {
       // prices and the TAO rates above (self-contained failure handling: keep-last, never throws)
       const dtaoRates = await fetchDTaoTokenRatesForWallet(tokens, tokenRates, previous.tokenRates)
       if (generation !== this.#updateGeneration) return
-      if (Object.keys(dtaoRates).length || Object.keys(previousDTaoRates).length)
-        this.publish({ ...tokenRates, ...dtaoRates })
+      // previousDTaoRates stays in the merge: the fetch only re-prices dtao tokens present in
+      // the current list, and entries it did not cover must survive this publish too (an empty
+      // fetch result must never regress the carried entries published above)
+      if (Object.keys(dtaoRates).length)
+        this.publish({ ...previousDTaoRates, ...tokenRates, ...dtaoRates })
     } catch (err) {
       // reset lastUpdateTokenIds to retry on next call
       this.#lastUpdateKey = ""

--- a/apps/extension/src/core/domains/tokenRates/store.ts
+++ b/apps/extension/src/core/domains/tokenRates/store.ts
@@ -46,7 +46,7 @@ type TokenRatesStoreData = TokenRatesStorage & {
 
 const blobStore = getBlobStore<TokenRatesStoreData>("tokenRates")
 
-const DEFAULT_TOKEN_RATES: TokenRatesStoreData = { tokenRates: {} }
+const DEFAULT_TOKEN_RATES: TokenRatesStoreData = { tokenRates: {}, dtaoCarriedSince: {} }
 const tokenRates$ = new ReplaySubject<TokenRatesStoreData>(1)
 // persist changes to disk
 tokenRates$
@@ -61,7 +61,13 @@ tokenRates$
 blobStore.get().then(
   (storage) => {
     if (!storage) return tokenRates$.next(DEFAULT_TOKEN_RATES)
-    tokenRates$.next({ ...DEFAULT_TOKEN_RATES, ...storage })
+    // dtaoCarriedSince ?? {}: a blob persisted with the key explicitly undefined must not
+    // clobber the default (see publish for why the key is always materialized)
+    tokenRates$.next({
+      ...DEFAULT_TOKEN_RATES,
+      ...storage,
+      dtaoCarriedSince: storage.dtaoCarriedSince ?? {},
+    })
   },
   (error) => {
     log.error("[tokenRates] failed to load tokenRates store on startup", error)
@@ -308,7 +314,9 @@ export class TokenRatesStore {
     dtaoCarriedSince?: Record<TokenId, number>
   ) {
     Object.values(this.#subscriptions.value).map((cb) => cb({ tokenRates }))
-    this.#storage$.next({ tokenRates, dtaoCarriedSince })
+    // always materialize the stamps key: an undefined-valued key is not isEqual to a missing
+    // one, which would defeat the persistence pipe's dedup right after hydration
+    this.#storage$.next({ tokenRates, dtaoCarriedSince: dtaoCarriedSince ?? {} })
   }
 
   public async subscribe(id: string, port: Port, unsubscribeCallback?: () => void) {

--- a/apps/extension/src/core/domains/tokenRates/store.ts
+++ b/apps/extension/src/core/domains/tokenRates/store.ts
@@ -1,8 +1,8 @@
 import { COINS_API_URL } from "@common/constants"
 import { log } from "@common/log"
 import {
+  isTokenIdOfType,
   type Network,
-  parseTokenId,
   type TokenId,
   type TokenList,
 } from "@talismn/chaindata-provider"
@@ -262,7 +262,7 @@ export class TokenRatesStore {
       const previous = await firstValueFrom(this.#storage$)
       const previousDTaoRates = Object.fromEntries(
         Object.entries(previous.tokenRates).filter(
-          ([tokenId]) => parseTokenId(tokenId).type === "substrate-dtao" && !tokenRates[tokenId]
+          ([tokenId]) => isTokenIdOfType(tokenId, "substrate-dtao") && !tokenRates[tokenId]
         )
       )
       if (generation !== this.#updateGeneration) return

--- a/apps/extension/src/core/domains/tokenRates/store.ts
+++ b/apps/extension/src/core/domains/tokenRates/store.ts
@@ -36,13 +36,21 @@ import {
 import { activeTokensStore, filterActiveTokens } from "../balances/store.activeTokens"
 import { fetchDTaoTokenRatesForWallet } from "./dtaoTokenRates"
 
-const blobStore = getBlobStore<TokenRatesStorage>("tokenRates")
+/** carried dtao rates whose token id stays out of the active token list longer than this are pruned */
+const DTAO_RATES_CARRY_TTL = 24 * 3_600_000
 
-const DEFAULT_TOKEN_RATES: TokenRatesStorage = { tokenRates: {} }
-const tokenRates$ = new ReplaySubject<TokenRatesStorage>(1)
+type TokenRatesStoreData = TokenRatesStorage & {
+  /** when each carried dtao rate was first seen missing from the active token list */
+  dtaoCarriedSince?: Record<TokenId, number>
+}
+
+const blobStore = getBlobStore<TokenRatesStoreData>("tokenRates")
+
+const DEFAULT_TOKEN_RATES: TokenRatesStoreData = { tokenRates: {} }
+const tokenRates$ = new ReplaySubject<TokenRatesStoreData>(1)
 // persist changes to disk
 tokenRates$
-  .pipe(debounceTime(2_000), distinctUntilChanged<TokenRatesStorage>(isEqual))
+  .pipe(debounceTime(2_000), distinctUntilChanged<TokenRatesStoreData>(isEqual))
   .subscribe((storage) => {
     log.debug(
       `[tokenRates] updating db blob with data (tokenRates:${Object.values(storage.tokenRates).length})`
@@ -72,7 +80,7 @@ type TokenRatesSubscriptionCallback = (rates: TokenRatesStorage) => void
 // TODO: Refactor this class to remove all the manual subscription handling, and instead just leverage the wonderful ReplaySubject to magically manage it all for us.
 /** @knipignore exported for typeof usage in stores.ts */
 export class TokenRatesStore {
-  #storage$: ReplaySubject<TokenRatesStorage>
+  #storage$: ReplaySubject<TokenRatesStoreData>
 
   #lastUpdateKey = ""
   #lastUpdateAt = Date.now() // will prevent a first empty call if tokens aren't loaded yet
@@ -258,15 +266,25 @@ export class TokenRatesStore {
       // the active token list re-emits repeatedly (dynamic token registration, chaindata
       // hydration) and a dtao id transiently missing from it must not lose its rate — a
       // published rates set without it zeroes the row's fiat and the row falls out of the
-      // portfolio's rendered range for a beat (visible flap)
+      // portfolio's rendered range for a beat (visible flap).
+      // unlisted ids are stamped and carried within a grace window only (covers the startup
+      // churn by orders of magnitude), then pruned: truly-gone ids (eg bittensor network
+      // deactivated, orphaned entries) must not pile up in the store forever
       const previous = await firstValueFrom(this.#storage$)
-      const previousDTaoRates = Object.fromEntries(
-        Object.entries(previous.tokenRates).filter(
-          ([tokenId]) => isTokenIdOfType(tokenId, "substrate-dtao") && !tokenRates[tokenId]
-        )
-      )
+      const prevStamps = previous.dtaoCarriedSince ?? {}
+      const dtaoCarriedSince: Record<TokenId, number> = {}
+      const previousDTaoRates: TokenRatesStorage["tokenRates"] = {}
+      for (const [tokenId, rates] of Object.entries(previous.tokenRates)) {
+        if (!isTokenIdOfType(tokenId, "substrate-dtao") || tokenRates[tokenId]) continue
+        if (!tokens[tokenId]) {
+          const since = prevStamps[tokenId] ?? now
+          if (now - since > DTAO_RATES_CARRY_TTL) continue
+          dtaoCarriedSince[tokenId] = since
+        }
+        previousDTaoRates[tokenId] = rates
+      }
       if (generation !== this.#updateGeneration) return
-      this.publish({ ...previousDTaoRates, ...tokenRates })
+      this.publish({ ...previousDTaoRates, ...tokenRates }, dtaoCarriedSince)
 
       // merge bittensor dtao (subnet alpha) token rates, computed from the subnet pool
       // prices and the TAO rates above (self-contained failure handling: keep-last, never throws)
@@ -276,7 +294,7 @@ export class TokenRatesStore {
       // the current list, and entries it did not cover must survive this publish too (an empty
       // fetch result must never regress the carried entries published above)
       if (Object.keys(dtaoRates).length)
-        this.publish({ ...previousDTaoRates, ...tokenRates, ...dtaoRates })
+        this.publish({ ...previousDTaoRates, ...tokenRates, ...dtaoRates }, dtaoCarriedSince)
     } catch (err) {
       // reset lastUpdateTokenIds to retry on next call
       this.#lastUpdateKey = ""
@@ -284,17 +302,19 @@ export class TokenRatesStore {
     }
   }
 
-  /** pushes a rates list to subscribers and the persisted store */
-  private publish(tokenRates: TokenRatesStorage["tokenRates"]) {
-    const putTokenRates: TokenRatesStorage = { tokenRates }
-    Object.values(this.#subscriptions.value).map((cb) => cb(putTokenRates))
-    this.#storage$.next(putTokenRates)
+  /** pushes a rates list to subscribers and the persisted store (carry stamps stay internal) */
+  private publish(
+    tokenRates: TokenRatesStorage["tokenRates"],
+    dtaoCarriedSince?: Record<TokenId, number>
+  ) {
+    Object.values(this.#subscriptions.value).map((cb) => cb({ tokenRates }))
+    this.#storage$.next({ tokenRates, dtaoCarriedSince })
   }
 
   public async subscribe(id: string, port: Port, unsubscribeCallback?: () => void) {
     const cb = createSubscription<"pri(tokenRates.subscribe)">(id, port)
-    const currentTokenRates = await firstValueFrom(this.#storage$)
-    cb(currentTokenRates)
+    const { tokenRates } = await firstValueFrom(this.#storage$)
+    cb({ tokenRates })
 
     const currentSubscriptions = this.#subscriptions.value
     this.#subscriptions.next({ ...currentSubscriptions, [id]: cb })

--- a/packages/balances/src/modules/shared/rpcQueryPack.test.ts
+++ b/packages/balances/src/modules/shared/rpcQueryPack.test.ts
@@ -173,4 +173,22 @@ describe("fetchRpcQueryPack", () => {
     expect(await fetchRpcQueryPack(connector, "polkadot", queries)).toEqual([","])
     expect(connector.send).not.toHaveBeenCalled()
   })
+
+  it("rejects on an empty state_queryStorageAt response instead of decoding all-null", async () => {
+    // an empty response is a bad response, not absent values: decoding it would fabricate
+    // "no value" for every queried key and downstream deletes the matching balances
+    const { connector } = makeFakeConnector()
+    ;(connector.send as ReturnType<typeof vi.fn>).mockResolvedValueOnce([])
+
+    let decodes = 0
+    const queries = makeQueries(2, (i, value) => {
+      decodes++
+      return `${i}:${value}`
+    })
+
+    await expect(fetchRpcQueryPack(connector, "polkadot", queries)).rejects.toThrow(
+      "Empty state_queryStorageAt response"
+    )
+    expect(decodes).toBe(0)
+  })
 })

--- a/packages/balances/src/modules/shared/rpcQueryPack.ts
+++ b/packages/balances/src/modules/shared/rpcQueryPack.ts
@@ -31,7 +31,12 @@ export const fetchRpcQueryPack = async <T>(
     allStateKeys,
   ])
 
-  return decodeRpcQueryPackChunked(queries, result ? new Map(result.changes) : null, {
+  // a valid state_queryStorageAt response carries one entry per queried block — an empty
+  // response is a bad response, not absent values: decoding it would fabricate "no value"
+  // for every queried key (eg empty RootClaimable maps deleting claim-only balances)
+  if (!result) throw new Error(`Empty state_queryStorageAt response on ${networkId}`)
+
+  return decodeRpcQueryPackChunked(queries, new Map(result.changes), {
     label: `rpcQueryPack decode ${networkId}`,
   })
 }
@@ -104,12 +109,12 @@ export const getRpcQueryPack$ = <T>(
 
 const decodeRpcQueryPackChunked = <T>(
   queries: RpcQueryPack<T>[],
-  changesByKey: ChangesByKey | null,
+  changesByKey: ChangesByKey,
   options?: ChunkedOptions
 ): Promise<T[]> =>
   mapWithYield(
     queries,
     ({ stateKeys, decodeResult }) =>
-      decodeResult(stateKeys.map((stateKey) => (stateKey && changesByKey?.get(stateKey)) ?? null)),
+      decodeResult(stateKeys.map((stateKey) => (stateKey && changesByKey.get(stateKey)) ?? null)),
     options
   )

--- a/packages/balances/src/modules/substrate-dtao/convictionLocks.ts
+++ b/packages/balances/src/modules/substrate-dtao/convictionLocks.ts
@@ -184,11 +184,13 @@ const fetchConvictionLockStorageKeys = async (
       try {
         keyPrefix = storageCoder.keys.enc(address)
       } catch (cause) {
+        // an unencodable key prefix (metadata drift) would make the address read as lock-free
+        // and delete its lock-only balances — fail the poll (stale) instead, like decode failures
         log.warn(
           `Failed to encode conviction Lock key prefix (address=${address}) on ${networkId}`,
           { cause }
         )
-        return []
+        throw cause
       }
 
       let stateKeys: `0x${string}`[]

--- a/packages/balances/src/modules/substrate-dtao/convictionLocks.ts
+++ b/packages/balances/src/modules/substrate-dtao/convictionLocks.ts
@@ -203,8 +203,10 @@ const fetchConvictionLockStorageKeys = async (
             // coldkey) to keep the address format consistent with the rest of the pipeline
             return [{ address, netuid, hotkey }]
           } catch (cause) {
+            // a returned state key that fails decode is a bad response (or metadata drift),
+            // not an absent lock — fail the poll (stale) instead of silently dropping it
             log.warn(`Failed to decode conviction Lock key ${stateKey} on ${networkId}`, { cause })
-            return []
+            throw cause
           }
         })
       } catch (cause) {
@@ -252,6 +254,11 @@ const fetchConvictionLockModes = async (
             hexValue,
             `Failed to decode DecayingLock for (netuid=${netuid}, address=${address}) on ${networkId}`
           )
+          // present-but-undecodable: defaulting to "decaying" would mislabel a perpetual lock
+          if (decoded === null)
+            throw new Error(
+              `Failed to decode DecayingLock for (netuid=${netuid}, address=${address}) on ${networkId}`
+            )
 
           return [key, decoded === false ? "perpetual" : "decaying"]
         },

--- a/packages/balances/src/modules/substrate-dtao/convictionLocks.ts
+++ b/packages/balances/src/modules/substrate-dtao/convictionLocks.ts
@@ -159,8 +159,11 @@ export const fetchConvictionLocks = async (
       ]
     })
   } catch (cause) {
+    // propagate instead of returning []: an empty result reads as "no locks", the provider
+    // deletes the stored lock-only balances, and the rows flap back in on the next
+    // successful poll. Throwing fails the whole poll so those balances go stale instead
     log.warn(`Failed to fetch Bittensor conviction locks on ${networkId}`, { cause })
-    return []
+    throw cause
   }
 }
 
@@ -205,10 +208,12 @@ const fetchConvictionLockStorageKeys = async (
           }
         })
       } catch (cause) {
+        // transient RPC failure: swallowing it would make every lock of this address read
+        // as removed for one poll (delete + re-add flap downstream) — fail the poll instead
         log.warn(`Failed to fetch conviction Lock keys (address=${address}) on ${networkId}`, {
           cause,
         })
-        return []
+        throw cause
       }
     })
   )
@@ -276,11 +281,13 @@ const fetchColdkeyLockStates = async (
         )
         return { address, netuid, lockState }
       } catch (cause) {
+        // a null lockState decodes as zero mass + zero conviction and the lock is silently
+        // dropped — transient RPC failures must fail the poll, not erase the lock
         log.warn(
           `Failed to fetch get_coldkey_lock for (netuid=${netuid}, address=${address}) on ${networkId}`,
           { cause }
         )
-        return { address, netuid, lockState: null }
+        throw cause
       }
     })
   )

--- a/packages/balances/src/modules/substrate-dtao/convictionLocks.ts
+++ b/packages/balances/src/modules/substrate-dtao/convictionLocks.ts
@@ -191,24 +191,9 @@ const fetchConvictionLockStorageKeys = async (
         return []
       }
 
+      let stateKeys: `0x${string}`[]
       try {
-        const stateKeys = await connector.send<`0x${string}`[]>(networkId, "state_getKeys", [
-          keyPrefix,
-        ])
-
-        return stateKeys.flatMap((stateKey) => {
-          try {
-            const [, netuid, hotkey] = storageCoder.keys.dec(stateKey) as [string, number, string]
-            // report the lock under the requested address (the prefix guarantees it is the
-            // coldkey) to keep the address format consistent with the rest of the pipeline
-            return [{ address, netuid, hotkey }]
-          } catch (cause) {
-            // a returned state key that fails decode is a bad response (or metadata drift),
-            // not an absent lock — fail the poll (stale) instead of silently dropping it
-            log.warn(`Failed to decode conviction Lock key ${stateKey} on ${networkId}`, { cause })
-            throw cause
-          }
-        })
+        stateKeys = await connector.send<`0x${string}`[]>(networkId, "state_getKeys", [keyPrefix])
       } catch (cause) {
         // transient RPC failure: swallowing it would make every lock of this address read
         // as removed for one poll (delete + re-add flap downstream) — fail the poll instead
@@ -217,6 +202,20 @@ const fetchConvictionLockStorageKeys = async (
         })
         throw cause
       }
+
+      return stateKeys.flatMap((stateKey) => {
+        try {
+          const [, netuid, hotkey] = storageCoder.keys.dec(stateKey) as [string, number, string]
+          // report the lock under the requested address (the prefix guarantees it is the
+          // coldkey) to keep the address format consistent with the rest of the pipeline
+          return [{ address, netuid, hotkey }]
+        } catch (cause) {
+          // a returned state key that fails decode is a bad response (or metadata drift),
+          // not an absent lock — fail the poll (stale) instead of silently dropping it
+          log.warn(`Failed to decode conviction Lock key ${stateKey} on ${networkId}`, { cause })
+          throw cause
+        }
+      })
     })
   )
 
@@ -231,14 +230,17 @@ const fetchConvictionLockModes = async (
 ): Promise<Map<string, SubDTaoConvictionLockType>> => {
   const queries = pairs.map(
     ({ address, netuid }): RpcQueryPack<[string, SubDTaoConvictionLockType]> => {
-      let stateKey: MaybeStateKey = null
+      let stateKey: MaybeStateKey
       try {
         stateKey = storageCoder.keys.enc(address, netuid) as MaybeStateKey
       } catch (cause) {
+        // an unencodable key (metadata drift) would silently default the pair to "decaying"
+        // below, mislabeling a perpetual lock — fail the poll instead, like decode failures
         log.warn(
           `Failed to encode conviction DecayingLock key (netuid=${netuid}, address=${address}) on ${networkId}`,
           { cause }
         )
+        throw cause
       }
 
       const key = convictionLockKey(address, netuid)

--- a/packages/balances/src/modules/substrate-dtao/fetchBalances.ts
+++ b/packages/balances/src/modules/substrate-dtao/fetchBalances.ts
@@ -439,7 +439,11 @@ const buildRootClaimableQueries = (
         hexValue,
         `Failed to decode RootClaimable for hotkey ${hotkey} on ${networkId}`
       )
-      return [hotkey, decoded ? new Map(decoded) : new Map<number, bigint>()]
+      // a present-but-undecodable value is a bad response, not an absent entry: an empty
+      // map here would erase the hotkey's claim-only balances for this poll
+      if (decoded === null)
+        throw new Error(`Failed to decode RootClaimable for hotkey ${hotkey} on ${networkId}`)
+      return [hotkey, new Map(decoded)]
     }
 
     return {
@@ -469,9 +473,11 @@ const fetchRootClaimableRates = async (
     const results = await fetchRpcQueryPack(connector, networkId, queries)
     return new Map(results)
   } catch (cause) {
+    // empty rates would make claim-only balances (zero direct stake) read as non-existent
+    // for this poll — the provider would delete them and they'd flap back in on the next
+    // one. Transient fetch failures must fail the poll (balances go stale) instead
     log.warn(`Failed to fetch RootClaimable for hotkeys on ${networkId}`, { cause })
-    // Fallback: return empty map for all hotkeys
-    return new Map(hotkeys.map((hotkey) => [hotkey, new Map<number, bigint>()]))
+    throw cause
   }
 }
 
@@ -503,7 +509,12 @@ const buildRootClaimedQueries = (
         hexValue,
         `Failed to decode RootClaimed for (netuid=${netuid}, hotkey=${hotkey}, address=${address}) on ${networkId}`
       )
-      return [address, hotkey, netuid, decoded ?? 0n]
+      // present-but-undecodable: claimed=0 would overstate the pending claim — fail the poll
+      if (decoded === null)
+        throw new Error(
+          `Failed to decode RootClaimed for (netuid=${netuid}, hotkey=${hotkey}, address=${address}) on ${networkId}`
+        )
+      return [address, hotkey, netuid, decoded]
     }
 
     return {
@@ -550,17 +561,11 @@ const fetchRootClaimedAmounts = async (
     }
     return result
   } catch (cause) {
+    // claimed=0 fallback overstates every pending root claim for this poll (claimable
+    // minus claimed) — transient fetch failures must fail the poll, not fabricate values
     log.warn(`Failed to fetch RootClaimed for address-hotkey-netuid pairs on ${networkId}`, {
       cause,
     })
-    // Fallback: return empty map for all pairs
-    const result = new Map<string, Map<string, Map<number, bigint>>>()
-    for (const [address, hotkey, netuid] of addressHotkeyNetuidPairs) {
-      if (!result.has(address)) result.set(address, new Map())
-      const addressMap = result.get(address)!
-      if (!addressMap.has(hotkey)) addressMap.set(hotkey, new Map())
-      addressMap.get(hotkey)!.set(netuid, 0n)
-    }
-    return result
+    throw cause
   }
 }

--- a/packages/balances/src/modules/substrate-dtao/fetchBalances.ts
+++ b/packages/balances/src/modules/substrate-dtao/fetchBalances.ts
@@ -421,11 +421,14 @@ const buildRootClaimableQueries = (
   storageCoder: ReturnType<ReturnType<typeof parseMetadataRpc>["builder"]["buildStorage"]>
 ): Array<RpcQueryPack<[string, Map<number, bigint>]>> => {
   return hotkeys.map((hotkey) => {
-    let stateKey: MaybeStateKey = null
+    let stateKey: MaybeStateKey
     try {
       stateKey = storageCoder.keys.enc(hotkey) as MaybeStateKey
     } catch (cause) {
+      // an unencodable key (metadata drift) would make the hotkey's RootClaimable read as an
+      // empty map, erasing its claim-only balances — fail the poll (stale) instead
       log.warn(`Failed to encode storage key for hotkey ${hotkey} on ${networkId}`, { cause })
+      throw cause
     }
 
     const decodeResult = (changes: MaybeStateKey[]): [string, Map<number, bigint>] => {
@@ -487,15 +490,18 @@ const buildRootClaimedQueries = (
   storageCoder: ReturnType<ReturnType<typeof parseMetadataRpc>["builder"]["buildStorage"]>
 ): Array<RpcQueryPack<[string, string, number, bigint]>> => {
   return addressHotkeyNetuidPairs.map(([address, hotkey, netuid]) => {
-    let stateKey: MaybeStateKey = null
+    let stateKey: MaybeStateKey
     try {
       // RootClaimed storage takes params: [netuid, hotkey, coldkey_ss58]
       stateKey = storageCoder.keys.enc(netuid, hotkey, address) as MaybeStateKey
     } catch (cause) {
+      // an unencodable key (metadata drift) would read as claimed=0, overstating the pending
+      // claim — fail the poll (stale) instead
       log.warn(
         `Failed to encode storage key for RootClaimed (netuid=${netuid}, hotkey=${hotkey}, address=${address}) on ${networkId}`,
         { cause }
       )
+      throw cause
     }
 
     const decodeResult = (changes: MaybeStateKey[]): [string, string, number, bigint] => {

--- a/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
+++ b/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
@@ -88,6 +88,38 @@ describe("fetchConvictionLocks transient failures", () => {
     ).rejects.toThrow("bad key")
   })
 
+  it("rejects when the Lock key prefix encode fails", async () => {
+    // an unencodable key prefix (metadata drift) would make the address read as lock-free
+    // and delete its lock-only balances — the poll must fail instead
+    const lockCoder = {
+      keys: {
+        enc: vi.fn(() => {
+          throw new Error("bad prefix")
+        }),
+        dec: vi.fn(),
+      },
+      value: { dec: vi.fn() },
+    }
+    vi.mocked(parseMetadataRpcCached).mockReturnValue({
+      builder: {
+        buildStorage: vi.fn((_pallet: string, entry: string) =>
+          entry === "Lock" ? lockCoder : makeCoder()
+        ),
+      },
+      unifiedMetadata: {},
+    } as unknown as ReturnType<typeof parseMetadataRpcCached>)
+    const connector = { send: vi.fn() }
+
+    await expect(
+      fetchConvictionLocks(
+        connector as unknown as Parameters<typeof fetchConvictionLocks>[0],
+        "bittensor",
+        "0x00",
+        ["address-1"]
+      )
+    ).rejects.toThrow("bad prefix")
+  })
+
   it("rejects when the DecayingLock key encode fails", async () => {
     // an unencodable DecayingLock key would silently default the pair to "decaying",
     // mislabeling a perpetual lock — the poll must fail instead
@@ -159,6 +191,100 @@ describe("fetchBalances transient failures", () => {
       networkId: "bittensor",
       tokensWithAddresses: [[token, ["address-1"]]] as TokensWithAddresses,
       connector: { send: vi.fn() },
+      miniMetadata: { data: "0x00", source: "substrate-dtao", chainId: "bittensor" },
+      signal: new AbortController().signal,
+    } as unknown as Parameters<typeof fetchBalances>[0])
+
+    expect(result.success).toEqual([])
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({ tokenId: token.id, address: "address-1" })
+  })
+
+  it("returns per-balance errors when the RootClaimable key encode fails", async () => {
+    // an unencodable key (metadata drift) would make the hotkey's RootClaimable read as an
+    // empty map, erasing its claim-only balances — the poll must fail instead
+    const rootClaimableCoder = {
+      keys: {
+        enc: vi.fn(() => {
+          throw new Error("bad claimable key")
+        }),
+        dec: vi.fn(),
+      },
+      value: { dec: vi.fn() },
+    }
+    vi.mocked(parseMetadataRpcCached).mockReturnValue({
+      builder: {
+        buildStorage: vi.fn((_pallet: string, entry: string) =>
+          entry === "RootClaimable" ? rootClaimableCoder : makeCoder()
+        ),
+      },
+      unifiedMetadata: {},
+    } as unknown as ReturnType<typeof parseMetadataRpcCached>)
+    vi.mocked(fetchRuntimeCallResult).mockResolvedValue([
+      ["address-1", [{ netuid: 0, hotkey: "hotkey-1", stake: 100n }]],
+    ] as unknown as Awaited<ReturnType<typeof fetchRuntimeCallResult>>)
+
+    const token = {
+      id: "bittensor:substrate-dtao:0",
+      type: "substrate-dtao",
+      platform: "polkadot",
+      networkId: "bittensor",
+      netuid: 0,
+    } as unknown as TokensWithAddresses[number][0]
+
+    const result = await fetchBalances({
+      networkId: "bittensor",
+      tokensWithAddresses: [[token, ["address-1"]]] as TokensWithAddresses,
+      connector: { send: vi.fn() },
+      miniMetadata: { data: "0x00", source: "substrate-dtao", chainId: "bittensor" },
+      signal: new AbortController().signal,
+    } as unknown as Parameters<typeof fetchBalances>[0])
+
+    expect(result.success).toEqual([])
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({ tokenId: token.id, address: "address-1" })
+  })
+
+  it("returns per-balance errors when the RootClaimed key encode fails", async () => {
+    // an unencodable key (metadata drift) would read as claimed=0, overstating the pending
+    // claim — the poll must fail instead
+    const rootClaimedCoder = {
+      keys: {
+        enc: vi.fn(() => {
+          throw new Error("bad claimed key")
+        }),
+        dec: vi.fn(),
+      },
+      value: { dec: vi.fn() },
+    }
+    vi.mocked(parseMetadataRpcCached).mockReturnValue({
+      builder: {
+        buildStorage: vi.fn((_pallet: string, entry: string) =>
+          entry === "RootClaimed" ? rootClaimedCoder : makeCoder()
+        ),
+      },
+      unifiedMetadata: {},
+    } as unknown as ReturnType<typeof parseMetadataRpcCached>)
+    vi.mocked(fetchRuntimeCallResult).mockResolvedValue([
+      ["address-1", [{ netuid: 0, hotkey: "hotkey-1", stake: 100n }]],
+    ] as unknown as Awaited<ReturnType<typeof fetchRuntimeCallResult>>)
+    // RootClaimable resolves with a claimable rate so the RootClaimed fetch runs
+    vi.mocked(fetchRpcQueryPack).mockResolvedValue([["hotkey-1", new Map([[5, 1n]])]])
+    // conviction lock scan finds no keys
+    const connector = { send: vi.fn().mockResolvedValue([]) }
+
+    const token = {
+      id: "bittensor:substrate-dtao:0",
+      type: "substrate-dtao",
+      platform: "polkadot",
+      networkId: "bittensor",
+      netuid: 0,
+    } as unknown as TokensWithAddresses[number][0]
+
+    const result = await fetchBalances({
+      networkId: "bittensor",
+      tokensWithAddresses: [[token, ["address-1"]]] as TokensWithAddresses,
+      connector,
       miniMetadata: { data: "0x00", source: "substrate-dtao", chainId: "bittensor" },
       signal: new AbortController().signal,
     } as unknown as Parameters<typeof fetchBalances>[0])

--- a/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
+++ b/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
@@ -88,6 +88,39 @@ describe("fetchConvictionLocks transient failures", () => {
     ).rejects.toThrow("bad key")
   })
 
+  it("rejects when the DecayingLock key encode fails", async () => {
+    // an unencodable DecayingLock key would silently default the pair to "decaying",
+    // mislabeling a perpetual lock — the poll must fail instead
+    const decayingCoder = {
+      keys: {
+        enc: vi.fn(() => {
+          throw new Error("bad decaying key")
+        }),
+        dec: vi.fn(),
+      },
+      value: { dec: vi.fn() },
+    }
+    vi.mocked(parseMetadataRpcCached).mockReturnValue({
+      builder: {
+        buildStorage: vi.fn((_pallet: string, entry: string) =>
+          entry === "DecayingLock" ? decayingCoder : makeCoder()
+        ),
+      },
+      unifiedMetadata: {},
+    } as unknown as ReturnType<typeof parseMetadataRpcCached>)
+    const connector = { send: vi.fn().mockResolvedValue(["0xstatekey1"]) }
+    vi.mocked(fetchRuntimeCallResult).mockResolvedValue(null)
+
+    await expect(
+      fetchConvictionLocks(
+        connector as unknown as Parameters<typeof fetchConvictionLocks>[0],
+        "bittensor",
+        "0x00",
+        ["address-1"]
+      )
+    ).rejects.toThrow("bad decaying key")
+  })
+
   it("rejects when get_coldkey_lock fails", async () => {
     mockMetadata()
     const connector = { send: vi.fn().mockResolvedValue(["0xstatekey1"]) }

--- a/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
+++ b/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { TokensWithAddresses } from "../../types/IBalanceModule"
+import { fetchRuntimeCallResult } from "../shared"
+import { parseMetadataRpcCached } from "../shared/parseMetadataRpcCached"
+import { fetchRpcQueryPack } from "../shared/rpcQueryPack"
+import { fetchConvictionLocks } from "./convictionLocks"
+import { fetchBalances } from "./fetchBalances"
+
+vi.mock("../../log", () => ({
+  default: { error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("../shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../shared")>()),
+  fetchRuntimeCallResult: vi.fn(),
+  hasRuntimeApi: vi.fn(() => true),
+  hasStorageItems: vi.fn(() => true),
+}))
+
+vi.mock("../shared/parseMetadataRpcCached", () => ({
+  parseMetadataRpcCached: vi.fn(),
+}))
+
+vi.mock("../shared/rpcQueryPack", () => ({
+  fetchRpcQueryPack: vi.fn(),
+}))
+
+const makeCoder = () => ({
+  keys: {
+    enc: vi.fn(() => "0xkeyprefix"),
+    dec: vi.fn(() => ["address-1", 128, "hotkey-1"]),
+  },
+  value: { dec: vi.fn() },
+})
+
+const makeBuilder = () => ({ buildStorage: vi.fn(() => makeCoder()) })
+
+const mockMetadata = () => {
+  vi.mocked(parseMetadataRpcCached).mockReturnValue({
+    builder: makeBuilder(),
+    unifiedMetadata: {},
+  } as unknown as ReturnType<typeof parseMetadataRpcCached>)
+}
+
+// transient RPC failures must reject (the poll fails, the provider marks balances stale)
+// instead of resolving empty: an empty result reads as "these balances no longer exist",
+// the provider deletes them from storage and the rows flap back in on the next good poll
+
+describe("fetchConvictionLocks transient failures", () => {
+  it("rejects when the Lock storage key scan fails", async () => {
+    mockMetadata()
+    const connector = { send: vi.fn().mockRejectedValue(new Error("rpc down")) }
+
+    await expect(
+      fetchConvictionLocks(
+        connector as unknown as Parameters<typeof fetchConvictionLocks>[0],
+        "bittensor",
+        "0x00",
+        ["address-1"]
+      )
+    ).rejects.toThrow("rpc down")
+  })
+
+  it("rejects when get_coldkey_lock fails", async () => {
+    mockMetadata()
+    const connector = { send: vi.fn().mockResolvedValue(["0xstatekey1"]) }
+    vi.mocked(fetchRpcQueryPack).mockResolvedValue([])
+    vi.mocked(fetchRuntimeCallResult).mockRejectedValue(new Error("runtime api failed"))
+
+    await expect(
+      fetchConvictionLocks(
+        connector as unknown as Parameters<typeof fetchConvictionLocks>[0],
+        "bittensor",
+        "0x00",
+        ["address-1"]
+      )
+    ).rejects.toThrow("runtime api failed")
+  })
+})
+
+describe("fetchBalances transient failures", () => {
+  it("returns per-balance errors (not empty success) when the RootClaimable fetch fails", async () => {
+    mockMetadata()
+    // root stake found for the coldkey, so the RootClaimable rates fetch runs
+    vi.mocked(fetchRuntimeCallResult).mockResolvedValue([
+      ["address-1", [{ netuid: 0, hotkey: "hotkey-1", stake: 100n }]],
+    ] as unknown as Awaited<ReturnType<typeof fetchRuntimeCallResult>>)
+    vi.mocked(fetchRpcQueryPack).mockRejectedValue(new Error("rpc down"))
+
+    const token = {
+      id: "bittensor-substrate-dtao-0",
+      type: "substrate-dtao",
+      platform: "polkadot",
+      networkId: "bittensor",
+      netuid: 0,
+    } as unknown as TokensWithAddresses[number][0]
+
+    const result = await fetchBalances({
+      networkId: "bittensor",
+      tokensWithAddresses: [[token, ["address-1"]]] as TokensWithAddresses,
+      connector: { send: vi.fn() },
+      miniMetadata: { data: "0x00", source: "substrate-dtao", chainId: "bittensor" },
+      signal: new AbortController().signal,
+    } as unknown as Parameters<typeof fetchBalances>[0])
+
+    expect(result.success).toEqual([])
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({ tokenId: token.id, address: "address-1" })
+  })
+})

--- a/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
+++ b/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
@@ -89,7 +89,7 @@ describe("fetchBalances transient failures", () => {
     vi.mocked(fetchRpcQueryPack).mockRejectedValue(new Error("rpc down"))
 
     const token = {
-      id: "bittensor-substrate-dtao-0",
+      id: "bittensor:substrate-dtao:0",
       type: "substrate-dtao",
       platform: "polkadot",
       networkId: "bittensor",

--- a/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
+++ b/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
@@ -62,6 +62,32 @@ describe("fetchConvictionLocks transient failures", () => {
     ).rejects.toThrow("rpc down")
   })
 
+  it("rejects when a returned Lock storage key fails to decode", async () => {
+    const coder = {
+      keys: {
+        enc: vi.fn(() => "0xkeyprefix"),
+        dec: vi.fn(() => {
+          throw new Error("bad key")
+        }),
+      },
+      value: { dec: vi.fn() },
+    }
+    vi.mocked(parseMetadataRpcCached).mockReturnValue({
+      builder: { buildStorage: vi.fn(() => coder) },
+      unifiedMetadata: {},
+    } as unknown as ReturnType<typeof parseMetadataRpcCached>)
+    const connector = { send: vi.fn().mockResolvedValue(["0xstatekey1"]) }
+
+    await expect(
+      fetchConvictionLocks(
+        connector as unknown as Parameters<typeof fetchConvictionLocks>[0],
+        "bittensor",
+        "0x00",
+        ["address-1"]
+      )
+    ).rejects.toThrow("bad key")
+  })
+
   it("rejects when get_coldkey_lock fails", async () => {
     mockMetadata()
     const connector = { send: vi.fn().mockResolvedValue(["0xstatekey1"]) }

--- a/packages/chaindata-provider/src/chaindata/utils.test.ts
+++ b/packages/chaindata-provider/src/chaindata/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import { isTokenIdInTypes, isTokenIdOfType } from "./utils"
+
+describe("isTokenIdOfType", () => {
+  it("matches a valid token id of the given type", () => {
+    expect(isTokenIdOfType("bittensor:substrate-dtao:128", "substrate-dtao")).toBe(true)
+    expect(isTokenIdOfType("bittensor:substrate-dtao:128:hotkey", "substrate-dtao")).toBe(true)
+    expect(isTokenIdOfType("polkadot:substrate-native", "substrate-native")).toBe(true)
+  })
+
+  it("returns false for a valid token id of another type", () => {
+    expect(isTokenIdOfType("polkadot:substrate-native", "substrate-dtao")).toBe(false)
+  })
+
+  it("returns false for unknown token types", () => {
+    expect(isTokenIdOfType("somechain:bitcoin-native", "substrate-dtao")).toBe(false)
+  })
+
+  it("returns false for malformed ids instead of throwing", () => {
+    expect(isTokenIdOfType("polkadot-substrate-native", "substrate-native")).toBe(false)
+    expect(isTokenIdOfType("", "substrate-native")).toBe(false)
+    expect(isTokenIdOfType("bittensor:substrate-dtao:not-a-netuid", "substrate-dtao")).toBe(false)
+  })
+
+  it("returns false for non-string values instead of throwing", () => {
+    expect(isTokenIdOfType(null, "substrate-native")).toBe(false)
+    expect(isTokenIdOfType(undefined, "substrate-native")).toBe(false)
+    expect(isTokenIdOfType(42, "substrate-native")).toBe(false)
+    expect(isTokenIdOfType({}, "substrate-native")).toBe(false)
+  })
+})
+
+describe("isTokenIdInTypes", () => {
+  it("matches any of the given types", () => {
+    expect(
+      isTokenIdInTypes("bittensor:substrate-dtao:128", ["substrate-native", "substrate-dtao"])
+    ).toBe(true)
+    expect(isTokenIdInTypes("bittensor:substrate-dtao:128", ["substrate-native"])).toBe(false)
+    expect(isTokenIdInTypes("garbage", ["substrate-native", "substrate-dtao"])).toBe(false)
+  })
+})

--- a/packages/chaindata-provider/src/chaindata/utils.ts
+++ b/packages/chaindata-provider/src/chaindata/utils.ts
@@ -183,6 +183,32 @@ export const parseTokenId = <T extends TokenType>(tokenId: TokenId): TokenIdSpec
   }
 }
 
+/**
+ * Throw-safe check of a token id's type: accepts any value and returns false for
+ * non-strings, malformed ids and unknown token types (eg ids persisted by another
+ * wallet version) instead of throwing like parseTokenId does.
+ */
+export const isTokenIdOfType = <T extends TokenType>(
+  tokenId: unknown,
+  type: T
+): tokenId is TokenId => {
+  if (typeof tokenId !== "string") return false
+  try {
+    // parseTokenId returns undefined (despite its declared type) for unknown token types
+    return parseTokenId(tokenId)?.type === type
+  } catch {
+    return false
+  }
+}
+
+/** Throw-safe: see isTokenIdOfType */
+export const isTokenIdInTypes = <T extends TokenType[]>(
+  tokenId: unknown,
+  types: T
+): tokenId is TokenId => {
+  return types.some((type) => isTokenIdOfType(tokenId, type))
+}
+
 export const networkIdFromTokenId = (tokenId: TokenId): Network["id"] =>
   parseTokenId(tokenId).networkId
 

--- a/packages/chaindata-provider/src/chaindata/utils.ts
+++ b/packages/chaindata-provider/src/chaindata/utils.ts
@@ -181,27 +181,22 @@ export const parseTokenId = <T extends TokenType>(tokenId: TokenId): TokenIdSpec
     case "sol-token2022":
       return parseSolToken2022TokenId(tokenId) as TokenIdSpecs<T>
   }
+
+  throw new Error(`Invalid TokenId: ${tokenId}`)
 }
 
-/**
- * Throw-safe check of a token id's type: accepts any value and returns false for
- * non-strings, malformed ids and unknown token types (eg ids persisted by another
- * wallet version) instead of throwing like parseTokenId does.
- */
 export const isTokenIdOfType = <T extends TokenType>(
   tokenId: unknown,
   type: T
 ): tokenId is TokenId => {
   if (typeof tokenId !== "string") return false
   try {
-    // parseTokenId returns undefined (despite its declared type) for unknown token types
-    return parseTokenId(tokenId)?.type === type
+    return parseTokenId(tokenId).type === type
   } catch {
     return false
   }
 }
 
-/** Throw-safe: see isTokenIdOfType */
 export const isTokenIdInTypes = <T extends TokenType[]>(
   tokenId: unknown,
   types: T


### PR DESCRIPTION
dtao conviction-lock and root-claim fetches swallowed transient RPC failures into empty results. For lock-only/claim-only balances (zero direct stake, e.g. SN128 rows) an empty result is indistinguishable from "position closed": the provider deletes the stored balance, and the next successful poll re-adds it — portfolio rows flap in/out continuously whenever the RPC struggles (worst during the post-add asset discovery storm).

- transient failures (`state_getKeys` lock scan, `get_coldkey_lock`, RootClaimable/RootClaimed queries, present-but-undecodable values) now fail the poll: the provider marks the module's balances stale and rows stay rendered
- deterministic fallbacks kept: chains without the runtime API / storage items still resolve empty
- the RootClaimed claimed=0 fallback also overstated pending root claims for the affected poll; now fails instead

The residual flap came from the token-rates store: dtao rate entries carried over between publishes (so alpha fiat values don't flicker while the dtao merge is in flight) were wiped by the follow-up merge publish, and the carry was keyed on membership in the current token list — dynamic per-hotkey dtao tokens absent from it during startup lost their rate. A rates set published without them zeroes the row's fiat, dropping the row out of the portfolio's rendered range for a beat.

- carried dtao entries now survive the merge publish, and an empty dtao fetch result no longer triggers a carry-wiping publish
- the carry is keyed on the token id shape instead of token-list membership
