### PR TITLE
🐛 Fix Solana sign popup crash on partial risk analysis response

### DIFF
--- a/apps/extension/src/ui/domains/Sign/risk-analysis/solana/RiskAnalysisStateChangesSol.tsx
+++ b/apps/extension/src/ui/domains/Sign/risk-analysis/solana/RiskAnalysisStateChangesSol.tsx
@@ -11,10 +11,11 @@ import { RiskAnalysisAssetImage } from "../RiskAnalysisAssetImage"
 import type { RiskAnalysisResult } from "../useRiskAnalysisBase"
 
 const getAccountStateChanges = (
-  accountSummary: MessageScanResponse.Result.Simulation.AccountSummary
+  // required in the type but may be missing from a partial/degraded Blockaid response
+  accountSummary: MessageScanResponse.Result.Simulation.AccountSummary | undefined
 ) => {
   return (
-    accountSummary.account_assets_diff?.map((diff) => {
+    accountSummary?.account_assets_diff?.map((diff) => {
       if (!diff.in && !diff.out) {
         log.warn("[getAccountStateChanges] assetDiff with no changes", { accountSummary, diff })
       }

--- a/apps/extension/src/ui/domains/Sign/risk-analysis/useRiskAnalysisBase.ts
+++ b/apps/extension/src/ui/domains/Sign/risk-analysis/useRiskAnalysisBase.ts
@@ -172,7 +172,7 @@ export const useRiskAnalysisBase = <
     }
     if (platform === "solana" && networkId) {
       const r = result as RiskAnalysisResponse<"solana"> | undefined
-      if (r?.result?.simulation?.account_summary.account_assets_diff) {
+      if (r?.result?.simulation?.account_summary?.account_assets_diff) {
         return r.result.simulation.account_summary.account_assets_diff
           .map((token) => {
             if (token.asset.type === "SOL") return solNativeTokenId(networkId)


### PR DESCRIPTION
Blockaid can return a Solana scan result whose `simulation` lacks `account_summary` (degraded/partial response), despite the type declaring it required. Two unguarded reads of `account_summary.account_assets_diff` crashed the sign popup into the error boundary.

Adds optional chaining at both call sites — a partial scan now renders the popup with no state changes instead of crashing.