### PR TITLE
💚 Skip Gandalf proof-of-work in e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
         env:
           ANVIL_RPC_URL: http://localhost:8545
           PLAYWRIGHT_HTML_OUTPUT_DIR: playwright-report/e2e
+          E2E_GANDALF_INSTALL_ID: ${{ secrets.E2E_GANDALF_INSTALL_ID }}
+          E2E_GANDALF_PRIVATE_KEY: ${{ secrets.E2E_GANDALF_PRIVATE_KEY }}
       - name: Checkout visual regression snapshots from base branch
         if: github.event_name == 'pull_request'
         run: |
@@ -155,6 +157,8 @@ jobs:
         env:
           ANVIL_RPC_URL: http://localhost:8545
           PLAYWRIGHT_HTML_OUTPUT_DIR: playwright-report/visual-regression
+          E2E_GANDALF_INSTALL_ID: ${{ secrets.E2E_GANDALF_INSTALL_ID }}
+          E2E_GANDALF_PRIVATE_KEY: ${{ secrets.E2E_GANDALF_PRIVATE_KEY }}
       - name: "Upload playwright report"
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -56,6 +56,9 @@ jobs:
         run: |
           xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" \
           pnpm exec playwright test visual-regression --project=chromium --update-snapshots
+        env:
+          E2E_GANDALF_INSTALL_ID: ${{ secrets.E2E_GANDALF_INSTALL_ID }}
+          E2E_GANDALF_PRIVATE_KEY: ${{ secrets.E2E_GANDALF_PRIVATE_KEY }}
 
       - name: Commit updated snapshots and create PR
         run: |

--- a/apps/extension/.env.sample
+++ b/apps/extension/.env.sample
@@ -15,3 +15,7 @@
 # Prod/canary only
 # SIMPLE_LOCALIZE_API_KEY=
 # SIMPLE_LOCALIZE_PROJECT_TOKEN=
+
+# to run e2e tests faster - generate with `pnpm chore:register-gandalf-e2e`
+# E2E_GANDALF_INSTALL_ID=
+# E2E_GANDALF_PRIVATE_KEY=

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -171,6 +171,7 @@
     "chore:generate-clients:tda:local": "pnpm dlx swagger-typescript-api@13.6.2 generate -p http://localhost:8787/openapi.json -o ./src/core/domains/bittensor/tao-data -n TaoDataApi --api-class-name TaoDataApi",
     "chore:generate-clients": "pnpm chore:generate-clients:sn45 && pnpm chore:generate-clients:tda && pnpm chore:generate-clients:wrc",
     "chore:generate-init-data": "tsx scripts/generateRemoteConfigInitData.ts",
+    "chore:register-gandalf-e2e": "pnpm --silent tsx scripts/register-gandalf-e2e.ts",
     "dev": "wxt",
     "dev:firefox": "wxt -b firefox",
     "dev:kill": "lsof -ti:8254 | xargs kill -9 2>/dev/null || true",

--- a/apps/extension/scripts/register-gandalf-e2e.ts
+++ b/apps/extension/scripts/register-gandalf-e2e.ts
@@ -1,0 +1,30 @@
+// biome-ignore-all lint/suspicious/noConsole: CLI script output
+import { registerInstall } from "../src/core/domains/gandalf/client"
+
+/**
+ * Registers a fresh install with Gandalf (challenge + proof-of-work solve, ~10-30s
+ * depending on CPU) and prints the credentials to paste into GitHub Actions secrets.
+ *
+ * E2E tests seed these into extension storage so test runs skip the proof-of-work,
+ * which otherwise starves the background service worker on slow CI runners.
+ *
+ * The key is an anonymous per-install API credential (rate limiting only, no funds
+ * access, revocable server-side) — but treat it as a secret: paste it into the two
+ * GitHub secrets below, never commit it.
+ */
+async function registerGandalfE2E() {
+  console.error("Registering a new Gandalf install (solving proof-of-work, this takes a while)...")
+  const start = performance.now()
+
+  const { installId, privateKeyHex } = await registerInstall()
+
+  console.error(`Registered in ${Math.round((performance.now() - start) / 1000)}s.`)
+  console.error("Paste these as GitHub Actions secrets (repo Settings > Secrets and variables):\n")
+  console.log(`E2E_GANDALF_INSTALL_ID=${installId}`)
+  console.log(`E2E_GANDALF_PRIVATE_KEY=${privateKeyHex}`)
+}
+
+registerGandalfE2E().catch((err) => {
+  console.error("Error:", err)
+  process.exit(1)
+})

--- a/apps/extension/src/core/domains/assetDiscovery/__tests__/substrate.test.ts
+++ b/apps/extension/src/core/domains/assetDiscovery/__tests__/substrate.test.ts
@@ -85,8 +85,15 @@ describe("isFresh (timestamp-only TTL)", () => {
   })
 
   it("is fresh at exact boundary minus 1ms", () => {
-    const justInsideTTL = Date.now() - (7 * 24 * 60 * 60 * 1000 - 1)
-    expect(isFresh(justInsideTTL)).toBe(true)
+    // freeze the clock: isFresh calls Date.now() again, and a ≥1ms drift between the
+    // two reads pushes the timestamp past the boundary (flaky on slow CI runners)
+    vi.useFakeTimers()
+    try {
+      const justInsideTTL = Date.now() - (7 * 24 * 60 * 60 * 1000 - 1)
+      expect(isFresh(justInsideTTL)).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/apps/extension/src/core/domains/gandalf/__tests__/observable.spec.ts
+++ b/apps/extension/src/core/domains/gandalf/__tests__/observable.spec.ts
@@ -106,6 +106,31 @@ describe("gandalfAccessToken$", () => {
     expect(result[1]).toEqual({ status: "success", data: "jwt-new" })
   })
 
+  it("keeps credentials that appeared while registration was in flight", async () => {
+    mockGandalfStore.get
+      .mockResolvedValueOnce({ installId: null, privateKeyHex: null })
+      .mockResolvedValueOnce({ installId: "seeded-inst", privateKeyHex: "1122" })
+    mockRegisterInstall.mockResolvedValue({
+      installId: "new-inst",
+      privateKeyHex: "ccdd",
+    })
+    mockRequestAccessToken.mockResolvedValue({
+      accessToken: "jwt-seeded",
+      expiresIn: 300,
+    })
+
+    const { gandalfAccessToken$ } = await importFresh()
+
+    const resultPromise = firstValueFrom(gandalfAccessToken$.pipe(take(2), toArray()))
+
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await resultPromise
+
+    expect(mockGandalfStore.set).not.toHaveBeenCalled()
+    expect(mockRequestAccessToken).toHaveBeenCalledWith("seeded-inst", "1122", expect.anything())
+    expect(result[1]).toEqual({ status: "success", data: "jwt-seeded" })
+  })
+
   it("emits error status when requestAccessToken fails", async () => {
     mockGandalfStore.get.mockResolvedValue({
       installId: "inst-1",

--- a/apps/extension/src/core/domains/gandalf/observable.ts
+++ b/apps/extension/src/core/domains/gandalf/observable.ts
@@ -37,6 +37,12 @@ async function ensureRegistered(
   log.debug("Gandalf: no install credentials found, registering…")
   const credentials = await registerInstall(signal)
 
+  // credentials may have appeared while the proof-of-work was solving (e.g. e2e fixtures
+  // seeding pre-registered ones) - keep them, ours were never used to sign anything
+  const existing = await gandalfStore.get()
+  if (existing.installId && existing.privateKeyHex)
+    return { installId: existing.installId, privateKeyHex: existing.privateKeyHex }
+
   await gandalfStore.set({
     installId: credentials.installId,
     privateKeyHex: credentials.privateKeyHex,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chore:download-translations": "pnpm run --filter extension chore:download-translations",
     "update:translations": "pnpm chore:update-translations",
     "chore:generate-clients": "pnpm -r chore:generate-clients",
+    "chore:register-gandalf-e2e": "pnpm --silent run --filter extension chore:register-gandalf-e2e",
     "chore:generate-init-data": "pnpm -r chore:generate-init-data",
     "chore:prepare-release": "pnpm chore:generate-init-data && pnpm chore:download-translations && pnpm biome check --fix",
     "dev": "pnpm dev:extension",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,35 +3,11 @@ import dotenv from "dotenv"
 
 dotenv.config({ path: "apps/extension/.env" })
 
-// TEST_WORKER_INDEX is only set in worker processes: warn once, from the runner process only
-if (
-  !process.env.TEST_WORKER_INDEX &&
-  !(process.env.E2E_GANDALF_INSTALL_ID && process.env.E2E_GANDALF_PRIVATE_KEY)
-) {
-  // biome-ignore lint/suspicious/noConsole: intentional warning for test runs
-  console.warn(
-    [
-      "",
-      "┌──────────────────────────────────────────────────────────────────────────────┐",
-      "│  ⚠️  E2E_GANDALF_INSTALL_ID / E2E_GANDALF_PRIVATE_KEY are not set            │",
-      "│                                                                              │",
-      "│  Without them, each e2e run registers a fresh Gandalf install, solving a     │",
-      "│  proof-of-work in the extension background worker at startup. On slow        │",
-      "│  machines this starves the background for 10s+ and makes tests flaky.        │",
-      "│                                                                              │",
-      "│  Generate credentials with:  pnpm chore:register-gandalf-e2e                 │",
-      "│  then add the two printed lines to apps/extension/.env (local runs)          │",
-      "│  or to the repository's GitHub Actions secrets (CI).                         │",
-      "└──────────────────────────────────────────────────────────────────────────────┘",
-      "",
-    ].join("\n")
-  )
-}
-
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  globalSetup: "./playwright/global-setup.ts",
   timeout: 60_000, // 60 seconds for all tests
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,10 +33,6 @@ if (
  */
 export default defineConfig({
   timeout: 60_000, // 60 seconds for all tests
-  // assertions poll until they pass; several forms validate asynchronously through the extension
-  // background (mnemonic validation, watched-address checks, ...), which on slow CI runners
-  // regularly exceeds the 5s default and makes those tests flaky
-  expect: { timeout: 15_000 },
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,31 @@ import dotenv from "dotenv"
 
 dotenv.config({ path: "apps/extension/.env" })
 
+// TEST_WORKER_INDEX is only set in worker processes: warn once, from the runner process only
+if (
+  !process.env.TEST_WORKER_INDEX &&
+  !(process.env.E2E_GANDALF_INSTALL_ID && process.env.E2E_GANDALF_PRIVATE_KEY)
+) {
+  // biome-ignore lint/suspicious/noConsole: intentional warning for test runs
+  console.warn(
+    [
+      "",
+      "┌──────────────────────────────────────────────────────────────────────────────┐",
+      "│  ⚠️  E2E_GANDALF_INSTALL_ID / E2E_GANDALF_PRIVATE_KEY are not set            │",
+      "│                                                                              │",
+      "│  Without them, each e2e run registers a fresh Gandalf install, solving a     │",
+      "│  proof-of-work in the extension background worker at startup. On slow        │",
+      "│  machines this starves the background for 10s+ and makes tests flaky.        │",
+      "│                                                                              │",
+      "│  Generate credentials with:  pnpm chore:register-gandalf-e2e                 │",
+      "│  then add the two printed lines to apps/extension/.env (local runs)          │",
+      "│  or to the repository's GitHub Actions secrets (CI).                         │",
+      "└──────────────────────────────────────────────────────────────────────────────┘",
+      "",
+    ].join("\n")
+  )
+}
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/playwright/e2e-tests/fixtures.ts
+++ b/playwright/e2e-tests/fixtures.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs"
 
 import { bytesToHex, randomBytes } from "@noble/hashes/utils"
-import type { BrowserContext, Locator, Page } from "@playwright/test"
+import type { BrowserContext, Locator, Page, Worker } from "@playwright/test"
 import { test as base, chromium } from "@playwright/test"
 
 type AccountType = "ethereum" | "substrate" | "solana"
@@ -21,6 +21,26 @@ export const ethDevChain = "http://localhost:8545"
 
 const isExternalDappError = (url: string | undefined) =>
   !!url && !url.startsWith("chrome-extension://")
+
+// Seeds pre-registered Gandalf credentials (from CI secrets) into extension storage so
+// test runs skip the registration proof-of-work, which starves the background service
+// worker on slow CI runners and makes background-dependent assertions time out.
+// Without the env vars (e.g. fork PRs, local runs) the extension registers as usual.
+const seedGandalfCredentials = async (background: Worker) => {
+  const installId = process.env.E2E_GANDALF_INSTALL_ID
+  const privateKeyHex = process.env.E2E_GANDALF_PRIVATE_KEY
+  if (!installId || !privateKeyHex) return
+
+  await background.evaluate(
+    (gandalf) => {
+      const { chrome } = globalThis as unknown as {
+        chrome: { storage: { local: { set: (items: Record<string, unknown>) => Promise<void> } } }
+      }
+      return chrome.storage.local.set({ gandalf })
+    },
+    { installId, privateKeyHex }
+  )
+}
 
 export const test = base.extend<{
   context: BrowserContext
@@ -70,6 +90,8 @@ export const test = base.extend<{
   extensionId: async ({ context }, utilize) => {
     let [background] = context.serviceWorkers()
     if (!background) background = await context.waitForEvent("serviceworker")
+
+    await seedGandalfCredentials(background)
 
     const extensionId = background.url().split("/")[2]
     await utilize(extensionId)

--- a/playwright/global-setup.ts
+++ b/playwright/global-setup.ts
@@ -1,0 +1,26 @@
+// Runs once when playwright actually executes tests — unlike playwright.config.ts,
+// which is also imported by static tooling (knip) where side effects would be noise.
+const globalSetup = () => {
+  if (!(process.env.E2E_GANDALF_INSTALL_ID && process.env.E2E_GANDALF_PRIVATE_KEY)) {
+    // biome-ignore lint/suspicious/noConsole: intentional warning for test runs
+    console.warn(
+      [
+        "",
+        "┌──────────────────────────────────────────────────────────────────────────────┐",
+        "│  ⚠️  E2E_GANDALF_INSTALL_ID / E2E_GANDALF_PRIVATE_KEY are not set            │",
+        "│                                                                              │",
+        "│  Without them, each e2e run registers a fresh Gandalf install, solving a     │",
+        "│  proof-of-work in the extension background worker at startup. On slow        │",
+        "│  machines this starves the background for 10s+ and makes tests flaky.        │",
+        "│                                                                              │",
+        "│  Generate credentials with:  pnpm chore:register-gandalf-e2e                 │",
+        "│  then add the two printed lines to apps/extension/.env (local runs)          │",
+        "│  or to the repository's GitHub Actions secrets (CI).                         │",
+        "└──────────────────────────────────────────────────────────────────────────────┘",
+        "",
+      ].join("\n")
+    )
+  }
+}
+
+export default globalSetup


### PR DESCRIPTION
E2E runs start from a fresh profile, so the extension registers a Gandalf install at startup — the proof-of-work solve starves the background service worker on slow CI runners and background-dependent assertions time out (e.g. mnemonic validation in \`derived-and-backup.spec.ts\`).

- e2e fixtures seed pre-registered credentials from new \`E2E_GANDALF_INSTALL_ID\` / \`E2E_GANDALF_PRIVATE_KEY\` repo secrets, skipping the proof-of-work
- \`pnpm chore:register-gandalf-e2e\` generates credentials
- warning on e2e runs (playwright global setup) when credentials are missing
- restores the default 5s expect timeout (reverts the bump from #2485)
- deflakes the asset discovery freshness boundary test (frozen clock)