### PR TITLE
🐛 fix biometric unlock on Windows Hello

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/BiometricSetting.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/BiometricSetting.tsx
@@ -7,6 +7,7 @@ import { useIsBiometricEnrolled } from "@ui/state/biometric"
 import {
   createBiometricCredential,
   isBiometricAvailable,
+  PrfEvaluationError,
   signalCredentialRemoved,
 } from "@ui/util/webauthnPrf"
 import { useCallback, useEffect, useRef, useState } from "react"
@@ -60,7 +61,18 @@ export const BiometricSetting = () => {
         }
       } catch (err) {
         // resolves to null if the user cancelled the biometric prompt, or if we abandoned it
-        setError(getErrorMessage(err) ?? undefined)
+        const message = getErrorMessage(err)
+
+        // a passkey was created before we found out the authenticator can't evaluate a PRF, and
+        // removing it again is only best-effort
+        if (message && err instanceof PrfEvaluationError)
+          setError(
+            t(
+              "{{reason}} A passkey may have been created, you can remove it from your system settings.",
+              { reason: message }
+            )
+          )
+        else setError(message ?? undefined)
       } finally {
         setProcessing(false)
       }

--- a/apps/extension/src/ui/apps/dashboard/routes/Settings/__tests__/BiometricSetting.test.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Settings/__tests__/BiometricSetting.test.tsx
@@ -17,7 +17,9 @@ vi.mock("@ui/api", () => ({
   },
 }))
 
-vi.mock("@ui/util/webauthnPrf", () => ({
+// keep the real PrfEvaluationError, the component and the error message hook both test against it
+vi.mock("@ui/util/webauthnPrf", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@ui/util/webauthnPrf")>()),
   isBiometricAvailable: () => mockIsAvailable(),
   createBiometricCredential: (...args: unknown[]) => mockCreateCredential(...args),
   signalCredentialRemoved: (...args: unknown[]) => mockSignalRemoved(...args),
@@ -26,6 +28,8 @@ vi.mock("@ui/util/webauthnPrf", () => ({
 vi.mock("@ui/state/biometric", () => ({
   useIsBiometricEnrolled: () => mockUseIsEnrolled(),
 }))
+
+import { PrfEvaluationError } from "@ui/util/webauthnPrf"
 
 import { BiometricSetting } from "../BiometricSetting"
 
@@ -87,6 +91,19 @@ describe("BiometricSetting", () => {
 
     await waitFor(() => expect(mockSignalRemoved).toHaveBeenCalledWith("credId"))
     expect(await screen.findByText(/A passkey may have been created/i)).toBeDefined()
+  })
+
+  test("explains an authenticator that can't evaluate a PRF, and mentions the passkey", async () => {
+    mockCreateCredential.mockRejectedValue(new PrfEvaluationError())
+
+    render(<BiometricSetting />)
+
+    fireEvent.click(await screen.findByRole("checkbox"))
+
+    expect(await screen.findByText(/can't be used for biometric unlock/i)).toBeDefined()
+    expect(screen.getByText(/A passkey may have been created/i)).toBeDefined()
+    // the raw error message must not reach the user
+    expect(screen.queryByText(/PRF evaluation failed/i)).toBeNull()
   })
 
   test("explains browser exceptions instead of showing their name", async () => {

--- a/apps/extension/src/ui/apps/popup/index.tsx
+++ b/apps/extension/src/ui/apps/popup/index.tsx
@@ -36,7 +36,7 @@ import { SwapModal } from "@ui/domains/Swap/components/SwapModal"
 import { MigrationProgress } from "@ui/domains/System/MigrationProgress"
 import { ExplorerNetworkPickerModal } from "@ui/domains/ViewOnExplorer"
 import { useLoginCheck } from "@ui/hooks/useLoginCheck"
-import { Suspense, useEffect } from "react"
+import { Suspense, useEffect, useRef } from "react"
 import { Navigate, Route, Routes } from "react-router-dom"
 
 import { LedgerPolkadotUpgradeAlertDrawer } from "./components/LedgerPolkadotUpgradeDrawer"
@@ -61,6 +61,13 @@ import { TxHistoryPage } from "./pages/TxHistory"
 const Popup = () => {
   const { isLoggedIn, isOnboarded, isMigrating } = useLoginCheck()
 
+  // the user locking the wallet (or the autolock timer) swaps the portfolio for the login screen
+  // in a popup that is on its way out - biometrics must not prompt on their behalf there
+  const wasLoggedIn = useRef(false)
+  useEffect(() => {
+    if (isLoggedIn) wasLoggedIn.current = true
+  }, [isLoggedIn])
+
   // force onboarding if not onboarded
   useEffect(() => {
     if (!isOnboarded) {
@@ -72,7 +79,7 @@ const Popup = () => {
     }
   }, [isOnboarded])
 
-  if (!isLoggedIn) return <LoginViewManager />
+  if (!isLoggedIn) return <LoginViewManager autoTriggerBiometric={!wasLoggedIn.current} />
 
   if (isMigrating) return <MigrationProgress />
 

--- a/apps/extension/src/ui/apps/popup/pages/Login.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Login.tsx
@@ -193,11 +193,23 @@ const BiometricUnlockButton = ({ autoTrigger }: { autoTrigger: boolean }) => {
 
     // an unfocused popup is one the browser is tearing down, or one the user has moved on from.
     // prompting there puts an OS dialog (Windows Hello) on screen that nobody asked for, and on
-    // windows that dialog outlives the page it was started from
-    if (document.visibilityState !== "visible" || !document.hasFocus()) return
+    // windows that dialog outlives the page it was started from.
+    //
+    // a popup the browser has just opened for us (a dapp request, or a login prompt) often hasn't
+    // been given focus yet by the time we get here, so wait for it instead of giving up - a popup
+    // on its way out never gets focus back
+    const trigger = () => {
+      if (triggeredRef.current) return
+      if (document.visibilityState !== "visible" || !document.hasFocus()) return
 
-    triggeredRef.current = true
-    handleBiometricUnlock(false)
+      triggeredRef.current = true
+      window.removeEventListener("focus", trigger)
+      handleBiometricUnlock(false)
+    }
+
+    trigger()
+    window.addEventListener("focus", trigger)
+    return () => window.removeEventListener("focus", trigger)
   }, [autoTrigger, enrolled, handleBiometricUnlock])
 
   if (!enrolled) return error ? <span className="text-alert-warn text-sm">{error}</span> : null

--- a/apps/extension/src/ui/apps/popup/pages/Login.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Login.tsx
@@ -129,12 +129,6 @@ const BiometricUnlockButton = ({ autoTrigger }: { autoTrigger: boolean }) => {
   const handleBiometricUnlock = useCallback(
     async (explicit: boolean) => {
       if (processing) return
-
-      // an unfocused popup is one the browser is tearing down, or one the user has moved on from.
-      // prompting there puts an OS dialog (Windows Hello) on screen that nobody asked for, and on
-      // windows that dialog outlives the page it was started from. explicit clicks always go ahead.
-      if (!explicit && (document.visibilityState !== "visible" || !document.hasFocus())) return
-
       setProcessing(true)
       setError(undefined)
       abortRef.current?.abort()
@@ -196,6 +190,12 @@ const BiometricUnlockButton = ({ autoTrigger }: { autoTrigger: boolean }) => {
   // auto-trigger biometric on first render, unless the user is already typing their password
   useEffect(() => {
     if (!autoTrigger || !enrolled || triggeredRef.current) return
+
+    // an unfocused popup is one the browser is tearing down, or one the user has moved on from.
+    // prompting there puts an OS dialog (Windows Hello) on screen that nobody asked for, and on
+    // windows that dialog outlives the page it was started from
+    if (document.visibilityState !== "visible" || !document.hasFocus()) return
+
     triggeredRef.current = true
     handleBiometricUnlock(false)
   }, [autoTrigger, enrolled, handleBiometricUnlock])
@@ -335,10 +335,10 @@ const Login = ({
 }
 
 export const LoginViewManager = ({
-  autoTriggerBiometric = true,
+  autoTriggerBiometric,
 }: {
   /** false when the login screen replaced an unlocked session, ie the user didn't come here to unlock */
-  autoTriggerBiometric?: boolean
+  autoTriggerBiometric: boolean
 }) => {
   const [showResetWallet, setShowResetWallet] = useState(false)
 

--- a/apps/extension/src/ui/apps/popup/pages/Login.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Login.tsx
@@ -116,13 +116,25 @@ const BiometricUnlockButton = ({ autoTrigger }: { autoTrigger: boolean }) => {
   const abortRef = useRef<AbortController>(null)
 
   useEffect(() => {
-    // abandon any ceremony still waiting on the user
-    return () => abortRef.current?.abort()
+    // abandon any ceremony still waiting on the user. pagehide covers the popup being torn down,
+    // where react never gets to run the unmount cleanup
+    const abort = () => abortRef.current?.abort()
+    window.addEventListener("pagehide", abort)
+    return () => {
+      window.removeEventListener("pagehide", abort)
+      abort()
+    }
   }, [])
 
   const handleBiometricUnlock = useCallback(
     async (explicit: boolean) => {
       if (processing) return
+
+      // an unfocused popup is one the browser is tearing down, or one the user has moved on from.
+      // prompting there puts an OS dialog (Windows Hello) on screen that nobody asked for, and on
+      // windows that dialog outlives the page it was started from. explicit clicks always go ahead.
+      if (!explicit && (document.visibilityState !== "visible" || !document.hasFocus())) return
+
       setProcessing(true)
       setError(undefined)
       abortRef.current?.abort()
@@ -210,7 +222,13 @@ const BiometricUnlockButton = ({ autoTrigger }: { autoTrigger: boolean }) => {
   )
 }
 
-const Login = ({ setShowResetWallet }: { setShowResetWallet: () => void }) => {
+const Login = ({
+  setShowResetWallet,
+  autoTriggerBiometric,
+}: {
+  setShowResetWallet: () => void
+  autoTriggerBiometric: boolean
+}) => {
   const { t } = useTranslation()
   const { popupOpenEvent } = useAnalytics()
 
@@ -300,7 +318,9 @@ const Login = ({ setShowResetWallet }: { setShowResetWallet: () => void }) => {
           >
             {t("Unlock")}
           </Button>
-          <BiometricUnlockButton autoTrigger={!isDirty && !IS_DEV_AUTOLOGIN} />
+          <BiometricUnlockButton
+            autoTrigger={autoTriggerBiometric && !isDirty && !IS_DEV_AUTOLOGIN}
+          />
           <button
             type="button"
             className="mt-2 cursor-pointer text-body-disabled text-sm transition-colors hover:text-white"
@@ -314,11 +334,21 @@ const Login = ({ setShowResetWallet }: { setShowResetWallet: () => void }) => {
   )
 }
 
-export const LoginViewManager = () => {
+export const LoginViewManager = ({
+  autoTriggerBiometric = true,
+}: {
+  /** false when the login screen replaced an unlocked session, ie the user didn't come here to unlock */
+  autoTriggerBiometric?: boolean
+}) => {
   const [showResetWallet, setShowResetWallet] = useState(false)
 
   if (showResetWallet) return <ResetWallet closeResetWallet={() => setShowResetWallet(false)} />
-  return <Login setShowResetWallet={() => setShowResetWallet(true)} />
+  return (
+    <Login
+      setShowResetWallet={() => setShowResetWallet(true)}
+      autoTriggerBiometric={autoTriggerBiometric}
+    />
+  )
 }
 
 /** autologin, for developers only */

--- a/apps/extension/src/ui/hooks/useBiometricErrorMessage.ts
+++ b/apps/extension/src/ui/hooks/useBiometricErrorMessage.ts
@@ -1,3 +1,4 @@
+import { PrfEvaluationError } from "@ui/util/webauthnPrf"
 import { useCallback } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -14,6 +15,13 @@ export const useBiometricErrorMessage = () => {
 
   return useCallback(
     (err: unknown): string | null => {
+      // the ceremony worked, the authenticator just can't evaluate a PRF - it isn't the right kind
+      // of authenticator, or the browser and OS are too old to expose the capability
+      if (err instanceof PrfEvaluationError)
+        return t(
+          "This authenticator can't be used for biometric unlock. Use your device's built-in authenticator, such as Touch ID, Windows Hello or your screen lock, and make sure your browser and operating system are up to date."
+        )
+
       switch ((err as DOMException)?.name) {
         case "NotAllowedError":
         case "AbortError":

--- a/apps/extension/src/ui/util/webauthnPrf.spec.ts
+++ b/apps/extension/src/ui/util/webauthnPrf.spec.ts
@@ -31,7 +31,7 @@ describe("createBiometricCredential", () => {
   })
 
   test("uses the PRF output returned at creation time", async () => {
-    create.mockResolvedValue(credential({ enabled: true, results: { first: CREATION_PRF_OUTPUT } }))
+    create.mockResolvedValue(credential({ results: { first: CREATION_PRF_OUTPUT } }))
 
     const result = await createBiometricCredential()
 
@@ -44,7 +44,7 @@ describe("createBiometricCredential", () => {
   })
 
   test("falls back to an assertion when creation returns no PRF output", async () => {
-    create.mockResolvedValue(credential({ enabled: true }))
+    create.mockResolvedValue(credential({}))
     get.mockResolvedValue(credential({ results: { first: ASSERTION_PRF_OUTPUT } }))
 
     const result = await createBiometricCredential()
@@ -72,16 +72,16 @@ describe("createBiometricCredential", () => {
 
   test("rejects an authenticator that does not support PRF, and drops its credential", async () => {
     create.mockResolvedValue(credential(undefined))
-    get.mockResolvedValue(credential({ enabled: true }))
+    get.mockResolvedValue(credential({}))
 
-    await expect(createBiometricCredential()).rejects.toThrow(/does not support biometric unlock/)
+    await expect(createBiometricCredential()).rejects.toThrow(PrfEvaluationError)
     expect(signalUnknownCredential).toHaveBeenCalledWith(
       expect.objectContaining({ credentialId: base64urlnopad.encode(RAW_ID) })
     )
   })
 
   test("drops the credential when the fallback assertion fails", async () => {
-    create.mockResolvedValue(credential({ enabled: true }))
+    create.mockResolvedValue(credential({}))
     get.mockRejectedValue(new DOMException("cancelled", "NotAllowedError"))
 
     await expect(createBiometricCredential()).rejects.toThrow(
@@ -93,7 +93,7 @@ describe("createBiometricCredential", () => {
   })
 
   test("keeps the credential when the ceremony succeeds", async () => {
-    create.mockResolvedValue(credential({ enabled: true, results: { first: CREATION_PRF_OUTPUT } }))
+    create.mockResolvedValue(credential({ results: { first: CREATION_PRF_OUTPUT } }))
 
     await createBiometricCredential()
 
@@ -111,7 +111,7 @@ describe("createBiometricCredential", () => {
   })
 
   test("forwards the abort signal", async () => {
-    create.mockResolvedValue(credential({ enabled: true, results: { first: CREATION_PRF_OUTPUT } }))
+    create.mockResolvedValue(credential({ results: { first: CREATION_PRF_OUTPUT } }))
     const { signal } = new AbortController()
 
     await createBiometricCredential(signal)
@@ -141,7 +141,7 @@ describe("getBiometricPrfOutput", () => {
   })
 
   test("rejects when the PRF could not be evaluated", async () => {
-    get.mockResolvedValue(credential({ enabled: true }))
+    get.mockResolvedValue(credential({}))
 
     await expect(getBiometricPrfOutput(base64urlnopad.encode(RAW_ID), "c2FsdA==")).rejects.toThrow(
       PrfEvaluationError

--- a/apps/extension/src/ui/util/webauthnPrf.spec.ts
+++ b/apps/extension/src/ui/util/webauthnPrf.spec.ts
@@ -1,7 +1,7 @@
 import { base64, base64urlnopad } from "@talismn/crypto"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-import { createBiometricCredential, getBiometricPrfOutput } from "./webauthnPrf"
+import { createBiometricCredential, getBiometricPrfOutput, PrfEvaluationError } from "./webauthnPrf"
 
 const create = vi.fn()
 const get = vi.fn()
@@ -58,11 +58,23 @@ describe("createBiometricCredential", () => {
     expect(prfSaltOf(get.mock.calls[0])).toEqual(prfSaltOf(create.mock.calls[0]))
   })
 
+  test("falls back to an assertion when creation reports no PRF support at all", async () => {
+    // windows hello on chrome 146 and below: nothing on create, PRF evaluated on assertion
+    create.mockResolvedValue(credential(undefined))
+    get.mockResolvedValue(credential({ results: { first: ASSERTION_PRF_OUTPUT } }))
+
+    const result = await createBiometricCredential()
+
+    expect(result.prfOutput).toBe(base64.encode(ASSERTION_PRF_OUTPUT))
+    expect(get).toHaveBeenCalledOnce()
+    expect(signalUnknownCredential).not.toHaveBeenCalled()
+  })
+
   test("rejects an authenticator that does not support PRF, and drops its credential", async () => {
     create.mockResolvedValue(credential(undefined))
+    get.mockResolvedValue(credential({ enabled: true }))
 
     await expect(createBiometricCredential()).rejects.toThrow(/does not support biometric unlock/)
-    expect(get).not.toHaveBeenCalled()
     expect(signalUnknownCredential).toHaveBeenCalledWith(
       expect.objectContaining({ credentialId: base64urlnopad.encode(RAW_ID) })
     )
@@ -132,7 +144,7 @@ describe("getBiometricPrfOutput", () => {
     get.mockResolvedValue(credential({ enabled: true }))
 
     await expect(getBiometricPrfOutput(base64urlnopad.encode(RAW_ID), "c2FsdA==")).rejects.toThrow(
-      "PRF evaluation failed"
+      PrfEvaluationError
     )
   })
 })

--- a/apps/extension/src/ui/util/webauthnPrf.ts
+++ b/apps/extension/src/ui/util/webauthnPrf.ts
@@ -74,21 +74,33 @@ export async function createBiometricCredential(
     const prf = getPrfExtensionResults(credential)
 
     // an authenticator that supports PRF may still be unable to evaluate it while creating the
-    // credential, in which case the spec only guarantees `enabled` and requires an assertion to
-    // obtain the output
-    if (!prf?.enabled && !prf?.results?.first)
-      throw new Error(
-        "This authenticator does not support biometric unlock. Please use your device's built-in authenticator, such as Touch ID, Windows Hello or your screen lock, instead of a browser profile or security key. A passkey may have been created, you can remove it from your system settings."
-      )
-
-    const prfOutput = prf.results?.first
+    // credential, and may not even advertise support at that point - Windows Hello reports nothing
+    // at all on Chrome 146 and below, while evaluating the PRF just fine during an assertion.
+    // asking for one is the only reliable way to find out
+    const prfOutput = prf?.results?.first
       ? base64.encode(new Uint8Array(prf.results.first))
-      : await getBiometricPrfOutput(credentialId, prfSalt, signal)
+      : await evaluatePrfOrExplain(credentialId, prfSalt, signal)
 
     return { credentialId, prfSalt, prfOutput }
   } catch (err) {
     await signalCredentialRemoved(credentialId)
     throw err
+  }
+}
+
+/** The assertion is what tells us PRF is unsupported, turn its failure into something actionable */
+const evaluatePrfOrExplain = async (
+  credentialId: string,
+  prfSalt: string,
+  signal?: AbortSignal
+) => {
+  try {
+    return await getBiometricPrfOutput(credentialId, prfSalt, signal)
+  } catch (err) {
+    if (!(err instanceof PrfEvaluationError)) throw err
+    throw new Error(
+      "This authenticator does not support biometric unlock. Please use your device's built-in authenticator, such as Touch ID, Windows Hello or your screen lock, instead of a browser profile or security key - and make sure your browser and operating system are up to date. A passkey may have been created, you can remove it from your system settings."
+    )
   }
 }
 
@@ -141,9 +153,17 @@ export async function getBiometricPrfOutput(
   if (!assertion) throw new Error("Biometric authentication was cancelled")
 
   const prfOutput = getPrfExtensionResults(assertion)?.results?.first
-  if (!prfOutput) throw new Error("PRF evaluation failed")
+  if (!prfOutput) throw new PrfEvaluationError()
 
   return base64.encode(new Uint8Array(prfOutput))
+}
+
+/** The ceremony completed but the authenticator returned no PRF output, it can't do this */
+export class PrfEvaluationError extends Error {
+  constructor() {
+    super("Biometric unlock is unavailable. Your browser or operating system may need an update.")
+    this.name = "PrfEvaluationError"
+  }
 }
 
 type PrfExtensionResults = { enabled?: boolean; results?: { first?: ArrayBuffer } }

--- a/apps/extension/src/ui/util/webauthnPrf.ts
+++ b/apps/extension/src/ui/util/webauthnPrf.ts
@@ -79,28 +79,12 @@ export async function createBiometricCredential(
     // asking for one is the only reliable way to find out
     const prfOutput = prf?.results?.first
       ? base64.encode(new Uint8Array(prf.results.first))
-      : await evaluatePrfOrExplain(credentialId, prfSalt, signal)
+      : await getBiometricPrfOutput(credentialId, prfSalt, signal)
 
     return { credentialId, prfSalt, prfOutput }
   } catch (err) {
     await signalCredentialRemoved(credentialId)
     throw err
-  }
-}
-
-/** The assertion is what tells us PRF is unsupported, turn its failure into something actionable */
-const evaluatePrfOrExplain = async (
-  credentialId: string,
-  prfSalt: string,
-  signal?: AbortSignal
-) => {
-  try {
-    return await getBiometricPrfOutput(credentialId, prfSalt, signal)
-  } catch (err) {
-    if (!(err instanceof PrfEvaluationError)) throw err
-    throw new Error(
-      "This authenticator does not support biometric unlock. Please use your device's built-in authenticator, such as Touch ID, Windows Hello or your screen lock, instead of a browser profile or security key - and make sure your browser and operating system are up to date. A passkey may have been created, you can remove it from your system settings."
-    )
   }
 }
 
@@ -158,15 +142,20 @@ export async function getBiometricPrfOutput(
   return base64.encode(new Uint8Array(prfOutput))
 }
 
-/** The ceremony completed but the authenticator returned no PRF output, it can't do this */
+/**
+ * The ceremony completed but the authenticator returned no PRF output, it can't do this.
+ * User facing copy lives in useBiometricErrorMessage, keyed on the error name.
+ */
 export class PrfEvaluationError extends Error {
   constructor() {
-    super("Biometric unlock is unavailable. Your browser or operating system may need an update.")
+    super("PRF evaluation failed")
     this.name = "PrfEvaluationError"
   }
 }
 
-type PrfExtensionResults = { enabled?: boolean; results?: { first?: ArrayBuffer } }
+// `enabled` is deliberately left out: it is unset on the browsers that evaluate the PRF anyway,
+// so it can't be used to decide anything
+type PrfExtensionResults = { results?: { first?: ArrayBuffer } }
 
 const getPrfExtensionResults = (credential: PublicKeyCredential): PrfExtensionResults | undefined =>
   // biome-ignore lint/suspicious/noExplicitAny: PRF extension results not in TS types yet


### PR DESCRIPTION
Two Windows-only bugs in biometric unlock.

**Lock Wallet prompted Windows Hello.** `api.lock()` swapped the popup to the login screen before `window.close()` landed, and the login screen auto-triggers the ceremony on mount. Auto-trigger is now limited to pages that mounted already locked, and skipped when the popup isn't focused. Same fix covers autolock firing while the popup is open.

**Enrollment failed on Chrome ≤146.** Windows Hello doesn't surface PRF at credential creation there, only on assertion — enrollment rejected it outright. Now always falls back to an assertion, and only fails if that returns no PRF.

Also moves the biometric error copy into i18n.