### PR TITLE
✨ per-origin bittensor staking remarks

### DIFF
--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorStakingPayload.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorStakingPayload.ts
@@ -7,6 +7,7 @@ import { useMemo } from "react"
 import { useGetBittensorMinJoinBond } from "../../hooks/bittensor/useGetBittensorMinJoinBond"
 import { useGetBittensorDefaultMinStake } from "../../hooks/bittensor/useGetBittensorMinStake"
 import { useGetSeekDiscount } from "../../Seek/hooks/useGetSeekDiscount"
+import type { RemarkType } from "../utils/constants"
 import {
   calculateEffectiveFeeRate,
   calculateFee,
@@ -31,6 +32,7 @@ type UseBittensorStakingPayloadProps = {
   netuid: number | null
   amountIn: bigint | null
   direction: StakeDirection
+  remarkType: RemarkType
 }
 
 const MOCKED_HOTKEY = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN"
@@ -42,6 +44,7 @@ export const useBittensorStakingPayload = ({
   netuid,
   direction,
   amountIn,
+  remarkType,
 }: UseBittensorStakingPayloadProps) => {
   const { tier } = useGetSeekDiscount()
   const subnetFee = useGetSubnetFee({ netuid: netuid ?? 0, direction })
@@ -191,6 +194,7 @@ export const useBittensorStakingPayload = ({
     amount,
     priceLimit,
     talismanFee,
+    remarkType,
   })
 
   const {
@@ -207,6 +211,7 @@ export const useBittensorStakingPayload = ({
     // Use fallbacks >= 16384 to match real values' 4-byte SCALE compact encoding - less would provide a fee estimate that is 2 plancks short
     priceLimit: priceLimit ?? 100_000n,
     talismanFee: talismanFee ?? 100_000n,
+    remarkType,
   })
 
   return {
@@ -254,6 +259,7 @@ type useBittensorAnyStakingPayloadProps = {
   amount: bigint | null | undefined
   priceLimit: bigint | null
   talismanFee: bigint | null
+  remarkType: RemarkType
 }
 
 const useBittensorAnyStakingPayload = ({
@@ -265,6 +271,7 @@ const useBittensorAnyStakingPayload = ({
   amount,
   priceLimit,
   talismanFee,
+  remarkType,
 }: useBittensorAnyStakingPayloadProps) => {
   return useQuery({
     queryKey: [
@@ -277,6 +284,7 @@ const useBittensorAnyStakingPayload = ({
       amount?.toString(),
       priceLimit?.toString(),
       talismanFee?.toString(),
+      remarkType,
     ],
     queryFn: () => {
       if (
@@ -300,6 +308,7 @@ const useBittensorAnyStakingPayload = ({
             priceLimit,
             netuid,
             talismanFee,
+            remarkType,
           })
         case "alphaToTao":
           return getBittensorUnbondPayload({
@@ -310,6 +319,7 @@ const useBittensorAnyStakingPayload = ({
             priceLimit,
             netuid,
             talismanFee,
+            remarkType,
           })
       }
     },

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useGetBittensorStakeInfo.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useGetBittensorStakeInfo.ts
@@ -50,6 +50,7 @@ export const useGetBittensorStakeInfo = ({
     hotkey,
     address,
     networkId,
+    remarkType: "stake",
   })
 
   const currentHotkey = useBittensorCurrentHotkey({ address, networkId, netuid })

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/constants.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/constants.ts
@@ -13,4 +13,13 @@ export const TALISMAN_FEE_RECEIVER_ADDRESS_BITTENSOR =
 
 export const TALISMAN_FEE_BITTENSOR = 0.3
 
+/** which UI a staking operation originates from: the staking wizard, or the TAO dashboard's buy/sell wizard */
+export type RemarkType = "stake" | "swap"
+
+// remarks batched with staking extrinsics, so on-chain volume can be attributed to the UI it originates from
+export const DTAO_STAKING_REMARKS: Record<RemarkType, string> = {
+  stake: "chili001",
+  swap: "garlic002",
+}
+
 export const DEFAULT_ROOT_CLAIM_TYPE: RootClaimType = "Swap"

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/helpers.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/helpers.ts
@@ -3,7 +3,12 @@ import { TAO_DECIMALS } from "@talismn/balances"
 import type { ScaleApi } from "@talismn/sapi"
 
 import type { StakeDirection } from "../hooks/types"
-import { ROOT_NETUID, TALISMAN_FEE_RECEIVER_ADDRESS_BITTENSOR } from "./constants"
+import type { RemarkType } from "./constants"
+import {
+  DTAO_STAKING_REMARKS,
+  ROOT_NETUID,
+  TALISMAN_FEE_RECEIVER_ADDRESS_BITTENSOR,
+} from "./constants"
 
 export type BittensorSwapSimulation = {
   tao_amount: bigint
@@ -59,6 +64,7 @@ export const getBittensorStakingPayload = async ({
   priceLimit,
   netuid,
   talismanFee,
+  remarkType,
 }: {
   sapi: ScaleApi
   address: string
@@ -67,6 +73,7 @@ export const getBittensorStakingPayload = async ({
   priceLimit: bigint
   netuid: number
   talismanFee: bigint
+  remarkType: RemarkType
 }) => {
   if (netuid === 0) {
     return sapi.getExtrinsicPayload(
@@ -80,7 +87,7 @@ export const getBittensorStakingPayload = async ({
             amount_staked: amount,
           }),
           sapi.getDecodedCall("System", "remark_with_event", {
-            remark: Binary.fromText("talisman-bittensor"),
+            remark: Binary.fromText(DTAO_STAKING_REMARKS[remarkType]),
           }),
         ],
       },
@@ -111,7 +118,7 @@ export const getBittensorStakingPayload = async ({
           allow_partial: false,
         }),
         sapi.getDecodedCall("System", "remark_with_event", {
-          remark: Binary.fromText("talisman-bittensor"),
+          remark: Binary.fromText(DTAO_STAKING_REMARKS[remarkType]),
         }),
       ],
     },
@@ -127,6 +134,7 @@ type GetBittensorUnbondPayload = {
   talismanFee: bigint
   priceLimit: bigint
   netuid: number
+  remarkType: RemarkType
 }
 
 type GetBittensorMoveStakePayload = {
@@ -147,6 +155,7 @@ export const getBittensorUnbondPayload = ({
   netuid,
   priceLimit,
   talismanFee,
+  remarkType,
 }: GetBittensorUnbondPayload) => {
   if (netuid === ROOT_NETUID) {
     return sapi.getExtrinsicPayload(
@@ -160,7 +169,7 @@ export const getBittensorUnbondPayload = ({
             amount_unstaked: amount,
           }),
           sapi.getDecodedCall("System", "remark_with_event", {
-            remark: Binary.fromText("talisman-bittensor"),
+            remark: Binary.fromText(DTAO_STAKING_REMARKS[remarkType]),
           }),
         ],
       },
@@ -187,7 +196,7 @@ export const getBittensorUnbondPayload = ({
           value: talismanFee,
         }),
         sapi.getDecodedCall("System", "remark_with_event", {
-          remark: Binary.fromText("talisman-bittensor"),
+          remark: Binary.fromText(DTAO_STAKING_REMARKS[remarkType]),
         }),
       ],
     },
@@ -237,7 +246,7 @@ export const getBittensorMoveStakePayload = ({
           alpha_amount: alphaAmount,
         }),
         sapi.getDecodedCall("System", "remark_with_event", {
-          remark: Binary.fromText("talisman-bittensor"),
+          remark: Binary.fromText(DTAO_STAKING_REMARKS.stake),
         }),
       ],
     },

--- a/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/SwapBuyProvider.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/SwapBuyProvider.tsx
@@ -205,6 +205,7 @@ const useSwapBuyProvider = ({ netuid }: { netuid: number }) => {
     hotkey,
     address,
     networkId: BITTENSOR_NETWORK_ID,
+    remarkType: "swap",
   })
 
   const txInfo: WalletTransactionInfo | undefined = useMemo(() => {

--- a/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/SwapSellProvider.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/SwapSellProvider.tsx
@@ -169,6 +169,7 @@ const useSwapSellProvider = ({ netuid }: { netuid: number }) => {
     hotkey,
     address,
     networkId: BITTENSOR_NETWORK_ID,
+    remarkType: "swap",
   })
 
   const txInfo: WalletTransactionInfo | undefined = useMemo(() => {


### PR DESCRIPTION
Distinguishes on-chain staking volume by the UI it originates from.

| Origin | Remark |
| --- | --- |
| dTAO staking wizard + change validator | `chili001` |
| TAO dashboard buy/sell wizard | `garlic002` |

Previously all batched `System.remark_with_event` calls used `talisman-bittensor`. The remark is now selected by a `remarkType: "stake" \| "swap"` prop threaded from the call site, resolved through `DTAO_STAKING_REMARKS`.