### PR TITLE
⚡️ virtualize TAO dashboard subnets table

### DIFF
--- a/.changeset/green-clubs-beg.md
+++ b/.changeset/green-clubs-beg.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": patch
+---
+
+adjust comments

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/normalizeGreek.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/normalizeGreek.ts
@@ -30,5 +30,16 @@ const GREEK_TO_LATIN: Record<string, string> = {
 
 const greekRegex = new RegExp(`[${Object.keys(GREEK_TO_LATIN).join("")}]`, "g")
 
-export const normalizeGreek = (str: string) =>
-  str.replace(greekRegex, (ch) => GREEK_TO_LATIN[ch] ?? ch)
+// pickers call this for every subnet on every keystroke - cache results
+const MAX_CACHE_SIZE = 10_000
+const cache = new Map<string, string>()
+
+export const normalizeGreek = (str: string) => {
+  const cached = cache.get(str)
+  if (cached !== undefined) return cached
+
+  if (cache.size >= MAX_CACHE_SIZE) cache.clear()
+  const normalized = str.replace(greekRegex, (ch) => GREEK_TO_LATIN[ch] ?? ch)
+  cache.set(str, normalized)
+  return normalized
+}

--- a/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardSubnetsTable.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardSubnetsTable.tsx
@@ -7,13 +7,14 @@ import {
   ZapOffIcon,
   ZapPlusIcon,
 } from "@talismn/icons"
+import { useVirtualizer } from "@tanstack/react-virtual"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
 import { FiatFromUsd } from "@ui/domains/Asset/Fiat"
 import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
 import { useBittensorBondModal } from "@ui/domains/Staking/Bittensor/hooks/useBittensorBondModal"
 import { normalizeGreek } from "@ui/domains/Staking/Bittensor/utils/normalizeGreek"
 import { cn } from "@ui/util/cn"
-import { type FC, memo, type PropsWithChildren, useCallback, useMemo } from "react"
+import { type FC, memo, type PropsWithChildren, useCallback, useMemo, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { BehaviorSubject } from "rxjs"
@@ -159,6 +160,8 @@ export const TaoDashboardSubnetsTable: FC<{
     })
   }, [search, subnets])
 
+  const listRef = useRef<HTMLDivElement>(null)
+
   const sortedSubnets = useMemo(() => {
     const pinRoot = sortSetting.key !== "balanceUsd"
 
@@ -189,6 +192,15 @@ export const TaoDashboardSubnetsTable: FC<{
       }
     })
   }, [filteredSubnets, sortSetting])
+
+  const virtualizer = useVirtualizer({
+    count: sortedSubnets.length,
+    overscan: 8,
+    gap: 1, // 1px separators, shown as the container's background
+    estimateSize: () => 64, // h-32 rows
+    getScrollElement: () => document.getElementById("main"),
+    scrollMargin: listRef.current?.offsetTop ?? 0,
+  })
 
   if (isLoading && subnets.length === 0) {
     return (
@@ -221,16 +233,32 @@ export const TaoDashboardSubnetsTable: FC<{
       )}
     >
       {!hideHeader && <HeaderRow sortSetting={sortSetting} setSortSetting={setSortSetting} />}
-      <div className="flex w-full flex-col gap-px overflow-hidden bg-grey-750">
-        {sortedSubnets.map((subnet) => (
-          <SubnetRow
-            key={subnet.netuid}
-            subnet={subnet}
-            loading={loading}
-            errors={errors}
-            stakeAddress={stakeAddress}
-          />
-        ))}
+      <div
+        ref={listRef}
+        className="relative w-full bg-grey-750"
+        style={{ height: `${virtualizer.getTotalSize()}px` }}
+      >
+        {virtualizer.getVirtualItems().map((item) => {
+          const subnet = sortedSubnets[item.index]
+          if (!subnet) return null
+          return (
+            <div
+              key={subnet.netuid}
+              className="absolute top-0 left-0 w-full"
+              style={{
+                height: `${item.size}px`,
+                transform: `translateY(${item.start - virtualizer.options.scrollMargin}px)`,
+              }}
+            >
+              <SubnetRow
+                subnet={subnet}
+                loading={loading}
+                errors={errors}
+                stakeAddress={stakeAddress}
+              />
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardSubnetsTable.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardSubnetsTable.tsx
@@ -227,15 +227,12 @@ export const TaoDashboardSubnetsTable: FC<{
     // biome-ignore lint/a11y/useSemanticElements: intentional div-based grid layout with ARIA roles
     <div
       role="table"
-      className={cn(
-        "w-full overflow-hidden bg-black-secondary",
-        hideHeader ? "rounded-b-lg" : "rounded-lg"
-      )}
+      className={cn("w-full overflow-hidden", hideHeader ? "rounded-b-lg" : "rounded-lg")}
     >
       {!hideHeader && <HeaderRow sortSetting={sortSetting} setSortSetting={setSortSetting} />}
       <div
         ref={listRef}
-        className="relative w-full bg-grey-750"
+        className="relative w-full"
         style={{ height: `${virtualizer.getTotalSize()}px` }}
       >
         {virtualizer.getVirtualItems().map((item) => {

--- a/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardSubnetsTable.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnets/TaoDashboardSubnetsTable.tsx
@@ -14,7 +14,16 @@ import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
 import { useBittensorBondModal } from "@ui/domains/Staking/Bittensor/hooks/useBittensorBondModal"
 import { normalizeGreek } from "@ui/domains/Staking/Bittensor/utils/normalizeGreek"
 import { cn } from "@ui/util/cn"
-import { type FC, memo, type PropsWithChildren, useCallback, useMemo, useRef } from "react"
+import {
+  type FC,
+  memo,
+  type PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { BehaviorSubject } from "rxjs"
@@ -200,6 +209,39 @@ export const TaoDashboardSubnetsTable: FC<{
     estimateSize: () => 64, // h-32 rows
     getScrollElement: () => document.getElementById("main"),
     scrollMargin: listRef.current?.offsetTop ?? 0,
+    scrollPaddingStart: 150, // keep target row clear of the page's sticky header block
+  })
+
+  // rows outside the virtualizer window are unmounted, so native Tab can't reach them:
+  // ArrowUp/ArrowDown mounts the target row via scrollToIndex, then focuses it once rendered
+  const [pendingFocusIndex, setPendingFocusIndex] = useState<number | null>(null)
+
+  const handleListKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return
+      const wrapper = (e.target as HTMLElement).closest<HTMLElement>("[data-index]")
+      if (!wrapper) return
+      const direction = e.key === "ArrowDown" ? 1 : -1
+      let next = Number(wrapper.dataset.index) + direction
+      while (sortedSubnets[next]?.netuid === 0) next += direction // Root row is not focusable
+      if (next < 0 || next >= sortedSubnets.length) return
+      e.preventDefault()
+      virtualizer.scrollToIndex(next)
+      setPendingFocusIndex(next)
+    },
+    [sortedSubnets, virtualizer]
+  )
+
+  // no dependency array: retries after each render until the virtualizer mounts the target row
+  useEffect(() => {
+    if (pendingFocusIndex === null) return
+    const row = listRef.current?.querySelector<HTMLElement>(
+      `[data-index="${pendingFocusIndex}"] [role="row"]`
+    )
+    if (row) {
+      row.focus({ preventScroll: true })
+      setPendingFocusIndex(null)
+    }
   })
 
   if (isLoading && subnets.length === 0) {
@@ -227,13 +269,16 @@ export const TaoDashboardSubnetsTable: FC<{
     // biome-ignore lint/a11y/useSemanticElements: intentional div-based grid layout with ARIA roles
     <div
       role="table"
+      aria-rowcount={sortedSubnets.length}
       className={cn("w-full overflow-hidden", hideHeader ? "rounded-b-lg" : "rounded-lg")}
     >
       {!hideHeader && <HeaderRow sortSetting={sortSetting} setSortSetting={setSortSetting} />}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: keyboard navigation across virtualized rows */}
       <div
         ref={listRef}
         className="relative w-full"
         style={{ height: `${virtualizer.getTotalSize()}px` }}
+        onKeyDown={handleListKeyDown}
       >
         {virtualizer.getVirtualItems().map((item) => {
           const subnet = sortedSubnets[item.index]
@@ -241,6 +286,7 @@ export const TaoDashboardSubnetsTable: FC<{
           return (
             <div
               key={subnet.netuid}
+              data-index={item.index}
               className="absolute top-0 left-0 w-full"
               style={{
                 height: `${item.size}px`,
@@ -249,6 +295,7 @@ export const TaoDashboardSubnetsTable: FC<{
             >
               <SubnetRow
                 subnet={subnet}
+                rowIndex={item.index + 1}
                 loading={loading}
                 errors={errors}
                 stakeAddress={stakeAddress}
@@ -412,10 +459,11 @@ const SkeletonBar: FC<{ className?: string }> = ({ className }) => {
 
 const SubnetRow: FC<{
   subnet: TaoDashboardSubnet
+  rowIndex: number
   loading: TaoDashboardSubnetsLoading
   errors: TaoDashboardSubnetsErrors
   stakeAddress: string | undefined
-}> = memo(({ subnet, loading, errors, stakeAddress }) => {
+}> = memo(({ subnet, rowIndex, loading, errors, stakeAddress }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { open: openBondModal } = useBittensorBondModal()
@@ -466,6 +514,7 @@ const SubnetRow: FC<{
     // biome-ignore lint/a11y/useSemanticElements: intentional div-based grid layout with ARIA roles
     <div
       role="row"
+      aria-rowindex={rowIndex}
       tabIndex={isRoot ? undefined : 0}
       aria-label={
         isRoot

--- a/packages/balances/src/modules/shared/fetchRuntimeCallResult.ts
+++ b/packages/balances/src/modules/shared/fetchRuntimeCallResult.ts
@@ -55,10 +55,8 @@ export const fetchRuntimeCallResult = async <T>(
       toHex(call.args.enc(args)),
     ])
 
-    // the response decode is synchronous and indivisible — for large results (e.g.
-    // bittensor get_stake_info_for_coldkeys / get_all_dynamic_info, polled every 6s)
-    // this can block the JS thread for hundreds of ms. Report it so host stall
-    // watchdogs can attribute the block.
+    // the response decode is synchronous and indivisible — large results can block
+    // the JS thread for hundreds of ms. Report it so host stall watchdogs can attribute the block.
     const start = performance.now()
     const result = call.value.dec(hex) as T
     reportJsActivity(


### PR DESCRIPTION
Prep for growing subnet count:

- virtualize subnets table rows (arrow-key navigation + `aria-rowcount`/`aria-rowindex` so off-screen rows stay reachable)
- transparent background behind virtualized rows
- memoize `normalizeGreek`
- fix misleading decode comment in `fetchRuntimeCallResult`

QA hint: check behavior of the main TAO dashboard table.