### PR TITLE
⚡️ skip provably-zero RootClaimed queries

### DIFF
--- a/.changeset/heavy-hoops-tease.md
+++ b/.changeset/heavy-hoops-tease.md
@@ -1,0 +1,5 @@
+---
+"@talismn/balances": patch
+---
+
+skip RootClaimed storage queries whose pending claim is provably zero

--- a/.changeset/heavy-hoops-tease.md
+++ b/.changeset/heavy-hoops-tease.md
@@ -2,4 +2,4 @@
 "@talismn/balances": patch
 ---
 
-skip RootClaimed storage queries whose pending claim is provably zero
+skip RootClaimed storage queries and pending root claim balances whose claimable total is provably zero

--- a/packages/balances/src/modules/substrate-dtao/calculatePendingRootClaimable.test.ts
+++ b/packages/balances/src/modules/substrate-dtao/calculatePendingRootClaimable.test.ts
@@ -1,6 +1,9 @@
 import { subDTaoTokenId } from "@talismn/chaindata-provider"
 import { describe, expect, it } from "vitest"
-import { calculatePendingRootClaimable } from "./calculatePendingRootClaimable"
+import {
+  calculatePendingRootClaimable,
+  calculateTotalRootClaimable,
+} from "./calculatePendingRootClaimable"
 
 const NETWORK_ID = "bittensor-0"
 const ADDRESS = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
@@ -16,6 +19,28 @@ const makeArgs = (overrides: Record<string, unknown> = {}) =>
     alreadyClaimedByNetuid: new Map<number, bigint>(),
     ...overrides,
   }) as unknown as Parameters<typeof calculatePendingRootClaimable>[0]
+
+describe("calculateTotalRootClaimable", () => {
+  it("returns 0n when rate is 0n", () => {
+    expect(calculateTotalRootClaimable(1_000_000_000n, 0n)).toBe(0n)
+  })
+
+  it("returns 0n when stake is 0n", () => {
+    expect(calculateTotalRootClaimable(0n, 1n << 32n)).toBe(0n)
+  })
+
+  it("rounds to 0n when stake * rate is below 2^31", () => {
+    expect(calculateTotalRootClaimable(1n, (1n << 31n) - 1n)).toBe(0n)
+  })
+
+  it("rounds half up", () => {
+    expect(calculateTotalRootClaimable(1n, 1n << 31n)).toBe(1n)
+  })
+
+  it("computes exact multiples for fixed-point 1.0", () => {
+    expect(calculateTotalRootClaimable(1000n, 1n << 32n)).toBe(1000n)
+  })
+})
 
 describe("calculatePendingRootClaimable", () => {
   it("returns empty array when validatorRootClaimableRate is empty", () => {

--- a/packages/balances/src/modules/substrate-dtao/calculatePendingRootClaimable.test.ts
+++ b/packages/balances/src/modules/substrate-dtao/calculatePendingRootClaimable.test.ts
@@ -57,6 +57,14 @@ describe("calculatePendingRootClaimable", () => {
     expect(result).toEqual([])
   })
 
+  it("skips netuids whose total rounds to 0n", () => {
+    const rates = new Map<number, bigint>([[1, (1n << 31n) - 1n]])
+    const result = calculatePendingRootClaimable(
+      makeArgs({ stake: 1n, validatorRootClaimableRate: rates })
+    )
+    expect(result).toEqual([])
+  })
+
   it("computes I96F32 math correctly for a single netuid", () => {
     const stake = 1_000_000_000n
     const rate = 1n << 32n // fixed-point 1.0

--- a/packages/balances/src/modules/substrate-dtao/calculatePendingRootClaimable.ts
+++ b/packages/balances/src/modules/substrate-dtao/calculatePendingRootClaimable.ts
@@ -2,6 +2,10 @@ import { subDTaoTokenId } from "@talismn/chaindata-provider"
 
 import type { SubDTaoBalance } from "./types"
 
+// claimableRate is a I96F32, a fixed-point number format: round((stake * rate) / 2^32)
+export const calculateTotalRootClaimable = (stake: bigint, claimableRate: bigint): bigint =>
+  (stake * claimableRate + (1n << 31n)) >> 32n
+
 export const calculatePendingRootClaimable = ({
   stake,
   hotkey,
@@ -23,12 +27,8 @@ export const calculatePendingRootClaimable = ({
     if (claimableRate === 0n) {
       continue
     }
-    // Calculate claimable = claimable_rate * root_stake
-    // Note: claimableRate is a I96F32, a fixed-point number format
 
-    // Multiply claimable_rate by root_stake
-    // I96F32 multiplication: round((a * b) / 2^32)
-    const totalClaimable = (stake * claimableRate + (1n << 31n)) >> 32n
+    const totalClaimable = calculateTotalRootClaimable(stake, claimableRate)
 
     // Subtract already claimed amount to get net pending claimable
     const alreadyClaimed = alreadyClaimedByNetuid.get(netuid) ?? 0n

--- a/packages/balances/src/modules/substrate-dtao/calculatePendingRootClaimable.ts
+++ b/packages/balances/src/modules/substrate-dtao/calculatePendingRootClaimable.ts
@@ -24,11 +24,13 @@ export const calculatePendingRootClaimable = ({
   const pendingRootClaimBalances: SubDTaoBalance[] = []
 
   for (const [netuid, claimableRate] of validatorRootClaimableRate) {
-    if (claimableRate === 0n) {
-      continue
-    }
+    if (claimableRate === 0n) continue
 
     const totalClaimable = calculateTotalRootClaimable(stake, claimableRate)
+
+    // a zero total is a provably-zero pending claim: skip it so no balance (nor
+    // dynamic token downstream) is built for the position
+    if (totalClaimable === 0n) continue
 
     // Subtract already claimed amount to get net pending claimable
     const alreadyClaimed = alreadyClaimedByNetuid.get(netuid) ?? 0n

--- a/packages/balances/src/modules/substrate-dtao/fetchBalances.ts
+++ b/packages/balances/src/modules/substrate-dtao/fetchBalances.ts
@@ -22,7 +22,10 @@ import { fetchRuntimeCallResult } from "../shared"
 import { parseMetadataRpcCached } from "../shared/parseMetadataRpcCached"
 import { fetchRpcQueryPack, type MaybeStateKey, type RpcQueryPack } from "../shared/rpcQueryPack"
 import { getBalanceDefs } from "../shared/types"
-import { calculatePendingRootClaimable } from "./calculatePendingRootClaimable"
+import {
+  calculatePendingRootClaimable,
+  calculateTotalRootClaimable,
+} from "./calculatePendingRootClaimable"
 import { MODULE_TYPE } from "./config"
 import { fetchConvictionLocks, getConvictionLockLabel } from "./convictionLocks"
 import type { GetStakeInfosResult, SubDTaoBalance, SubDTaoBalanceMeta } from "./types"
@@ -110,8 +113,10 @@ export const fetchBalances: IBalanceModule<typeof MODULE_TYPE>["fetchBalances"] 
         if (stake.netuid === ROOT_NETUID) {
           const claimableRates = rootClaimableRatesByHotkey.get(stake.hotkey)
           if (claimableRates) {
-            // For each netuid that has a claimable rate, we need to check RootClaimed
-            for (const netuid of claimableRates.keys()) {
+            for (const [netuid, claimableRate] of claimableRates) {
+              // pending = totalClaimable - claimed, and claimed >= 0: when totalClaimable
+              // is 0 the pending claim is 0 whatever RootClaimed holds - skip the query
+              if (calculateTotalRootClaimable(stake.stake, claimableRate) === 0n) continue
               addressHotkeyNetuidPairs.push([address, stake.hotkey, netuid])
             }
           }

--- a/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
+++ b/packages/balances/src/modules/substrate-dtao/transientFailures.test.ts
@@ -268,8 +268,9 @@ describe("fetchBalances transient failures", () => {
     vi.mocked(fetchRuntimeCallResult).mockResolvedValue([
       ["address-1", [{ netuid: 0, hotkey: "hotkey-1", stake: 100n }]],
     ] as unknown as Awaited<ReturnType<typeof fetchRuntimeCallResult>>)
-    // RootClaimable resolves with a claimable rate so the RootClaimed fetch runs
-    vi.mocked(fetchRpcQueryPack).mockResolvedValue([["hotkey-1", new Map([[5, 1n]])]])
+    // RootClaimable resolves with a rate whose rounded total is nonzero so the RootClaimed
+    // fetch runs — provably-zero totals skip the query entirely (see the test below)
+    vi.mocked(fetchRpcQueryPack).mockResolvedValue([["hotkey-1", new Map([[5, 1n << 32n]])]])
     // conviction lock scan finds no keys
     const connector = { send: vi.fn().mockResolvedValue([]) }
 
@@ -292,5 +293,64 @@ describe("fetchBalances transient failures", () => {
     expect(result.success).toEqual([])
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0]).toMatchObject({ tokenId: token.id, address: "address-1" })
+    // guards against the fixture rounding to a zero total, which would skip the RootClaimed
+    // query and let this test pass without exercising the encode failure at all
+    expect(rootClaimedCoder.keys.enc).toHaveBeenCalled()
+  })
+
+  it("skips the RootClaimed query when every claimable total rounds to zero", async () => {
+    // stake=100n at rate=1n rounds to a zero total: pending is provably zero whatever
+    // RootClaimed holds, so the query must be skipped and its coder never invoked
+    const rootClaimedCoder = {
+      keys: {
+        enc: vi.fn(() => {
+          throw new Error("bad claimed key")
+        }),
+        dec: vi.fn(),
+      },
+      value: { dec: vi.fn() },
+    }
+    vi.mocked(parseMetadataRpcCached).mockReturnValue({
+      builder: {
+        buildStorage: vi.fn((_pallet: string, entry: string) =>
+          entry === "RootClaimed" ? rootClaimedCoder : makeCoder()
+        ),
+      },
+      unifiedMetadata: {},
+    } as unknown as ReturnType<typeof parseMetadataRpcCached>)
+    vi.mocked(fetchRuntimeCallResult).mockResolvedValue([
+      ["address-1", [{ netuid: 0, hotkey: "hotkey-1", stake: 100n }]],
+    ] as unknown as Awaited<ReturnType<typeof fetchRuntimeCallResult>>)
+    vi.mocked(fetchRpcQueryPack).mockClear()
+    vi.mocked(fetchRpcQueryPack).mockResolvedValue([["hotkey-1", new Map([[5, 1n]])]])
+    // conviction lock scan finds no keys
+    const connector = { send: vi.fn().mockResolvedValue([]) }
+
+    // request the position's own token id so the success row survives untouched
+    const token = {
+      id: "bittensor:substrate-dtao:0:hotkey-1",
+      type: "substrate-dtao",
+      platform: "polkadot",
+      networkId: "bittensor",
+      netuid: 0,
+    } as unknown as TokensWithAddresses[number][0]
+
+    const result = await fetchBalances({
+      networkId: "bittensor",
+      tokensWithAddresses: [[token, ["address-1"]]] as TokensWithAddresses,
+      connector,
+      miniMetadata: { data: "0x00", source: "substrate-dtao", chainId: "bittensor" },
+      signal: new AbortController().signal,
+    } as unknown as Parameters<typeof fetchBalances>[0])
+
+    expect(rootClaimedCoder.keys.enc).not.toHaveBeenCalled()
+    // only the RootClaimable rates fetch goes through fetchRpcQueryPack, not RootClaimed
+    expect(vi.mocked(fetchRpcQueryPack)).toHaveBeenCalledTimes(1)
+    expect(result.errors).toEqual([])
+    expect(result.success).toHaveLength(1)
+    expect(result.success[0]).toMatchObject({ tokenId: token.id, address: "address-1" })
+    expect(result.success[0]!.values).toContainEqual(
+      expect.objectContaining({ type: "free", amount: "100" })
+    )
   })
 })


### PR DESCRIPTION
On the 6s dtao poll we currently query one \`RootClaimed\` storage key per \`RootClaimable\` entry, including entries whose pending claim can only be zero. Since \`pending = totalClaimable − claimed\` and \`claimed ≥ 0\`, any key where \`(stake × rate + 2³¹) >> 32 === 0\` (zero rate or dust position) can be skipped without changing the result. Emitted balance rows are unchanged.

Estimated impact per 6s poll (from live mainnet measurements, ~83% of \`RootClaimable\` entries chain-wide are zero-rate):

| Scenario | Keys before | Keys after | Payload before | Payload after |
|---|---|---|---|---|
| Normal user (2 positions, mid-tier validators — 100% zero-rate maps) | ~250 | 0 | ~65 KB | 0 |
| Whale (30 hotkeys, mixed validators) | ~3,840 | ~650 | ~1 MB (~1.3s per call) | ~170 KB |

Positions held exclusively on top validators see a smaller reduction (~127 non-zero rates each), but dust netuids are still filtered out.

QA hint: in portfolio compare root staking pending rewards against dev branch