### PR TITLE
🐛 detect insufficient gas balance when swap estimation fails

### DIFF
--- a/apps/extension/src/ui/domains/Swap/__tests__/swap-errors.test.ts
+++ b/apps/extension/src/ui/domains/Swap/__tests__/swap-errors.test.ts
@@ -6,6 +6,7 @@ import {
   getSwapErrorMessage,
   type SwapConfirmError,
 } from "../swap-errors"
+import { InsufficientGasBalanceError } from "../swap-modules/evm-gas-check"
 
 const mockT = ((key: string, opts?: Record<string, string>) => {
   if (!opts) return key
@@ -39,6 +40,20 @@ describe("classifySwapError", () => {
     const viemError = { shortMessage: "Execution reverted", message: "long details..." }
     const result = classifySwapError(viemError)
     expect(result).toEqual({ type: "transaction-craft-error", message: "Execution reverted" })
+  })
+
+  it("maps InsufficientGasBalanceError to insufficient-fee-balance", () => {
+    const error = new InsufficientGasBalanceError(
+      "evm-native-42161",
+      2_534_600_000_000_000n,
+      2_653_076_276_816n
+    )
+    expect(classifySwapError(error)).toEqual({
+      type: "insufficient-fee-balance",
+      feeTokenId: "evm-native-42161",
+      required: 2_534_600_000_000_000n,
+      available: 2_653_076_276_816n,
+    })
   })
 })
 

--- a/apps/extension/src/ui/domains/Swap/swap-errors.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-errors.ts
@@ -1,5 +1,6 @@
 import type { TokenId } from "@talismn/chaindata-provider"
 import type { TFunction } from "i18next"
+import { InsufficientGasBalanceError } from "./swap-modules/evm-gas-check"
 
 /**
  * Structured error types for the swap confirmation flow.
@@ -59,6 +60,14 @@ const isAbortError = (err: unknown): boolean => {
 export const classifySwapError = (rawError: unknown): SwapConfirmError | null => {
   if (!rawError) return null
   if (isAbortError(rawError)) return null
+
+  if (rawError instanceof InsufficientGasBalanceError)
+    return {
+      type: "insufficient-fee-balance",
+      feeTokenId: rawError.feeTokenId,
+      required: rawError.required,
+      available: rawError.available,
+    }
 
   const message =
     (rawError as { shortMessage?: string }).shortMessage ??

--- a/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/evm-gas-check.spec.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/evm-gas-check.spec.ts
@@ -1,0 +1,113 @@
+import type { PublicClient } from "viem"
+import { describe, expect, it, vi } from "vitest"
+import {
+  InsufficientGasBalanceError,
+  prepareTransactionRequestWithGasCheck,
+} from "../evm-gas-check"
+
+const request = {
+  chain: null,
+  account: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+  to: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+  data: "0xa9059cbb",
+  value: 0n,
+} as const
+
+const bareRevert = new Error("Execution reverted for an unknown reason.")
+
+const GAS = 60_000n
+const LOW_FEE = 40_000_000n // 0.04 gwei
+const HIGH_FEE = 40_000_000_000n // 40 gwei
+const BALANCE = 3_000_000_000_000n // covers GAS * LOW_FEE, not GAS * HIGH_FEE
+
+const makeClient = (overrides: Partial<Record<string, unknown>>) =>
+  ({
+    prepareTransactionRequest: vi.fn().mockRejectedValue(bareRevert),
+    estimateGas: vi.fn().mockResolvedValue(GAS),
+    estimateFeesPerGas: vi
+      .fn()
+      .mockResolvedValue({ maxFeePerGas: LOW_FEE, maxPriorityFeePerGas: 0n }),
+    getBalance: vi.fn().mockResolvedValue(BALANCE),
+    ...overrides,
+  }) as unknown as PublicClient
+
+describe("prepareTransactionRequestWithGasCheck", () => {
+  it("returns the prepared request when estimation succeeds", async () => {
+    const prepared = { gas: GAS }
+    const client = makeClient({
+      prepareTransactionRequest: vi.fn().mockResolvedValue(prepared),
+    })
+
+    await expect(
+      prepareTransactionRequestWithGasCheck(client, "evm-native-42161", request)
+    ).resolves.toBe(prepared)
+    expect(client.estimateGas).not.toHaveBeenCalled()
+  })
+
+  it("throws InsufficientGasBalanceError when sender cannot afford worst-case gas", async () => {
+    const client = makeClient({
+      estimateFeesPerGas: vi
+        .fn()
+        .mockResolvedValue({ maxFeePerGas: HIGH_FEE, maxPriorityFeePerGas: 0n }),
+    })
+
+    const error = await prepareTransactionRequestWithGasCheck(
+      client,
+      "evm-native-42161",
+      request
+    ).catch((e) => e)
+
+    expect(error).toBeInstanceOf(InsufficientGasBalanceError)
+    expect(error.feeTokenId).toBe("evm-native-42161")
+    expect(error.required).toBe(GAS * HIGH_FEE)
+    expect(error.available).toBe(BALANCE)
+  })
+
+  it("includes the transfer value in the required amount", async () => {
+    const client = makeClient({})
+
+    const error = await prepareTransactionRequestWithGasCheck(client, "evm-native-42161", {
+      ...request,
+      data: undefined,
+      value: BALANCE,
+    }).catch((e) => e)
+
+    expect(error).toBeInstanceOf(InsufficientGasBalanceError)
+    expect(error.required).toBe(BALANCE + GAS * LOW_FEE)
+  })
+
+  it("rethrows the original error on a genuine revert", async () => {
+    const client = makeClient({
+      estimateGas: vi.fn().mockRejectedValue(new Error("ERC20: transfer amount exceeds balance")),
+    })
+
+    await expect(
+      prepareTransactionRequestWithGasCheck(client, "evm-native-42161", request)
+    ).rejects.toBe(bareRevert)
+  })
+
+  it("rethrows the original error when the sender can afford gas", async () => {
+    const client = makeClient({
+      getBalance: vi.fn().mockResolvedValue(10n ** 18n),
+    })
+
+    await expect(
+      prepareTransactionRequestWithGasCheck(client, "evm-native-42161", request)
+    ).rejects.toBe(bareRevert)
+  })
+
+  it("falls back to gasPrice on legacy fee networks", async () => {
+    const client = makeClient({
+      estimateFeesPerGas: vi.fn().mockResolvedValue({ gasPrice: HIGH_FEE }),
+    })
+
+    const error = await prepareTransactionRequestWithGasCheck(
+      client,
+      "evm-native-42161",
+      request
+    ).catch((e) => e)
+
+    expect(error).toBeInstanceOf(InsufficientGasBalanceError)
+    expect(error.required).toBe(GAS * HIGH_FEE)
+  })
+})

--- a/apps/extension/src/ui/domains/Swap/swap-modules/deposit-swap-transactions.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/deposit-swap-transactions.ts
@@ -24,6 +24,7 @@ import { firstValueFrom } from "rxjs"
 import { encodeFunctionData, erc20Abi, type TransactionRequest } from "viem"
 import { parseUserInputToPlanck } from "../swap-utils"
 import type { QuoteFee, SwapModuleTransaction, SwapTransactionContext } from "./common.swap-module"
+import { prepareTransactionRequestWithGasCheck } from "./evm-gas-check"
 
 /**
  * Common info needed to build a deposit transaction for a centralized swap.
@@ -165,10 +166,10 @@ async function buildEvmDepositTransaction(params: {
     const depositAmount = parseUserInputToPlanck(deposit.depositAmount, fromAsset.decimals)
 
     const publicClient = await getPublicClient(evmNetwork.id)
-    if (!publicClient) throw new Error("Missing public client")
+    if (!publicClient || !evmNetwork.nativeTokenId) throw new Error("Missing public client")
 
     if (!fromAsset.contractAddress)
-      return publicClient.prepareTransactionRequest({
+      return prepareTransactionRequestWithGasCheck(publicClient, evmNetwork.nativeTokenId, {
         chain: null,
         to: deposit.depositAddress as `0x${string}`,
         value: depositAmount,
@@ -180,7 +181,7 @@ async function buildEvmDepositTransaction(params: {
       functionName: "transfer",
       args: [deposit.depositAddress as `0x${string}`, depositAmount],
     })
-    return publicClient.prepareTransactionRequest({
+    return prepareTransactionRequestWithGasCheck(publicClient, evmNetwork.nativeTokenId, {
       chain: null,
       to: fromAsset.contractAddress as `0x${string}`,
       data,

--- a/apps/extension/src/ui/domains/Swap/swap-modules/evm-gas-check.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/evm-gas-check.ts
@@ -1,0 +1,82 @@
+import type { TokenId } from "@talismn/chaindata-provider"
+import type { PublicClient, TransactionRequest } from "viem"
+
+export class InsufficientGasBalanceError extends Error {
+  constructor(
+    public readonly feeTokenId: TokenId,
+    /** Worst-case cost in planck: value + gas * maxFeePerGas. */
+    public readonly required: bigint,
+    /** Sender's native balance in planck. */
+    public readonly available: bigint
+  ) {
+    super("Insufficient balance to pay for gas")
+    this.name = "InsufficientGasBalanceError"
+  }
+}
+
+type PrepareRequest = {
+  account: `0x${string}`
+  to: `0x${string}`
+  data?: `0x${string}`
+  value?: bigint
+  chain: null
+  gasLimit?: string
+}
+
+/**
+ * Wraps `prepareTransactionRequest` to diagnose gas-affordability failures.
+ *
+ * Nodes estimate gas with the fee caps applied, which limits the allowed gas to
+ * `balance / maxFeePerGas`. When the sender cannot afford worst-case gas, the
+ * transaction runs out of gas mid-execution and estimation fails with a bare
+ * "execution reverted" instead of an explicit insufficient-funds error.
+ *
+ * On failure, re-estimate without fee fields (which skips the affordability cap):
+ * - if that also fails, the revert is genuine → rethrow the original error
+ * - if it succeeds but the sender cannot cover `value + gas * maxFeePerGas`,
+ *   throw {@link InsufficientGasBalanceError} so the UI can show a proper hint
+ */
+export async function prepareTransactionRequestWithGasCheck(
+  publicClient: PublicClient,
+  feeTokenId: TokenId,
+  request: PrepareRequest
+): Promise<TransactionRequest> {
+  try {
+    return (await publicClient.prepareTransactionRequest(request)) as TransactionRequest
+  } catch (originalError) {
+    await throwIfCannotAffordGas(publicClient, feeTokenId, request)
+    throw originalError
+  }
+}
+
+async function throwIfCannotAffordGas(
+  publicClient: PublicClient,
+  feeTokenId: TokenId,
+  request: PrepareRequest
+): Promise<void> {
+  let required: bigint
+  let available: bigint
+  try {
+    const [gas, fees, balance] = await Promise.all([
+      publicClient.estimateGas({
+        account: request.account,
+        to: request.to,
+        data: request.data,
+        value: request.value,
+      }),
+      publicClient.estimateFeesPerGas(),
+      publicClient.getBalance({ address: request.account }),
+    ])
+
+    const maxFeePerGas = fees.maxFeePerGas ?? fees.gasPrice
+    if (!maxFeePerGas) return
+
+    required = (request.value ?? 0n) + gas * maxFeePerGas
+    available = balance
+  } catch {
+    // diagnostic itself failed (e.g. a genuine revert) - let the caller rethrow the original error
+    return
+  }
+
+  if (required > available) throw new InsufficientGasBalanceError(feeTokenId, required, available)
+}

--- a/apps/extension/src/ui/domains/Swap/swap-modules/lifi-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/lifi-swap-module.ts
@@ -33,6 +33,7 @@ import {
   type SwapModule,
   type SwapModuleTransaction,
 } from "./common.swap-module"
+import { prepareTransactionRequestWithGasCheck } from "./evm-gas-check"
 import { getLifiTalismanFee as getTalismanFee, LIFI_PROTOCOL_FEE as LIFI_FEE } from "./fee-utils"
 
 const apiUrl = "https://lifi.talisman.xyz/v1"
@@ -613,16 +614,20 @@ const getTransaction = async (
     if (!evmNetwork) throw new Error("Unknown chain")
 
     const publicClient = await getPublicClient(evmNetwork.id)
-    if (!publicClient) throw new Error("Missing public client")
+    if (!publicClient || !evmNetwork.nativeTokenId) throw new Error("Missing public client")
 
-    const transaction = await publicClient.prepareTransactionRequest({
-      chain: null,
-      to: txRequest.to as `0x${string}`,
-      value: BigInt(txRequest.value),
-      data: txRequest.data as `0x${string}`,
-      gasLimit: txRequest.gasLimit,
-      account: txRequest.from as `0x${string}`,
-    })
+    const transaction = await prepareTransactionRequestWithGasCheck(
+      publicClient,
+      evmNetwork.nativeTokenId,
+      {
+        chain: null,
+        to: txRequest.to as `0x${string}`,
+        value: BigInt(txRequest.value),
+        data: txRequest.data as `0x${string}`,
+        gasLimit: txRequest.gasLimit,
+        account: txRequest.from as `0x${string}`,
+      }
+    )
 
     return { platform: "ethereum", transaction }
   } catch (cause) {


### PR DESCRIPTION
This PR makes it so insufficient balance to pay for gas will be flagged on the swap confirm form, for EVM transactions.

Can test with Guardians EVM 2 account
<img width="425" height="618" alt="image" src="https://github.com/user-attachments/assets/c970ce84-da35-4e6f-8b8f-ff4cd16eaf64" />
