### PR TITLE
🐛 hide inactive tokens from swap input picker

### DIFF
--- a/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
+++ b/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
@@ -506,6 +506,7 @@ type TokenPickerProps = {
   initialSearch?: string
   allowUntransferable?: boolean
   ownedOnly?: boolean
+  activeOnly?: boolean
   isInitializing?: boolean
   className?: string
   showEmptyBalances?: boolean
@@ -526,6 +527,7 @@ export const TokenPicker: FC<TokenPickerProps> = ({
   initialSearch = "",
   allowUntransferable,
   ownedOnly,
+  activeOnly,
   isInitializing,
   className,
   showEmptyBalances,
@@ -599,7 +601,7 @@ export const TokenPicker: FC<TokenPickerProps> = ({
           onAvailableNetworksChange={networkFilterContainerId ? setAvailableNetworks : undefined}
           onSelect={onSelect}
           showEmptyBalances={showEmptyBalances}
-          activeOnly={!showEmptyBalances}
+          activeOnly={activeOnly ?? !showEmptyBalances}
         />
       </ScrollContainer>
       {!!networkFilterContainerId && (

--- a/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
+++ b/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
@@ -40,6 +40,7 @@ type TokenRowProps = {
   onClick?: () => void
   balances: Balances
   allowUntransferable?: boolean
+  isActive: boolean
 }
 
 const TokenRowSkeleton = () => (
@@ -71,6 +72,7 @@ type TokenData = {
   token: Token
   balances: Balances
   chainNameSearch: string | null | undefined
+  isActive: boolean
 }
 
 const TokenRows: FC<{
@@ -119,6 +121,7 @@ const TokenRows: FC<{
                 token={tokenData.token}
                 balances={tokenData.balances}
                 allowUntransferable={allowUntransferable}
+                isActive={tokenData.isActive}
                 onClick={() => onTokenClick(tokenData.token.id)}
               />
             </div>
@@ -134,6 +137,7 @@ const TokenRow: FC<TokenRowProps> = ({
   selected,
   balances,
   allowUntransferable,
+  isActive,
   onClick,
 }) => {
   const { t } = useTranslation()
@@ -192,7 +196,8 @@ const TokenRow: FC<TokenRowProps> = ({
             )}
             {selected && <CheckCircleIcon className="inline shrink-0 align-text-top" />}
           </div>
-          <div className={cn(isLoading && "animate-pulse")}>
+          {/* balances aren't fetched for inactive tokens, showing 0 could be inaccurate */}
+          <div className={cn(isLoading && "animate-pulse", !isActive && "invisible")}>
             <Tokens
               amount={tokensTotal}
               decimals={token.decimals}
@@ -213,7 +218,7 @@ const TokenRow: FC<TokenRowProps> = ({
               )}
             </div>
           </div>
-          <div className={cn(isLoading && "animate-pulse")}>
+          <div className={cn(isLoading && "animate-pulse", !isActive && "invisible")}>
             {hasFiatRate ? (
               <Fiat
                 amount={balances.sum.fiat(currency).transferable}
@@ -268,6 +273,7 @@ const TokensList: FC<TokensListProps> = ({
   const { t } = useTranslation()
   const account = useAccountByAddress(address)
   const allTokens = useTokens({ activeOnly, includeTestnets: true })
+  const activeTokens = useTokens({ activeOnly: true, includeTestnets: true })
   const tokenRatesMap = useTokenRatesMap()
   const networksMap = useNetworksMapById()
 
@@ -295,6 +301,8 @@ const TokensList: FC<TokensListProps> = ({
     [account, networksMap]
   )
 
+  const activeTokenIds = useMemo(() => new Set(activeTokens.map((t) => t.id)), [activeTokens])
+
   const accountCompatibleTokens = useMemo(() => {
     return allTokens
       .filter(tokenFilter)
@@ -308,9 +316,17 @@ const TokensList: FC<TokensListProps> = ({
           chainNameSearch: network?.name,
           chainLogo: network?.logo,
           hasFiatRate: !!tokenRatesMap[token.id],
+          isActive: activeTokenIds.has(token.id),
         }
       })
-  }, [allTokens, filterAccountCompatibleTokens, networksMap, tokenFilter, tokenRatesMap])
+  }, [
+    allTokens,
+    activeTokenIds,
+    filterAccountCompatibleTokens,
+    networksMap,
+    tokenFilter,
+    tokenRatesMap,
+  ])
 
   // sort by token balance
   const sortTokens = useCallback(

--- a/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
+++ b/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
@@ -14,7 +14,7 @@ import { ScrollContainer, useScrollContainer } from "@ui/components/ScrollContai
 import { SearchInput } from "@ui/components/SearchInput"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
 import { useOpenClose } from "@ui/hooks/useOpenClose"
-import { useAccountByAddress } from "@ui/state/accounts"
+import { useAccountByAddress, useAccounts } from "@ui/state/accounts"
 import { useBalances, useIsBalanceInitializing } from "@ui/state/balances"
 import { useNetworksMapById, useTokens } from "@ui/state/chaindata"
 import { useSelectedCurrency } from "@ui/state/settings"
@@ -272,6 +272,7 @@ const TokensList: FC<TokensListProps> = ({
 }) => {
   const { t } = useTranslation()
   const account = useAccountByAddress(address)
+  const accounts = useAccounts()
   const allTokens = useTokens({ activeOnly, includeTestnets: true })
   const activeTokens = useTokens({ activeOnly: true, includeTestnets: true })
   const tokenRatesMap = useTokenRatesMap()
@@ -290,15 +291,25 @@ const TokensList: FC<TokensListProps> = ({
     [address, selected, balances]
   )
 
+  const compatibleNetworkIds = useMemo(
+    () =>
+      new Set(
+        Object.values(networksMap)
+          .filter((network) => accounts.some((acc) => isAccountCompatibleWithNetwork(network, acc)))
+          .map((network) => network.id)
+      ),
+    [accounts, networksMap]
+  )
+
   const filterAccountCompatibleTokens = useCallback(
     (token: Token) => {
       const network = networksMap[token.networkId]
       if (!network) return false
-      if (!account) return true
+      if (!account) return compatibleNetworkIds.has(token.networkId)
 
       return isAccountCompatibleWithNetwork(network, account)
     },
-    [account, networksMap]
+    [account, compatibleNetworkIds, networksMap]
   )
 
   const activeTokenIds = useMemo(() => new Set(activeTokens.map((t) => t.id)), [activeTokens])

--- a/apps/extension/src/ui/domains/Swap/components/SelectTokenButton.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SelectTokenButton.tsx
@@ -25,10 +25,12 @@ type Props = {
   onSelectTokenId: (tokenId: string) => void
   /** Used to determine which tokens should be prioritized to the top of the list */
   priorityMode?: "buy" | "sell"
+  /** Hide inactive tokens and tokens from inactive networks */
+  activeOnly?: boolean
 }
 
 export const SelectTokenButton: React.FC<Props> = memo(
-  ({ allowedTokenIds, selectedTokenId, onSelectTokenId, priorityMode }) => {
+  ({ allowedTokenIds, selectedTokenId, onSelectTokenId, priorityMode, activeOnly }) => {
     const { open, close, isOpen } = useOpenClose()
 
     const handleSelect = useCallback(
@@ -47,6 +49,7 @@ export const SelectTokenButton: React.FC<Props> = memo(
           tokenId={selectedTokenId ?? null}
           allowedTokenIds={allowedTokenIds}
           priorityMode={priorityMode}
+          activeOnly={activeOnly}
           onSelect={handleSelect}
           onDismiss={close}
         />
@@ -60,6 +63,7 @@ const TokenPickerModal: FC<{
   tokenId: TokenId | null
   allowedTokenIds: string[] | undefined
   priorityMode?: "buy" | "sell"
+  activeOnly?: boolean
   onSelect: (tokenId: TokenId) => void
   onDismiss: () => void
 }> = ({ isOpen, ...contentProps }) => {
@@ -74,9 +78,10 @@ const TokenPickerModalContent: FC<{
   tokenId: TokenId | null
   allowedTokenIds: string[] | undefined
   priorityMode?: "buy" | "sell"
+  activeOnly?: boolean
   onSelect: (tokenId: TokenId) => void
   onDismiss: () => void
-}> = ({ tokenId, allowedTokenIds, priorityMode, onSelect, onDismiss }) => {
+}> = ({ tokenId, allowedTokenIds, priorityMode, activeOnly, onSelect, onDismiss }) => {
   const { t } = useTranslation()
   const remoteConfig = useRemoteConfig()
 
@@ -148,6 +153,7 @@ const TokenPickerModalContent: FC<{
         selected={tokenId ?? undefined}
         allowUntransferable
         ownedOnly
+        activeOnly={activeOnly}
         isInitializing={!allowedTokenIds}
         networkFilterContainerId={PICKER_CONTAINER_ID}
         priorityTokens={priorityTokens}

--- a/apps/extension/src/ui/domains/Swap/components/SwapForm.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapForm.tsx
@@ -114,6 +114,7 @@ export const SwapForm = () => {
                 selectedTokenId={fromTokenId}
                 allowedTokenIds={fromAssetIds}
                 priorityMode="sell"
+                activeOnly
               />
             }
             tokenAmount={<InputFromAmount />}


### PR DESCRIPTION
- swap input (sell) token picker now only lists active tokens on active networks
- token picker rows for inactive tokens/networks no longer show a balance (we don't fetch it, so 0 could be inaccurate)

new input token picker - inactive tokens are not displayed at all: 
<img width="437" height="625" alt="image" src="https://github.com/user-attachments/assets/eca10666-b287-4284-be75-dca4aa3164d4" />

new output token picker - inactive tokens have no balance, they are now hidden instead of displaying 0:
<img width="447" height="637" alt="image" src="https://github.com/user-attachments/assets/9a847639-9742-4ba6-a349-21fed864c444" />
