### PR TITLE
💄 Redesign swap progress screen

### DIFF
--- a/apps/extension/src/core/domains/transactions/watchEthereumTransaction.ts
+++ b/apps/extension/src/core/domains/transactions/watchEthereumTransaction.ts
@@ -77,17 +77,20 @@ export const watchEthereumTransaction = async (
 
       // wait 2 confirmations before marking as confirmed
       if (receipt.status === "success") {
-        // Start watching exchange status for swap transactions
-        if (txInfo) watchSwapStatus(hash)
+        // A receipt for another hash means a same-nonce replacement mined instead:
+        // that transaction's own watcher owns swap tracking and the confirmed update,
+        // and status reconciliation will mark this hash as replaced.
+        if (receipt.transactionHash === hash) {
+          // Start watching exchange status for swap transactions
+          if (txInfo) watchSwapStatus(hash)
 
-        const receipt = await client.waitForTransactionReceipt({ hash, confirmations: 2 })
-        if (receipt.status === "success")
-          updateTransactionStatus(
+          const confirmedReceipt = await client.waitForTransactionReceipt({
             hash,
-            receipt.status === "success" ? "success" : "error",
-            receipt.blockNumber,
-            true
-          )
+            confirmations: 2,
+          })
+          if (confirmedReceipt.status === "success" && confirmedReceipt.transactionHash === hash)
+            updateTransactionStatus(hash, "success", confirmedReceipt.blockNumber, true)
+        }
 
         // if tx orignates from a dapp, in case it's a swap for a new token, launch an asset discovery scan
         if (siteUrl && unsigned.from)

--- a/apps/extension/src/core/domains/transactions/watchSwapStatus.ts
+++ b/apps/extension/src/core/domains/transactions/watchSwapStatus.ts
@@ -62,7 +62,11 @@ async function pollSwapStatus(txId: string, txInfo: WalletTransactionInfo): Prom
     // Allow a grace period for not_found — the tx may still be in the mempool
     if (status === "not_found") {
       notFoundSince ??= Date.now()
-      if (Date.now() - notFoundSince >= NOT_FOUND_GRACE_PERIOD_MS) return
+      if (Date.now() - notFoundSince >= NOT_FOUND_GRACE_PERIOD_MS) {
+        // Giving up — mark as unknown so the UI stops showing an active deposit
+        await updateSwapStatus(txId, "unknown")
+        return
+      }
     } else {
       notFoundSince = null
     }
@@ -178,27 +182,28 @@ export const resumeSwapWatchers = async () => {
         if (!tx.txInfo || !isTxInfoSwap(tx.txInfo)) return false
         if (tx.txInfo.type === "bittensor-staking") return false
         // Resume if swapStatus hasn't reached a terminal state
-        if (!tx.swapStatus) return true
-        if (FINAL_SWAP_STATUSES.includes(tx.swapStatus)) return false
-
-        // Don't resume not_found watchers past their grace period
-        if (tx.swapStatus === "not_found" && now - tx.timestamp >= NOT_FOUND_GRACE_PERIOD_MS)
-          return false
-
-        // Don't resume unknown watchers past the max age
-        if (tx.swapStatus === "unknown" && now - tx.timestamp >= UNKNOWN_MAX_AGE_MS) return false
-
-        return true
+        return !tx.swapStatus || !FINAL_SWAP_STATUSES.includes(tx.swapStatus)
       })
       .toArray()
 
+    let resumed = 0
     for (const tx of successSwaps) {
+      // Watcher died before giving up on a missing exchange status — mark as unknown
+      // so the UI stops showing an active deposit
+      if (tx.swapStatus === "not_found" && now - tx.timestamp >= NOT_FOUND_GRACE_PERIOD_MS) {
+        await updateSwapStatus(tx.id, "unknown")
+        continue
+      }
+
+      // Don't resume unknown watchers past the max age
+      if (tx.swapStatus === "unknown" && now - tx.timestamp >= UNKNOWN_MAX_AGE_MS) continue
+
       // Fire-and-forget — each watcher runs independently
       watchSwapStatus(tx.id)
+      resumed++
     }
 
-    if (successSwaps.length > 0)
-      log.debug(`[resumeSwapWatchers] Resumed ${successSwaps.length} swap watcher(s)`)
+    if (resumed > 0) log.debug(`[resumeSwapWatchers] Resumed ${resumed} swap watcher(s)`)
   } catch (err) {
     log.error("resumeSwapWatchers", { err })
   }

--- a/apps/extension/src/ui/domains/Earn/seek/SeekStakingModal.tsx
+++ b/apps/extension/src/ui/domains/Earn/seek/SeekStakingModal.tsx
@@ -423,6 +423,7 @@ const SeekStakingForm: FC<{
           hash={submittedHash}
           networkIdOrHash={config.networkId}
           onClose={close}
+          containerId={SEEK_STAKING_MODAL_CONTAINER_ID}
           onReplacementComplete={handleReplacementComplete}
         />
       </div>

--- a/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
@@ -4,16 +4,21 @@ import type {
   WalletTransaction,
   WalletTransactionInfo,
 } from "@core/domains/transactions/types"
-import { getBlockExplorerUrls, type Network } from "@talismn/chaindata-provider"
-import { ExternalLinkIcon } from "@talismn/icons"
+import {
+  getBlockExplorerUrls,
+  type Network,
+  networkIdFromTokenId,
+} from "@talismn/chaindata-provider"
+import { ExternalLinkIcon, LoaderIcon } from "@talismn/icons"
 import { Button } from "@ui/components/Button"
 import {
   ProcessAnimation,
   type ProcessAnimationStatus,
 } from "@ui/components/ProcessAnimation/ProcessAnimation"
+import { type ReplacementCallbackArgs, TxReplaceActions } from "@ui/domains/Transactions/TxProgress"
 import { useAnyNetwork } from "@ui/state/chaindata"
 import { useLiveQuery } from "dexie-react-hooks"
-import { type FC, useMemo } from "react"
+import { type FC, useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
 const getBlockExplorerUrl = (network: Network | undefined | null, hash: string) => {
@@ -41,40 +46,45 @@ const useTransactionLocal = (hash: string): WalletTransaction | null | undefined
     return (await db.transactionsV2.get(hash)) ?? null
   }, [hash])
 
-type SwapStatusPhase = "submitting" | "exchange-in-progress" | "success" | "failure" | "unknown"
+type SwapProgressPill = "confirming" | "swapping"
 
 type SwapStatusDetails = {
-  phase: SwapStatusPhase
   title: string
   subtitle: string
   animStatus: ProcessAnimationStatus
+  pill?: SwapProgressPill
 }
 
 const useSwapProgressStatus = (
   txHash: string,
-  _networkId: string,
-  _txInfo: WalletTransactionInfo
+  txInfo: WalletTransactionInfo
 ): SwapStatusDetails => {
   const { t } = useTranslation()
 
   const tx = useTransactionLocal(txHash)
   const swapStatus: SwapStatus | undefined = tx?.swapStatus
 
+  const isCrossChain = useMemo(
+    () =>
+      "fromTokenId" in txInfo &&
+      networkIdFromTokenId(txInfo.fromTokenId) !== networkIdFromTokenId(txInfo.toTokenId),
+    [txInfo]
+  )
+
   return useMemo<SwapStatusDetails>(() => {
+    const inProgress = (pill: SwapProgressPill): SwapStatusDetails => ({
+      title: t("Transaction in progress"),
+      subtitle: isCrossChain ? t("This may take a few minutes") : t("This may take a moment"),
+      animStatus: "processing",
+      pill,
+    })
+
     // Phase 1: On-chain tx is still pending/processing
-    if (!tx || tx.status === "pending") {
-      return {
-        phase: "submitting",
-        title: t("Swap in progress"),
-        subtitle: t("Submitting your transaction to the network."),
-        animStatus: "processing",
-      }
-    }
+    if (!tx || tx.status === "pending") return inProgress("confirming")
 
     // On-chain tx failed
     if (tx.status === "error") {
       return {
-        phase: "failure",
         title: t("Transaction failed"),
         subtitle: t("Your swap transaction failed on-chain."),
         animStatus: "failure",
@@ -84,7 +94,6 @@ const useSwapProgressStatus = (
     // On-chain tx status unknown
     if (tx.status === "unknown") {
       return {
-        phase: "unknown",
         title: t("Transaction not found"),
         subtitle: t("Transaction was submitted, but Talisman is unable to track its progress."),
         animStatus: "failure",
@@ -94,7 +103,6 @@ const useSwapProgressStatus = (
     // On-chain tx replaced
     if (tx.status === "replaced") {
       return {
-        phase: "failure",
         title: t("Transaction cancelled"),
         subtitle: t("This transaction has been replaced with another one."),
         animStatus: "failure",
@@ -104,43 +112,14 @@ const useSwapProgressStatus = (
     // Phase 2: On-chain tx succeeded — track exchange/protocol status
     switch (swapStatus) {
       case "waiting":
-        return {
-          phase: "exchange-in-progress",
-          title: t("Depositing funds"),
-          subtitle: t("Your deposit is being processed by the exchange."),
-          animStatus: "processing",
-        }
       case "confirming":
-        return {
-          phase: "exchange-in-progress",
-          title: t("Confirming deposit"),
-          subtitle: t("The exchange is confirming your deposit."),
-          animStatus: "processing",
-        }
+        return inProgress("confirming")
       case "exchanging":
-        return {
-          phase: "exchange-in-progress",
-          title: t("Exchanging"),
-          subtitle: t("Your tokens are being exchanged."),
-          animStatus: "processing",
-        }
       case "sending":
-        return {
-          phase: "exchange-in-progress",
-          title: t("Sending funds"),
-          subtitle: t("The exchange is sending your tokens."),
-          animStatus: "processing",
-        }
       case "verifying":
-        return {
-          phase: "exchange-in-progress",
-          title: t("Verifying"),
-          subtitle: t("The exchange is verifying the transaction."),
-          animStatus: "processing",
-        }
+        return inProgress("swapping")
       case "finished":
         return {
-          phase: "success",
           title: t("Swap complete"),
           subtitle: t("Your swap was successful!"),
           animStatus: "success",
@@ -149,7 +128,6 @@ const useSwapProgressStatus = (
       case "expired":
       case "refunded":
         return {
-          phase: "failure",
           title: t("Swap failed"),
           subtitle:
             swapStatus === "refunded"
@@ -164,7 +142,6 @@ const useSwapProgressStatus = (
         // even though the on-chain tx succeeded. Show an ambiguous status instead of
         // a definitive "Swap failed" since the user's funds may have been swapped.
         return {
-          phase: "unknown",
           title: t("Swap status unknown"),
           subtitle: t(
             "Your transaction succeeded on-chain but the swap tracker couldn't confirm the result. Please check your balance."
@@ -172,15 +149,21 @@ const useSwapProgressStatus = (
           animStatus: "failure",
         }
       default:
-        // Swap status not yet loaded — show generic processing for confirmed tx
-        return {
-          phase: "exchange-in-progress",
-          title: t("Swap in progress"),
-          subtitle: t("Waiting for the exchange to process your swap."),
-          animStatus: "processing",
-        }
+        // Swap status not yet loaded — deposit is on-chain, exchange is processing
+        return inProgress("swapping")
     }
-  }, [tx, swapStatus, t])
+  }, [tx, swapStatus, isCrossChain, t])
+}
+
+const SwapStatusPill: FC<{ pill: SwapProgressPill }> = ({ pill }) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="inline-flex items-center gap-3 rounded-full bg-grey-800 px-6 py-3 text-primary text-xs">
+      <LoaderIcon className="animate-spin-slow text-sm" />
+      <span>{pill === "confirming" ? t("Confirming") : t("Swapping")}</span>
+    </div>
+  )
 }
 
 type SwapProgressProps = {
@@ -188,11 +171,18 @@ type SwapProgressProps = {
   networkId: string
   txInfo: WalletTransactionInfo
   onClose: () => void
+  onReplacementComplete?: (args: ReplacementCallbackArgs) => void
 }
 
-export const SwapProgress: FC<SwapProgressProps> = ({ hash, networkId, txInfo, onClose }) => {
+export const SwapProgress: FC<SwapProgressProps> = ({
+  hash,
+  networkId,
+  txInfo,
+  onClose,
+  onReplacementComplete,
+}) => {
   const { t } = useTranslation()
-  const { title, subtitle, animStatus } = useSwapProgressStatus(hash, networkId, txInfo)
+  const { title, subtitle, animStatus, pill } = useSwapProgressStatus(hash, txInfo)
 
   const tx = useTransactionLocal(hash)
   const network = useAnyNetwork(networkId)
@@ -206,12 +196,16 @@ export const SwapProgress: FC<SwapProgressProps> = ({ hash, networkId, txInfo, o
   const explorerUrl = useMemo(() => getBlockExplorerUrl(network, hash), [network, hash])
   const swapTrackerUrl = useMemo(() => getSwapTrackerUrl(txInfo, hash), [txInfo, hash])
 
+  const handleTrackClick = useCallback(() => {
+    if (swapTrackerUrl) window.open(swapTrackerUrl, "_blank", "noopener")
+  }, [swapTrackerUrl])
+
   return (
     <div className="flex h-full w-full flex-col items-center p-12">
       <div className="mt-8 font-bold text-body text-lg">{title}</div>
       <div className="mt-12 text-center font-light text-base text-body-secondary">{subtitle}</div>
       <ProcessAnimation status={animStatus} className="mt-18.75 mb-8 h-36.25" />
-      <div className="flex w-full grow flex-col justify-center gap-10 px-10 text-center text-body-secondary">
+      <div className="flex w-full grow flex-col items-center justify-center gap-8 px-10 text-center text-body-secondary">
         <div>
           {blockNumber ? (
             <>
@@ -241,22 +235,19 @@ export const SwapProgress: FC<SwapProgressProps> = ({ hash, networkId, txInfo, o
             </a>
           ) : null}
         </div>
-        <div>
-          {swapTrackerUrl && (
-            <a
-              target="_blank"
-              className="text-grey-200 hover:text-body"
-              href={swapTrackerUrl}
-              rel="noopener"
-            >
-              {t("Track swap progress")} <ExternalLinkIcon className="inline align-text-top" />
-            </a>
-          )}
-        </div>
+        {pill && <SwapStatusPill pill={pill} />}
+        {tx && <TxReplaceActions tx={tx} onReplacementComplete={onReplacementComplete} />}
       </div>
-      <Button fullWidth onClick={onClose}>
-        {t("Close")}
-      </Button>
+      <div className="flex w-full flex-col gap-4">
+        {swapTrackerUrl && (
+          <Button primary fullWidth onClick={handleTrackClick}>
+            {t("Track swap progress")}
+          </Button>
+        )}
+        <Button primary={!swapTrackerUrl} fullWidth onClick={onClose}>
+          {t("Close")}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
@@ -148,7 +148,12 @@ export const SwapProgress: FC<SwapProgressProps> = ({
           ) : null}
         </div>
         <SwapStatusPill label={pillLabel} />
-        <TxReplaceActions tx={tx} className="mt-0" onReplacementComplete={onReplacementComplete} />
+        <TxReplaceActions
+          tx={tx}
+          className="mt-0"
+          containerId="swap-modal"
+          onReplacementComplete={onReplacementComplete}
+        />
       </div>
       <div className="flex w-full flex-col gap-4 pt-6">
         {swapTrackerUrl && (

--- a/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
@@ -1,9 +1,4 @@
-import { db } from "@core/db"
-import type {
-  SwapStatus,
-  WalletTransaction,
-  WalletTransactionInfo,
-} from "@core/domains/transactions/types"
+import type { WalletTransaction, WalletTransactionInfo } from "@core/domains/transactions/types"
 import {
   getBlockExplorerUrls,
   type Network,
@@ -11,16 +6,15 @@ import {
 } from "@talismn/chaindata-provider"
 import { ExternalLinkIcon, LoaderIcon } from "@talismn/icons"
 import { Button } from "@ui/components/Button"
-import {
-  ProcessAnimation,
-  type ProcessAnimationStatus,
-} from "@ui/components/ProcessAnimation/ProcessAnimation"
+import { ProcessAnimation } from "@ui/components/ProcessAnimation/ProcessAnimation"
+import { getCanonicalTransaction } from "@ui/domains/Transactions/getCanonicalTransaction"
 import { type ReplacementCallbackArgs, TxReplaceActions } from "@ui/domains/Transactions/TxProgress"
 import { useAnyNetwork } from "@ui/state/chaindata"
 import { cn } from "@ui/util/cn"
 import { useLiveQuery } from "dexie-react-hooks"
 import { type FC, useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
+import { getSwapProgressDetails, type SwapStatusDetails } from "./swapProgressStatus"
 
 const getBlockExplorerUrl = (network: Network | undefined | null, hash: string) => {
   if (!network) return null
@@ -40,28 +34,21 @@ const getSwapTrackerUrl = (txInfo: WalletTransactionInfo, txHash: string): strin
   }
 }
 
-/** Non-suspending hook — uses Dexie's useLiveQuery (returns undefined while loading). */
-const useTransactionLocal = (hash: string): WalletTransaction | null | undefined =>
+/**
+ * Non-suspending hook — uses Dexie's useLiveQuery (returns undefined while loading).
+ * When the tracked tx lost a speed-up nonce race, resolves to the mined transaction.
+ */
+const useCanonicalTransaction = (hash: string): WalletTransaction | null | undefined =>
   useLiveQuery(async () => {
     if (!hash) return undefined
-    return (await db.transactionsV2.get(hash)) ?? null
+    return getCanonicalTransaction(hash)
   }, [hash])
 
-type SwapStatusDetails = {
-  title: string
-  subtitle: string
-  animStatus: ProcessAnimationStatus
-  pillLabel?: string
-}
-
 const useSwapProgressStatus = (
-  txHash: string,
+  tx: WalletTransaction | null | undefined,
   txInfo: WalletTransactionInfo
 ): SwapStatusDetails => {
   const { t } = useTranslation()
-
-  const tx = useTransactionLocal(txHash)
-  const swapStatus: SwapStatus | undefined = tx?.swapStatus
 
   const isCrossChain = useMemo(
     () =>
@@ -70,92 +57,10 @@ const useSwapProgressStatus = (
     [txInfo]
   )
 
-  return useMemo<SwapStatusDetails>(() => {
-    // Pill labels match the swap status labels used in TxHistoryList
-    const inProgress = (pillLabel: string): SwapStatusDetails => ({
-      title: t("Transaction in progress"),
-      subtitle: isCrossChain ? t("This may take a few minutes") : t("This may take a moment"),
-      animStatus: "processing",
-      pillLabel,
-    })
-
-    // Phase 1: On-chain tx is still pending/processing
-    if (!tx || tx.status === "pending") return inProgress(t("Submitting"))
-
-    // On-chain tx failed
-    if (tx.status === "error") {
-      return {
-        title: t("Transaction failed"),
-        subtitle: t("Your swap transaction failed on-chain."),
-        animStatus: "failure",
-      }
-    }
-
-    // On-chain tx status unknown
-    if (tx.status === "unknown") {
-      return {
-        title: t("Transaction not found"),
-        subtitle: t("Transaction was submitted, but Talisman is unable to track its progress."),
-        animStatus: "failure",
-      }
-    }
-
-    // On-chain tx replaced
-    if (tx.status === "replaced") {
-      return {
-        title: t("Transaction cancelled"),
-        subtitle: t("This transaction has been replaced with another one."),
-        animStatus: "failure",
-      }
-    }
-
-    // Phase 2: On-chain tx succeeded — track exchange/protocol status
-    switch (swapStatus) {
-      case "waiting":
-        return inProgress(t("Depositing funds"))
-      case "confirming":
-        return inProgress(t("Confirming"))
-      case "exchanging":
-        return inProgress(t("Exchanging"))
-      case "sending":
-        return inProgress(t("Sending"))
-      case "verifying":
-        return inProgress(t("Verifying"))
-      case "finished":
-        return {
-          title: t("Swap complete"),
-          subtitle: t("Your swap was successful!"),
-          animStatus: "success",
-        }
-      case "failed":
-      case "expired":
-      case "refunded":
-        return {
-          title: t("Swap failed"),
-          subtitle:
-            swapStatus === "refunded"
-              ? t("The exchange has refunded your tokens.")
-              : swapStatus === "expired"
-                ? t("The exchange has expired.")
-                : t("The exchange failed to complete your swap."),
-          animStatus: "failure",
-        }
-      case "invalid":
-        // LiFi's status API sometimes fails to parse transactions (especially Solana)
-        // even though the on-chain tx succeeded. Show an ambiguous status instead of
-        // a definitive "Swap failed" since the user's funds may have been swapped.
-        return {
-          title: t("Swap status unknown"),
-          subtitle: t(
-            "Your transaction succeeded on-chain but the swap tracker couldn't confirm the result. Please check your balance."
-          ),
-          animStatus: "failure",
-        }
-      default:
-        // Swap status not yet loaded — exchange hasn't seen the deposit yet
-        return inProgress(t("Depositing funds"))
-    }
-  }, [tx, swapStatus, isCrossChain, t])
+  return useMemo<SwapStatusDetails>(
+    () => getSwapProgressDetails(t, tx, isCrossChain),
+    [tx, isCrossChain, t]
+  )
 }
 
 const SwapStatusPill: FC<{ label: string | null | undefined }> = ({ label }) => (
@@ -186,9 +91,12 @@ export const SwapProgress: FC<SwapProgressProps> = ({
   onReplacementComplete,
 }) => {
   const { t } = useTranslation()
-  const { title, subtitle, animStatus, pillLabel } = useSwapProgressStatus(hash, txInfo)
 
-  const tx = useTransactionLocal(hash)
+  const tx = useCanonicalTransaction(hash)
+  // tx may point at the winning same-nonce tx after a lost speed-up race
+  const txHash = tx?.id ?? hash
+
+  const { title, subtitle, animStatus, pillLabel } = useSwapProgressStatus(tx, txInfo)
   const network = useAnyNetwork(networkId)
 
   const blockNumber = useMemo(() => {
@@ -197,8 +105,8 @@ export const SwapProgress: FC<SwapProgressProps> = ({
     return undefined
   }, [tx])
 
-  const explorerUrl = useMemo(() => getBlockExplorerUrl(network, hash), [network, hash])
-  const swapTrackerUrl = useMemo(() => getSwapTrackerUrl(txInfo, hash), [txInfo, hash])
+  const explorerUrl = useMemo(() => getBlockExplorerUrl(network, txHash), [network, txHash])
+  const swapTrackerUrl = useMemo(() => getSwapTrackerUrl(txInfo, txHash), [txInfo, txHash])
 
   const handleTrackClick = useCallback(() => {
     if (swapTrackerUrl) window.open(swapTrackerUrl, "_blank", "noopener")

--- a/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
@@ -17,6 +17,7 @@ import {
 } from "@ui/components/ProcessAnimation/ProcessAnimation"
 import { type ReplacementCallbackArgs, TxReplaceActions } from "@ui/domains/Transactions/TxProgress"
 import { useAnyNetwork } from "@ui/state/chaindata"
+import { cn } from "@ui/util/cn"
 import { useLiveQuery } from "dexie-react-hooks"
 import { type FC, useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
@@ -157,8 +158,13 @@ const useSwapProgressStatus = (
   }, [tx, swapStatus, isCrossChain, t])
 }
 
-const SwapStatusPill: FC<{ label: string }> = ({ label }) => (
-  <div className="inline-flex items-center gap-3 rounded-full bg-grey-800 px-6 py-3 text-primary text-xs">
+const SwapStatusPill: FC<{ label: string | null | undefined }> = ({ label }) => (
+  <div
+    className={cn(
+      "inline-flex items-center gap-3 rounded-full bg-grey-800 p-4 text-primary text-xs",
+      !label && "invisible"
+    )}
+  >
     <LoaderIcon className="animate-spin-slow text-sm" />
     <span>{label}</span>
   </div>
@@ -199,10 +205,10 @@ export const SwapProgress: FC<SwapProgressProps> = ({
   }, [swapTrackerUrl])
 
   return (
-    <div className="flex h-full w-full flex-col items-center p-12">
+    <div className="flex h-full w-full flex-col items-center overflow-hidden p-12">
       <div className="mt-8 font-bold text-body text-lg">{title}</div>
       <div className="mt-12 text-center font-light text-base text-body-secondary">{subtitle}</div>
-      <ProcessAnimation status={animStatus} className="mt-18.75 mb-8 h-36.25" />
+      <ProcessAnimation status={animStatus} className="mt-16 mb-8 h-36.25" />
       <div className="flex w-full grow flex-col items-center justify-center gap-8 px-10 text-center text-body-secondary">
         <div>
           {blockNumber ? (
@@ -233,10 +239,10 @@ export const SwapProgress: FC<SwapProgressProps> = ({
             </a>
           ) : null}
         </div>
-        {pillLabel && <SwapStatusPill label={pillLabel} />}
-        {tx && <TxReplaceActions tx={tx} onReplacementComplete={onReplacementComplete} />}
+        <SwapStatusPill label={pillLabel} />
+        <TxReplaceActions tx={tx} className="mt-0" onReplacementComplete={onReplacementComplete} />
       </div>
-      <div className="flex w-full flex-col gap-4">
+      <div className="flex w-full flex-col gap-4 pt-6">
         {swapTrackerUrl && (
           <Button primary fullWidth onClick={handleTrackClick}>
             {t("Track swap progress")}

--- a/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapProgress.tsx
@@ -46,13 +46,11 @@ const useTransactionLocal = (hash: string): WalletTransaction | null | undefined
     return (await db.transactionsV2.get(hash)) ?? null
   }, [hash])
 
-type SwapProgressPill = "confirming" | "swapping"
-
 type SwapStatusDetails = {
   title: string
   subtitle: string
   animStatus: ProcessAnimationStatus
-  pill?: SwapProgressPill
+  pillLabel?: string
 }
 
 const useSwapProgressStatus = (
@@ -72,15 +70,16 @@ const useSwapProgressStatus = (
   )
 
   return useMemo<SwapStatusDetails>(() => {
-    const inProgress = (pill: SwapProgressPill): SwapStatusDetails => ({
+    // Pill labels match the swap status labels used in TxHistoryList
+    const inProgress = (pillLabel: string): SwapStatusDetails => ({
       title: t("Transaction in progress"),
       subtitle: isCrossChain ? t("This may take a few minutes") : t("This may take a moment"),
       animStatus: "processing",
-      pill,
+      pillLabel,
     })
 
     // Phase 1: On-chain tx is still pending/processing
-    if (!tx || tx.status === "pending") return inProgress("confirming")
+    if (!tx || tx.status === "pending") return inProgress(t("Submitting"))
 
     // On-chain tx failed
     if (tx.status === "error") {
@@ -112,12 +111,15 @@ const useSwapProgressStatus = (
     // Phase 2: On-chain tx succeeded — track exchange/protocol status
     switch (swapStatus) {
       case "waiting":
+        return inProgress(t("Depositing funds"))
       case "confirming":
-        return inProgress("confirming")
+        return inProgress(t("Confirming"))
       case "exchanging":
+        return inProgress(t("Exchanging"))
       case "sending":
+        return inProgress(t("Sending"))
       case "verifying":
-        return inProgress("swapping")
+        return inProgress(t("Verifying"))
       case "finished":
         return {
           title: t("Swap complete"),
@@ -149,22 +151,18 @@ const useSwapProgressStatus = (
           animStatus: "failure",
         }
       default:
-        // Swap status not yet loaded — deposit is on-chain, exchange is processing
-        return inProgress("swapping")
+        // Swap status not yet loaded — exchange hasn't seen the deposit yet
+        return inProgress(t("Depositing funds"))
     }
   }, [tx, swapStatus, isCrossChain, t])
 }
 
-const SwapStatusPill: FC<{ pill: SwapProgressPill }> = ({ pill }) => {
-  const { t } = useTranslation()
-
-  return (
-    <div className="inline-flex items-center gap-3 rounded-full bg-grey-800 px-6 py-3 text-primary text-xs">
-      <LoaderIcon className="animate-spin-slow text-sm" />
-      <span>{pill === "confirming" ? t("Confirming") : t("Swapping")}</span>
-    </div>
-  )
-}
+const SwapStatusPill: FC<{ label: string }> = ({ label }) => (
+  <div className="inline-flex items-center gap-3 rounded-full bg-grey-800 px-6 py-3 text-primary text-xs">
+    <LoaderIcon className="animate-spin-slow text-sm" />
+    <span>{label}</span>
+  </div>
+)
 
 type SwapProgressProps = {
   hash: string
@@ -182,7 +180,7 @@ export const SwapProgress: FC<SwapProgressProps> = ({
   onReplacementComplete,
 }) => {
   const { t } = useTranslation()
-  const { title, subtitle, animStatus, pill } = useSwapProgressStatus(hash, txInfo)
+  const { title, subtitle, animStatus, pillLabel } = useSwapProgressStatus(hash, txInfo)
 
   const tx = useTransactionLocal(hash)
   const network = useAnyNetwork(networkId)
@@ -235,7 +233,7 @@ export const SwapProgress: FC<SwapProgressProps> = ({
             </a>
           ) : null}
         </div>
-        {pill && <SwapStatusPill pill={pill} />}
+        {pillLabel && <SwapStatusPill label={pillLabel} />}
         {tx && <TxReplaceActions tx={tx} onReplacementComplete={onReplacementComplete} />}
       </div>
       <div className="flex w-full flex-col gap-4">

--- a/apps/extension/src/ui/domains/Swap/components/SwapWizard.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapWizard.tsx
@@ -1,3 +1,5 @@
+import type { ReplacementCallbackArgs } from "@ui/domains/Transactions/TxProgress"
+import { useCallback } from "react"
 import { useSwapModal } from "../hooks/useSwapModal"
 import { useSwap } from "../SwapProvider"
 import { SwapConfirm } from "./SwapConfirm"
@@ -19,8 +21,18 @@ export const SwapWizard = () => {
 }
 
 const SwapSubmitted = () => {
-  const { submittedTxHash, submittedNetworkId, submittedTxInfo } = useSwap()
+  const { submittedTxHash, submittedNetworkId, submittedTxInfo, gotoSubmitted } = useSwap()
   const { close: closeSwapTokensModal } = useSwapModal()
+
+  // Follow speed-up replacements so tracking continues on the new hash.
+  // Cancels keep tracking the original hash, which flips to "replaced" (cancelled UI).
+  const handleReplacementComplete = useCallback(
+    ({ txId, networkId, replaceType }: ReplacementCallbackArgs) => {
+      if (replaceType !== "speed-up" || !submittedTxInfo) return
+      gotoSubmitted({ hash: txId, networkId, txInfo: submittedTxInfo })
+    },
+    [gotoSubmitted, submittedTxInfo]
+  )
 
   if (!submittedTxHash || !submittedNetworkId || !submittedTxInfo) return null
 
@@ -30,6 +42,7 @@ const SwapSubmitted = () => {
       networkId={submittedNetworkId}
       txInfo={submittedTxInfo}
       onClose={closeSwapTokensModal}
+      onReplacementComplete={handleReplacementComplete}
     />
   )
 }

--- a/apps/extension/src/ui/domains/Swap/components/SwapWizard.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapWizard.tsx
@@ -24,7 +24,9 @@ const SwapSubmitted = () => {
   const { submittedTxHash, submittedNetworkId, submittedTxInfo, gotoSubmitted } = useSwap()
   const { close: closeSwapTokensModal } = useSwapModal()
 
-  // Follow speed-up replacements so tracking continues on the new hash.
+  // Follow speed-up replacements so tracking continues on the new hash. If the
+  // original still wins the nonce race, SwapProgress redirects to the mined tx
+  // via getCanonicalTransaction.
   // Cancels keep tracking the original hash, which flips to "replaced" (cancelled UI).
   const handleReplacementComplete = useCallback(
     ({ txId, networkId, replaceType }: ReplacementCallbackArgs) => {

--- a/apps/extension/src/ui/domains/Swap/components/swapProgressStatus.test.ts
+++ b/apps/extension/src/ui/domains/Swap/components/swapProgressStatus.test.ts
@@ -1,0 +1,92 @@
+import type { SwapStatus, WalletTransactionEth } from "@core/domains/transactions/types"
+import { describe, expect, it } from "vitest"
+
+import { getSwapProgressDetails } from "./swapProgressStatus"
+
+const t = (key: string) => key
+
+const makeTx = (
+  status: WalletTransactionEth["status"],
+  swapStatus?: SwapStatus
+): WalletTransactionEth => ({
+  id: "0xaaaa000000000000000000000000000000000000000000000000000000000001",
+  platform: "ethereum",
+  networkId: "1",
+  account: "0x1111111111111111111111111111111111111111",
+  status,
+  confirmed: false,
+  payload: {},
+  hash: "0xaaaa000000000000000000000000000000000000000000000000000000000001",
+  nonce: 5,
+  timestamp: Date.now(),
+  swapStatus,
+})
+
+describe("getSwapProgressDetails", () => {
+  it("shows Submitting while the tx is loading", () => {
+    const details = getSwapProgressDetails(t, undefined, false)
+    expect(details.animStatus).toBe("processing")
+    expect(details.pillLabel).toBe("Submitting")
+  })
+
+  it("shows Submitting while the tx is pending", () => {
+    const details = getSwapProgressDetails(t, makeTx("pending"), false)
+    expect(details.animStatus).toBe("processing")
+    expect(details.pillLabel).toBe("Submitting")
+  })
+
+  it("shows Depositing funds while the swap status hasn't loaded", () => {
+    const details = getSwapProgressDetails(t, makeTx("success"), false)
+    expect(details.animStatus).toBe("processing")
+    expect(details.pillLabel).toBe("Depositing funds")
+  })
+
+  it("shows Depositing funds while the exchange hasn't seen the deposit (not_found)", () => {
+    const details = getSwapProgressDetails(t, makeTx("success", "not_found"), false)
+    expect(details.animStatus).toBe("processing")
+    expect(details.pillLabel).toBe("Depositing funds")
+  })
+
+  it("shows an ambiguous state when the tracker gave up (unknown)", () => {
+    const details = getSwapProgressDetails(t, makeTx("success", "unknown"), false)
+    expect(details.animStatus).toBe("failure")
+    expect(details.title).toBe("Swap status unknown")
+    expect(details.pillLabel).toBeUndefined()
+  })
+
+  it("shows an ambiguous state when the tracker couldn't parse the tx (invalid)", () => {
+    const details = getSwapProgressDetails(t, makeTx("success", "invalid"), false)
+    expect(details.animStatus).toBe("failure")
+    expect(details.title).toBe("Swap status unknown")
+  })
+
+  it("shows success when the swap finished", () => {
+    const details = getSwapProgressDetails(t, makeTx("success", "finished"), false)
+    expect(details.animStatus).toBe("success")
+    expect(details.title).toBe("Swap complete")
+  })
+
+  it("shows failure when the exchange failed the swap", () => {
+    const details = getSwapProgressDetails(t, makeTx("success", "failed"), false)
+    expect(details.animStatus).toBe("failure")
+    expect(details.title).toBe("Swap failed")
+  })
+
+  it("shows cancelled when the tx was replaced", () => {
+    const details = getSwapProgressDetails(t, makeTx("replaced"), false)
+    expect(details.animStatus).toBe("failure")
+    expect(details.title).toBe("Transaction cancelled")
+  })
+
+  it("shows failure when the tx failed on-chain", () => {
+    const details = getSwapProgressDetails(t, makeTx("error"), false)
+    expect(details.animStatus).toBe("failure")
+    expect(details.title).toBe("Transaction failed")
+  })
+
+  it("shows not found when the tx status is unknown", () => {
+    const details = getSwapProgressDetails(t, makeTx("unknown"), false)
+    expect(details.animStatus).toBe("failure")
+    expect(details.title).toBe("Transaction not found")
+  })
+})

--- a/apps/extension/src/ui/domains/Swap/components/swapProgressStatus.ts
+++ b/apps/extension/src/ui/domains/Swap/components/swapProgressStatus.ts
@@ -1,0 +1,111 @@
+import type { WalletTransaction } from "@core/domains/transactions/types"
+import type { ProcessAnimationStatus } from "@ui/components/ProcessAnimation/ProcessAnimation"
+
+export type SwapStatusDetails = {
+  title: string
+  subtitle: string
+  animStatus: ProcessAnimationStatus
+  pillLabel?: string
+}
+
+type Translator = (key: string) => string
+
+export const getSwapProgressDetails = (
+  t: Translator,
+  tx: WalletTransaction | null | undefined,
+  isCrossChain: boolean
+): SwapStatusDetails => {
+  // Pill labels match the swap status labels used in TxHistoryList
+  const inProgress = (pillLabel: string): SwapStatusDetails => ({
+    title: t("Transaction in progress"),
+    subtitle: isCrossChain ? t("This may take a few minutes") : t("This may take a moment"),
+    animStatus: "processing",
+    pillLabel,
+  })
+
+  // Phase 1: On-chain tx is still pending/processing
+  if (!tx || tx.status === "pending") return inProgress(t("Submitting"))
+
+  // On-chain tx failed
+  if (tx.status === "error") {
+    return {
+      title: t("Transaction failed"),
+      subtitle: t("Your swap transaction failed on-chain."),
+      animStatus: "failure",
+    }
+  }
+
+  // On-chain tx status unknown
+  if (tx.status === "unknown") {
+    return {
+      title: t("Transaction not found"),
+      subtitle: t("Transaction was submitted, but Talisman is unable to track its progress."),
+      animStatus: "failure",
+    }
+  }
+
+  // On-chain tx replaced (getCanonicalTransaction already redirected speed-ups
+  // to the mined transaction, so this means the swap was genuinely cancelled)
+  if (tx.status === "replaced") {
+    return {
+      title: t("Transaction cancelled"),
+      subtitle: t("This transaction has been replaced with another one."),
+      animStatus: "failure",
+    }
+  }
+
+  // Phase 2: On-chain tx succeeded — track exchange/protocol status
+  switch (tx.swapStatus) {
+    case "waiting":
+      return inProgress(t("Depositing funds"))
+    case "confirming":
+      return inProgress(t("Confirming"))
+    case "exchanging":
+      return inProgress(t("Exchanging"))
+    case "sending":
+      return inProgress(t("Sending"))
+    case "verifying":
+      return inProgress(t("Verifying"))
+    case "finished":
+      return {
+        title: t("Swap complete"),
+        subtitle: t("Your swap was successful!"),
+        animStatus: "success",
+      }
+    case "failed":
+    case "expired":
+    case "refunded":
+      return {
+        title: t("Swap failed"),
+        subtitle:
+          tx.swapStatus === "refunded"
+            ? t("The exchange has refunded your tokens.")
+            : tx.swapStatus === "expired"
+              ? t("The exchange has expired.")
+              : t("The exchange failed to complete your swap."),
+        animStatus: "failure",
+      }
+    case "invalid":
+    case "unknown":
+      // invalid: LiFi's status API sometimes fails to parse transactions (especially Solana)
+      // even though the on-chain tx succeeded.
+      // unknown: the watcher gave up after repeated fetch failures or an expired
+      // not-found grace period.
+      // Both are ambiguous — the user's funds may have been swapped, so don't show
+      // a definitive "Swap failed".
+      return {
+        title: t("Swap status unknown"),
+        subtitle: t(
+          "Your transaction succeeded on-chain but the swap tracker couldn't confirm the result. Please check your balance."
+        ),
+        animStatus: "failure",
+      }
+    case "not_found":
+      // Exchange hasn't seen the deposit yet — the watcher flips this to "unknown"
+      // if it stays not found past the grace period
+      return inProgress(t("Depositing funds"))
+    default:
+      // Swap status not yet loaded — exchange hasn't seen the deposit yet
+      return inProgress(t("Depositing funds"))
+  }
+}

--- a/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryModal.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxHistory/TxHistoryModal.tsx
@@ -26,6 +26,8 @@ import { TxHistoryDetailsTokens } from "./TxHistoryDetails/TxHistoryDetailsToken
 import { TxHistoryDetailsTxInfo } from "./TxHistoryDetails/TxHistoryDetailsTxInfo"
 import { TxHistoryDetailsUrl } from "./TxHistoryDetails/TxHistoryDetailsUrl"
 
+const TX_HISTORY_MODAL_CONTAINER_ID = "tx-history-modal"
+
 type TxHistoryModalProps = {
   tx?: WalletTransaction
   isOpen: boolean
@@ -73,8 +75,9 @@ const DialogWrapper: FC<{ tx: WalletTransaction; onClose: () => void; children: 
   const { t } = useTranslation()
   return (
     <ModalDialog
+      id={TX_HISTORY_MODAL_CONTAINER_ID}
       title={t("Transaction Details")}
-      className={cn("h-150 w-100", tx.status === "pending" && "[&_header]:invisible")}
+      className={cn("relative h-150 w-100", tx.status === "pending" && "[&_header]:invisible")}
       onClose={onClose}
     >
       {children}
@@ -94,6 +97,7 @@ const ModalContent: FC<{
           hash={getTransactionId(tx)}
           onClose={onClose}
           networkIdOrHash={tx.networkId}
+          containerId={TX_HISTORY_MODAL_CONTAINER_ID}
           onReplacementComplete={onReplacementComplete}
         />
       )

--- a/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
@@ -34,12 +34,14 @@ export type ReplacementCallbackArgs = {
 type TxReplaceActionsProps = {
   tx: WalletTransaction | null | undefined
   className?: string
+  containerId?: string
   onReplacementComplete?: (args: ReplacementCallbackArgs) => void
 }
 
 export const TxReplaceActions: FC<TxReplaceActionsProps> = ({
   tx,
   className,
+  containerId,
   onReplacementComplete,
 }) => {
   const { t } = useTranslation()
@@ -92,7 +94,14 @@ export const TxReplaceActions: FC<TxReplaceActionsProps> = ({
           {t("Cancel Transaction")}
         </PillButton>
       </div>
-      {!!tx && <TxReplaceDrawer tx={tx} type={replaceType} onClose={handleClose} />}
+      {!!tx && (
+        <TxReplaceDrawer
+          tx={tx}
+          type={replaceType}
+          containerId={containerId}
+          onClose={handleClose}
+        />
+      )}
     </>
   )
 }
@@ -172,6 +181,7 @@ type TxProgressBaseProps = {
   blockNumber?: string
   onClose?: () => void
   href?: string | null
+  containerId?: string
   onReplacementComplete?: (args: ReplacementCallbackArgs) => void
 }
 
@@ -180,6 +190,7 @@ const TxProgressBase: FC<TxProgressBaseProps> = ({
   blockNumber,
   href,
   onClose,
+  containerId,
   onReplacementComplete,
 }) => {
   const { t } = useTranslation()
@@ -225,7 +236,11 @@ const TxProgressBase: FC<TxProgressBaseProps> = ({
         </div>
         <div className="h-[2.25rem]">
           {tx?.status === "pending" && (
-            <TxReplaceActions tx={tx} onReplacementComplete={onReplacementComplete} />
+            <TxReplaceActions
+              tx={tx}
+              containerId={containerId}
+              onReplacementComplete={onReplacementComplete}
+            />
           )}
           {tx?.status === "success" && !tx?.confirmed && (
             <div className="h-[2.25rem] animate-pulse text-secondary">
@@ -245,6 +260,7 @@ type TxProgressDotProps = {
   tx: WalletTransactionDot
   onClose?: () => void
   className?: string
+  containerId?: string
   onReplacementComplete?: (args: ReplacementCallbackArgs) => void
 }
 
@@ -252,6 +268,7 @@ const TxProgressDot: FC<TxProgressDotProps> = ({
   tx,
   onClose,
   className,
+  containerId,
   onReplacementComplete,
 }) => {
   const chain = useNetworkById(tx.networkId)
@@ -264,6 +281,7 @@ const TxProgressDot: FC<TxProgressDotProps> = ({
       onClose={onClose}
       blockNumber={tx.blockNumber}
       href={href}
+      containerId={containerId}
       onReplacementComplete={onReplacementComplete}
     />
   )
@@ -273,6 +291,7 @@ type TxProgressEthProps = {
   tx: WalletTransactionEth
   onClose?: () => void
   className?: string
+  containerId?: string
   onReplacementComplete?: (args: ReplacementCallbackArgs) => void
 }
 
@@ -280,6 +299,7 @@ const TxProgressEth: FC<TxProgressEthProps> = ({
   tx,
   className,
   onClose,
+  containerId,
   onReplacementComplete,
 }) => {
   const network = useNetworkById(tx.networkId, "ethereum")
@@ -292,6 +312,7 @@ const TxProgressEth: FC<TxProgressEthProps> = ({
       onClose={onClose}
       blockNumber={tx.blockNumber}
       href={href}
+      containerId={containerId}
       onReplacementComplete={onReplacementComplete}
     />
   )
@@ -315,6 +336,7 @@ type TxProgressProps = {
   networkIdOrHash: string
   onClose?: () => void
   className?: string
+  containerId?: string
   onReplacementComplete?: (args: ReplacementCallbackArgs) => void
 }
 
@@ -323,6 +345,7 @@ export const TxProgress: FC<TxProgressProps> = ({
   networkIdOrHash,
   onClose,
   className,
+  containerId,
   onReplacementComplete,
 }) => {
   const tx = useTransaction(hash)
@@ -336,6 +359,7 @@ export const TxProgress: FC<TxProgressProps> = ({
         href={href}
         className={className}
         onClose={onClose}
+        containerId={containerId}
         onReplacementComplete={onReplacementComplete}
       />
     )
@@ -348,6 +372,7 @@ export const TxProgress: FC<TxProgressProps> = ({
           tx={tx}
           onClose={onClose}
           className={className}
+          containerId={containerId}
           onReplacementComplete={onReplacementComplete}
         />
       )
@@ -357,6 +382,7 @@ export const TxProgress: FC<TxProgressProps> = ({
           tx={tx}
           onClose={onClose}
           className={className}
+          containerId={containerId}
           onReplacementComplete={onReplacementComplete}
         />
       )

--- a/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
@@ -15,9 +15,9 @@ import {
 } from "@ui/components/ProcessAnimation/ProcessAnimation"
 import { useAnyNetwork, useNetworkById } from "@ui/state/chaindata"
 import { useTransaction } from "@ui/state/transactions"
+import { cn } from "@ui/util/cn"
 import { type FC, useCallback, useMemo, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
-
 import { TxReplaceDrawer } from "./TxReplaceDrawer"
 import type { TxReplaceType } from "./types"
 
@@ -32,11 +32,16 @@ export type ReplacementCallbackArgs = {
 }
 
 type TxReplaceActionsProps = {
-  tx: WalletTransaction
+  tx: WalletTransaction | null | undefined
+  className?: string
   onReplacementComplete?: (args: ReplacementCallbackArgs) => void
 }
 
-export const TxReplaceActions: FC<TxReplaceActionsProps> = ({ tx, onReplacementComplete }) => {
+export const TxReplaceActions: FC<TxReplaceActionsProps> = ({
+  tx,
+  className,
+  onReplacementComplete,
+}) => {
   const { t } = useTranslation()
   const [replaceType, setReplaceType] = useState<TxReplaceType>()
 
@@ -45,21 +50,31 @@ export const TxReplaceActions: FC<TxReplaceActionsProps> = ({ tx, onReplacementC
   const handleClose = useCallback(
     (newHash?: HexString) => {
       setReplaceType(undefined)
-      if (newHash && replaceType) {
+      if (newHash && replaceType && tx) {
         onReplacementComplete?.({ txId: newHash, networkId: tx.networkId, replaceType })
       }
     },
     [onReplacementComplete, tx, replaceType]
   )
 
-  const evmNetwork = useNetworkById(tx.networkId, "ethereum")
+  const evmNetwork = useNetworkById(tx?.networkId, "ethereum")
 
-  if (evmNetwork?.preserveGasEstimate) return null
-  if (tx.status !== "pending" || tx.platform !== "ethereum") return null
+  const isInvisible = useMemo(() => {
+    if (!tx) return true
+    if (evmNetwork?.preserveGasEstimate) return true
+    if (tx.status !== "pending" || tx.platform !== "ethereum") return true
+    return false
+  }, [tx, evmNetwork])
 
   return (
     <>
-      <div className="mt-8 flex w-full items-center justify-center gap-4">
+      <div
+        className={cn(
+          "mt-8 flex w-full items-center justify-center gap-4",
+          className,
+          isInvisible && "invisible"
+        )}
+      >
         <PillButton
           size="sm"
           onClick={handleShowDrawer("speed-up")}
@@ -77,7 +92,7 @@ export const TxReplaceActions: FC<TxReplaceActionsProps> = ({ tx, onReplacementC
           {t("Cancel Transaction")}
         </PillButton>
       </div>
-      <TxReplaceDrawer tx={tx} type={replaceType} onClose={handleClose} />
+      {!!tx && <TxReplaceDrawer tx={tx} type={replaceType} onClose={handleClose} />}
     </>
   )
 }

--- a/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxProgress.tsx
@@ -25,14 +25,18 @@ const getBlockExplorerUrl = (network: Network | undefined | null, hash: string) 
   if (!network) return null
   return getBlockExplorerUrls(network, { type: "transaction", id: hash })[0] ?? null
 }
-export type ReplacementCallbackArgs = { txId: `0x${string}`; networkId: string }
+export type ReplacementCallbackArgs = {
+  txId: `0x${string}`
+  networkId: string
+  replaceType: TxReplaceType
+}
 
 type TxReplaceActionsProps = {
   tx: WalletTransaction
   onReplacementComplete?: (args: ReplacementCallbackArgs) => void
 }
 
-const TxReplaceActions: FC<TxReplaceActionsProps> = ({ tx, onReplacementComplete }) => {
+export const TxReplaceActions: FC<TxReplaceActionsProps> = ({ tx, onReplacementComplete }) => {
   const { t } = useTranslation()
   const [replaceType, setReplaceType] = useState<TxReplaceType>()
 
@@ -41,11 +45,11 @@ const TxReplaceActions: FC<TxReplaceActionsProps> = ({ tx, onReplacementComplete
   const handleClose = useCallback(
     (newHash?: HexString) => {
       setReplaceType(undefined)
-      if (newHash) {
-        onReplacementComplete?.({ txId: newHash, networkId: tx.networkId })
+      if (newHash && replaceType) {
+        onReplacementComplete?.({ txId: newHash, networkId: tx.networkId, replaceType })
       }
     },
-    [onReplacementComplete, tx]
+    [onReplacementComplete, tx, replaceType]
   )
 
   const evmNetwork = useNetworkById(tx.networkId, "ethereum")

--- a/apps/extension/src/ui/domains/Transactions/TxReplaceDrawer.tsx
+++ b/apps/extension/src/ui/domains/Transactions/TxReplaceDrawer.tsx
@@ -37,6 +37,7 @@ const ANALYTICS_PAGE: AnalyticsPage = {
 type TxReplaceDrawerProps = {
   tx?: WalletTransaction
   type?: TxReplaceType // will open if set
+  containerId?: string
   onClose?: (newTxHash?: HexString) => void
 }
 
@@ -281,7 +282,7 @@ const EvmDrawerContent: FC<{
             onSigned={handleSendSigned}
             onCancel={() => onClose?.()}
             onSentToDevice={handleSentToDevice}
-            containerId="main"
+            containerId={containerId ?? "main"}
           />
         </div>
       ) : (
@@ -306,14 +307,14 @@ const EvmDrawerContent: FC<{
   )
 }
 
-export const TxReplaceDrawer: FC<TxReplaceDrawerProps> = ({ tx, type, onClose }) => {
+export const TxReplaceDrawer: FC<TxReplaceDrawerProps> = ({ tx, type, containerId, onClose }) => {
   const inputs = useMemo(() => (tx && type ? { tx, type } : undefined), [tx, type])
   const { isOpenReady, data } = useOpenCloseWithData(!!inputs, inputs)
 
   // can't use a drawer in dashbaord, render a modal instead
   if (!IS_POPUP) {
     return (
-      <Modal isOpen={isOpenReady} anchor="center" onDismiss={onClose}>
+      <Modal isOpen={isOpenReady} anchor="center" containerId={containerId} onDismiss={onClose}>
         <div
           id="tx-main"
           className="flex h-150 max-h-dvh w-100 max-w-dvw flex-col items-center overflow-hidden rounded border border-grey-850 bg-black p-12"
@@ -336,12 +337,17 @@ export const TxReplaceDrawer: FC<TxReplaceDrawerProps> = ({ tx, type, onClose })
     <Drawer
       isOpen={isOpenReady}
       anchor="bottom"
-      containerId="main"
+      containerId={containerId ?? "main"}
       onDismiss={onClose}
       className="flex w-full flex-col items-center rounded-t-xl bg-grey-800 p-12"
     >
       {data?.type && data?.tx?.platform === "ethereum" ? (
-        <EvmDrawerContent tx={data.tx} type={data.type} onClose={onClose} />
+        <EvmDrawerContent
+          containerId={containerId}
+          tx={data.tx}
+          type={data.type}
+          onClose={onClose}
+        />
       ) : null}
     </Drawer>
   )

--- a/apps/extension/src/ui/domains/Transactions/getCanonicalTransaction.test.ts
+++ b/apps/extension/src/ui/domains/Transactions/getCanonicalTransaction.test.ts
@@ -1,0 +1,160 @@
+import { db } from "@core/db"
+import type { WalletTransactionEth } from "@core/domains/transactions/types"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { getCanonicalTransaction } from "./getCanonicalTransaction"
+
+const ACCOUNT = "0x1111111111111111111111111111111111111111" as `0x${string}`
+const OTHER_ACCOUNT = "0x2222222222222222222222222222222222222222" as `0x${string}`
+const ROUTER = "0x9999999999999999999999999999999999999999" as `0x${string}`
+const NETWORK_ID = "1"
+
+const HASH_ORIGINAL = "0xaaaa000000000000000000000000000000000000000000000000000000000001"
+const HASH_REPLACEMENT = "0xbbbb000000000000000000000000000000000000000000000000000000000002"
+
+const makeEvmTx = (
+  hash: string,
+  status: WalletTransactionEth["status"],
+  {
+    account = ACCOUNT,
+    networkId = NETWORK_ID,
+    nonce = 5,
+    isReplacement = false,
+    to = ROUTER,
+    value = "0xde0b6b3a7640000",
+    // null = omit the data field, as with real cancel transactions
+    data = "0x12345678" as `0x${string}` | null,
+  }: Partial<{
+    account: `0x${string}`
+    networkId: string
+    nonce: number
+    isReplacement: boolean
+    to: `0x${string}`
+    value: string
+    data: `0x${string}` | null
+  }> = {}
+): WalletTransactionEth => ({
+  id: hash,
+  platform: "ethereum",
+  networkId,
+  account,
+  status,
+  confirmed: false,
+  payload: { from: account, nonce, to, value, ...(data === null ? {} : { data }) },
+  hash: hash as `0x${string}`,
+  nonce,
+  isReplacement,
+  timestamp: Date.now(),
+})
+
+describe("getCanonicalTransaction", () => {
+  beforeEach(async () => {
+    await db.transactionsV2.clear()
+  })
+
+  it("returns null for an unknown hash", async () => {
+    expect(await getCanonicalTransaction(HASH_ORIGINAL)).toBeNull()
+  })
+
+  it("returns the tx as-is when pending", async () => {
+    await db.transactionsV2.put(makeEvmTx(HASH_ORIGINAL, "pending"))
+
+    const tx = await getCanonicalTransaction(HASH_ORIGINAL)
+    expect(tx?.id).toBe(HASH_ORIGINAL)
+    expect(tx?.status).toBe("pending")
+  })
+
+  it("returns the tx as-is when success", async () => {
+    await db.transactionsV2.put(makeEvmTx(HASH_ORIGINAL, "success"))
+
+    const tx = await getCanonicalTransaction(HASH_ORIGINAL)
+    expect(tx?.id).toBe(HASH_ORIGINAL)
+    expect(tx?.status).toBe("success")
+  })
+
+  it("follows the mined speed-up when the original was replaced", async () => {
+    await db.transactionsV2.put(makeEvmTx(HASH_ORIGINAL, "replaced"))
+    await db.transactionsV2.put(makeEvmTx(HASH_REPLACEMENT, "success", { isReplacement: true }))
+
+    const tx = await getCanonicalTransaction(HASH_ORIGINAL)
+    expect(tx?.id).toBe(HASH_REPLACEMENT)
+    expect(tx?.status).toBe("success")
+  })
+
+  it("follows the mined original when the speed-up lost the nonce race", async () => {
+    await db.transactionsV2.put(makeEvmTx(HASH_ORIGINAL, "success"))
+    await db.transactionsV2.put(makeEvmTx(HASH_REPLACEMENT, "replaced", { isReplacement: true }))
+
+    const tx = await getCanonicalTransaction(HASH_REPLACEMENT)
+    expect(tx?.id).toBe(HASH_ORIGINAL)
+    expect(tx?.status).toBe("success")
+  })
+
+  it("follows the mined speed-up even when it failed on-chain", async () => {
+    await db.transactionsV2.put(makeEvmTx(HASH_ORIGINAL, "replaced"))
+    await db.transactionsV2.put(makeEvmTx(HASH_REPLACEMENT, "error", { isReplacement: true }))
+
+    const tx = await getCanonicalTransaction(HASH_ORIGINAL)
+    expect(tx?.id).toBe(HASH_REPLACEMENT)
+    expect(tx?.status).toBe("error")
+  })
+
+  it("keeps the replaced status when the winner is a cancel", async () => {
+    await db.transactionsV2.put(makeEvmTx(HASH_ORIGINAL, "replaced"))
+    await db.transactionsV2.put(
+      makeEvmTx(HASH_REPLACEMENT, "success", {
+        isReplacement: true,
+        to: ACCOUNT,
+        value: "0x0",
+        data: null,
+      })
+    )
+
+    const tx = await getCanonicalTransaction(HASH_ORIGINAL)
+    expect(tx?.id).toBe(HASH_ORIGINAL)
+    expect(tx?.status).toBe("replaced")
+  })
+
+  it("does not mistake a zero-value speed-up with calldata for a cancel", async () => {
+    // ERC-20 swaps have value 0 but carry calldata — only a bare self-transfer is a cancel
+    await db.transactionsV2.put(makeEvmTx(HASH_ORIGINAL, "replaced"))
+    await db.transactionsV2.put(
+      makeEvmTx(HASH_REPLACEMENT, "success", { isReplacement: true, value: "0x0" })
+    )
+
+    const tx = await getCanonicalTransaction(HASH_ORIGINAL)
+    expect(tx?.id).toBe(HASH_REPLACEMENT)
+  })
+
+  it("keeps the replaced status when no same-nonce tx has mined", async () => {
+    await db.transactionsV2.put(makeEvmTx(HASH_ORIGINAL, "replaced"))
+    await db.transactionsV2.put(makeEvmTx(HASH_REPLACEMENT, "pending", { isReplacement: true }))
+
+    const tx = await getCanonicalTransaction(HASH_ORIGINAL)
+    expect(tx?.id).toBe(HASH_ORIGINAL)
+    expect(tx?.status).toBe("replaced")
+  })
+
+  it("ignores mined txs from other accounts, nonces or networks", async () => {
+    await db.transactionsV2.put(makeEvmTx(HASH_ORIGINAL, "replaced"))
+    await db.transactionsV2.put(
+      makeEvmTx("0xcccc000000000000000000000000000000000000000000000000000000000003", "success", {
+        account: OTHER_ACCOUNT,
+      })
+    )
+    await db.transactionsV2.put(
+      makeEvmTx("0xdddd000000000000000000000000000000000000000000000000000000000004", "success", {
+        nonce: 6,
+      })
+    )
+    await db.transactionsV2.put(
+      makeEvmTx("0xeeee000000000000000000000000000000000000000000000000000000000005", "success", {
+        networkId: "137",
+      })
+    )
+
+    const tx = await getCanonicalTransaction(HASH_ORIGINAL)
+    expect(tx?.id).toBe(HASH_ORIGINAL)
+    expect(tx?.status).toBe("replaced")
+  })
+})

--- a/apps/extension/src/ui/domains/Transactions/getCanonicalTransaction.ts
+++ b/apps/extension/src/ui/domains/Transactions/getCanonicalTransaction.ts
@@ -1,0 +1,38 @@
+import { db } from "@core/db"
+import type { WalletTransaction, WalletTransactionEth } from "@core/domains/transactions/types"
+import { isAddressEqual } from "@talismn/crypto"
+
+// A cancel is a zero-value self-transfer with no calldata. Speed-ups keep the
+// original calldata, so ERC-20 transactions (value 0) are not mistaken for cancels.
+const isCancelTransaction = (tx: WalletTransactionEth) =>
+  !!tx.isReplacement &&
+  !!tx.payload.to &&
+  isAddressEqual(tx.payload.to, tx.account) &&
+  (!tx.payload.data || tx.payload.data === "0x")
+
+/**
+ * Resolves the transaction that actually carried out the tracked intent.
+ *
+ * After a speed-up, the original and the replacement compete for the same nonce
+ * and either can mine. If the tracked hash lost that race, follow the same-nonce
+ * transaction that mined instead — unless it's a cancel, in which case the
+ * "replaced" status is the genuine outcome.
+ */
+export const getCanonicalTransaction = async (hash: string): Promise<WalletTransaction | null> => {
+  const tx = (await db.transactionsV2.get(hash)) ?? null
+  if (tx?.platform !== "ethereum" || tx.status !== "replaced") return tx
+
+  const winner = await db.transactionsV2
+    .filter(
+      (row) =>
+        row.platform === "ethereum" &&
+        row.id !== tx.id &&
+        row.networkId === tx.networkId &&
+        row.nonce === tx.nonce &&
+        ["success", "error"].includes(row.status) &&
+        isAddressEqual(row.account, tx.account)
+    )
+    .first()
+
+  return winner?.platform === "ethereum" && !isCancelTransaction(winner) ? winner : tx
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/f3443ed2-528b-4bfb-8026-9011fbb1cbbb

Also hardens EVM speed-up/cancel handling for swaps:
- Speed-up: progress follows the new hash, and falls back to whichever same-nonce tx actually mines if the original wins the race (`getCanonicalTransaction`) — no more false "cancelled" state.
- Cancel: keeps tracking the original hash, which flips to "replaced" → cancelled UI (a mined cancel is never mistaken for a speed-up, and vice versa).
- Tx watcher now hash-gates receipts so a losing replacement can't be marked successful, and swap tracking only starts for the tx that mined.
- Degraded tracker states (`not_found` past grace, `unknown`) surface as "Swap status unknown" instead of an endless "Depositing funds" spinner.

Late fix — speed-up/cancel drawers were unreachable or escaping their modal:
- In popup, the replace drawer portaled into `#main` below the overlaying modal (z-order) → clicking Speed Up/Cancel appeared to do nothing.
- `containerId` is now threaded through `TxProgress`/`TxReplaceActions`/`TxReplaceDrawer` so the drawer (and nested fee select/Ledger drawers) render inside the parent modal: swap, tx history and Seek staking modals. Defaults unchanged everywhere else.
