### PR TITLE
💄 Rename claim rewards label

### DIFF
--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorClaimRewardsRow.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorClaimRewardsRow.tsx
@@ -35,7 +35,7 @@ export const BittensorClaimRewardsRow = () => {
 
   return (
     <div className="flex items-center justify-between gap-8 text-xs">
-      <div className="whitespace-nowrap">{t("Claim pending rewards")}</div>
+      <div className="whitespace-nowrap">{t("Claim rewards")}</div>
       <div className="flex items-center gap-4 overflow-hidden">
         <TokensAndFiat
           isBalance


### PR DESCRIPTION
## Summary
- Rename the pending rewards label to “Claim rewards” in the Bittensor bond modal.

## Testing
- Not run (label-only change).