### PR TITLE
💄 Substrate sign summary improvements

### DIFF
--- a/apps/extension/src/ui/apps/popup/pages/Sign/substrate/FooterContent.tsx
+++ b/apps/extension/src/ui/apps/popup/pages/Sign/substrate/FooterContent.tsx
@@ -11,6 +11,7 @@ import { SignHardwareSubstrate } from "@ui/domains/Sign/SignHardwareSubstrate"
 import { usePolkadotSigningRequest } from "@ui/domains/Sign/SignRequestContext"
 import { SignSignetSubstrate } from "@ui/domains/Sign/SignSignetSubstrate"
 import { getMultiLocationTokenId } from "@ui/domains/Sign/Substrate/util/getMultiLocationTokenId"
+import { getPayloadTip } from "@ui/domains/Sign/Substrate/util/getPayloadTip"
 import { useBalancesByParams } from "@ui/hooks/useBalancesByParams"
 import { useTokensMap } from "@ui/state/chaindata"
 import { uniq } from "lodash-es"
@@ -148,12 +149,15 @@ const EstimatedFeesRow: FC = () => {
     chain,
     errorDecodingExtrinsic,
     signingRequest,
+    payload,
     dryRun,
     dryRunIsLoading,
   } = usePolkadotSigningRequest()
   const tokens = useTokensMap()
 
   const feeToken = useFeeToken(chain?.nativeTokenId)
+
+  const tip = useMemo(() => getPayloadTip(payload), [payload])
 
   const deliveryFees = useMemo<FeeDetails[]>(() => {
     if (!chain?.nativeTokenId || !dryRun?.ok || !dryRun.data.success) return []
@@ -223,8 +227,22 @@ const EstimatedFeesRow: FC = () => {
           ]
         : []
 
-    return [...deliveryFeesWithBalances, ...executionFee]
-  }, [deliveryFees, fee, feeToken?.id, t, allBalances])
+    const tipFee =
+      tip > 0n && feeToken?.id
+        ? [
+            {
+              label: t("Tip:"),
+              plancks: tip,
+              tokenId: feeToken.id,
+              balance:
+                allBalances.balances.find({ tokenId: feeToken.id }).each[0]?.transferable.planck ??
+                null,
+            },
+          ]
+        : []
+
+    return [...deliveryFeesWithBalances, ...executionFee, ...tipFee]
+  }, [deliveryFees, fee, feeToken?.id, t, allBalances, tip])
 
   const estimatedFee = useMemo(
     () =>

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/SummaryAssetConversion.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/SummaryAssetConversion.tsx
@@ -26,9 +26,15 @@ const SwapExactTokensForTokens: DecodedCallSummaryComponent<
 
   const [tokenIn, tokenOut] = useMemo(() => {
     if (!chain) throw new Error("Missing data")
+
+    // the path may route through intermediate pools: `amount_out_min` is denominated in its last hop
+    const [locationIn] = decodedCall.args.path
+    const locationOut = decodedCall.args.path.at(-1)
+    if (!locationIn || !locationOut) throw new Error("Missing data")
+
     return [
-      getTokenFromlocation(chain, tokens, decodedCall.args.path[0]),
-      getTokenFromlocation(chain, tokens, decodedCall.args.path[1]),
+      getTokenFromlocation(chain, tokens, locationIn),
+      getTokenFromlocation(chain, tokens, locationOut),
     ]
   }, [chain, decodedCall.args.path, tokens])
 

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/SummaryAssetConversion.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/SummaryAssetConversion.tsx
@@ -6,20 +6,27 @@ import type {
   SubNativeToken,
   Token,
 } from "@talismn/chaindata-provider"
+import { isAddressEqual } from "@talismn/crypto"
 import { papiStringify } from "@talismn/scale"
 import { useNetworkById, useTokens } from "@ui/state/chaindata"
 import { useMemo } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
 import type { DecodedCallSummaryComponent, DecodedCallSummaryComponentDefs } from "../../types"
-import { SummaryContainer, SummaryContent } from "../shared/SummaryContainer"
+import { SummaryAddressDisplay } from "../shared/SummaryAddressDisplay"
+import {
+  SummaryAlert,
+  SummaryContainer,
+  SummaryContent,
+  SummarySeparator,
+} from "../shared/SummaryContainer"
 import { SummaryLineBreak } from "../shared/SummaryLineBreak"
 import { SummaryTokenSymbolDisplay } from "../shared/SummaryTokenSymbolDisplay"
 import { SummaryTokensAndFiat } from "../shared/SummaryTokensAndFiat"
 
 const SwapExactTokensForTokens: DecodedCallSummaryComponent<
   PolkadotAssetHubCalls["AssetConversion"]["swap_exact_tokens_for_tokens"]
-> = ({ decodedCall, sapi, mode }) => {
+> = ({ decodedCall, sapi, payload, mode }) => {
   const { t } = useTranslation()
   const chain = useNetworkById(sapi.chainId, "polkadot")
   const tokens = useTokens()
@@ -40,6 +47,9 @@ const SwapExactTokensForTokens: DecodedCallSummaryComponent<
 
   if (!tokenIn?.id || !tokenOut?.id || !chain) throw new Error("Missing data")
 
+  const recipient = decodedCall.args.send_to
+  const isSelfRecipient = isAddressEqual(recipient, payload.address)
+
   if (mode === "compact")
     return (
       <Trans
@@ -54,8 +64,9 @@ const SwapExactTokensForTokens: DecodedCallSummaryComponent<
           ),
           LineBreak: <SummaryLineBreak mode={mode} />,
           TokensOut: <SummaryTokenSymbolDisplay tokenId={tokenOut.id} />,
+          Recipient: <SummaryAddressDisplay address={recipient} networkId={chain.id} mode={mode} />,
         }}
-        defaults="Swap <TokensIn /><LineBreak /> for <TokensOut />"
+        defaults="Swap <TokensIn /><LineBreak /> for <TokensOut /> to <Recipient />"
       />
     )
 
@@ -78,8 +89,9 @@ const SwapExactTokensForTokens: DecodedCallSummaryComponent<
               mode={mode}
             />
           ),
+          Recipient: <SummaryAddressDisplay address={recipient} networkId={chain.id} mode={mode} />,
         }}
-        defaults="Swap <TokensIn /><br/>for a minimum of <TokensOut />"
+        defaults="Swap <TokensIn /><br/>for a minimum of <TokensOut /><br/>to <Recipient />"
       />
     )
 
@@ -103,10 +115,21 @@ const SwapExactTokensForTokens: DecodedCallSummaryComponent<
                 mode={mode}
               />
             ),
+            Recipient: (
+              <SummaryAddressDisplay address={recipient} networkId={chain.id} mode={mode} />
+            ),
           }}
-          defaults="Swap <TokensIn /><br/>for a minimum of <TokensOut />"
+          defaults="Swap <TokensIn /><br/>for a minimum of <TokensOut /><br/>to <Recipient />"
         />
       </SummaryContent>
+      {!isSelfRecipient && (
+        <>
+          <SummarySeparator />
+          <SummaryAlert>
+            {t("The swap output will be paid to another account, not to the signing account.")}
+          </SummaryAlert>
+        </>
+      )}
     </SummaryContainer>
   )
 }

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/SummaryXTokens.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/SummaryXTokens.tsx
@@ -36,6 +36,8 @@ const Transfer: DecodedCallSummaryComponent<TransferArgs> = ({
 
     return {
       value: args.amount,
+      // `transfer_with_fee` debits the signer `amount + fee`, both in `currency_id`
+      fee: "fee" in args ? args.fee : undefined,
       tokenId: token.id,
       fromNetwork: chain.id,
       toNetwork: targetChain.id,

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryAssetConversion.test.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryAssetConversion.test.tsx
@@ -1,0 +1,140 @@
+import { render } from "@testing-library/react"
+import { type FC, Fragment, type ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+const fx = vi.hoisted(() => {
+  const CHAIN_ID = "polkadot-asset-hub"
+  const chain = { id: CHAIN_ID, prefix: 0, topology: { type: "parachain", relayId: "polkadot" } }
+  const tokens = [
+    {
+      id: "polkadot-asset-hub-substrate-native",
+      type: "substrate-native",
+      networkId: CHAIN_ID,
+      symbol: "DOT",
+      decimals: 10,
+    },
+    {
+      id: "polkadot-asset-hub-substrate-assets-1984",
+      type: "substrate-assets",
+      networkId: CHAIN_ID,
+      assetId: "1984",
+      symbol: "USDT",
+      decimals: 6,
+    },
+    {
+      id: "polkadot-asset-hub-substrate-assets-1337",
+      type: "substrate-assets",
+      networkId: CHAIN_ID,
+      assetId: "1337",
+      symbol: "USDC",
+      decimals: 6,
+    },
+  ]
+  return { CHAIN_ID, chain, tokens }
+})
+
+// The global test setup mocks `useTranslation` only, and this summary renders `<Trans />`.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (value: string) => value,
+    i18n: { changeLanguage: () => Promise.resolve() },
+  }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  Trans: ({ components = {} }: { components?: Record<string, ReactNode>; defaults?: string }) => (
+    <>
+      {Object.entries(components).map(([key, node]) => (
+        <Fragment key={key}>{node}</Fragment>
+      ))}
+    </>
+  ),
+}))
+
+vi.mock("@ui/state/chaindata", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ui/state/chaindata")>()
+  return {
+    ...actual,
+    useNetworkById: () => fx.chain,
+    useTokens: () => fx.tokens,
+    useToken: (id: string) => fx.tokens.find((token) => token.id === id),
+  }
+})
+
+// Surfaces the token symbol and planck it is given, so assertions can read what was rendered.
+vi.mock("@ui/domains/Asset/TokensAndFiat", () => ({
+  TokensAndFiat: ({ tokenId, planck }: { tokenId?: string; planck?: bigint | string }) => (
+    <span data-testid="tokens-and-fiat">
+      {fx.tokens.find((token) => token.id === tokenId)?.symbol}:{String(planck)}
+    </span>
+  ),
+}))
+vi.mock("@ui/domains/Asset/TokenLogo", () => ({ TokenLogo: () => null }))
+
+import { SUMMARY_COMPONENTS_ASSET_CONVERSION } from "@ui/domains/Sign/Substrate/summary/calls/SummaryAssetConversion"
+
+const SwapExactTokensForTokens = SUMMARY_COMPONENTS_ASSET_CONVERSION[0][2] as unknown as FC<
+  Record<string, unknown>
+>
+
+const SIGNER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+
+const AMOUNT_IN = 5_000_000_000_000n // 500 DOT
+const AMOUNT_OUT_MIN = 1_000_000n // 1 unit of the last token in the path
+
+const NATIVE_LOCATION = { parents: 0, interior: { type: "Here", value: undefined } }
+const assetLocation = (assetId: bigint) => ({
+  parents: 0,
+  interior: {
+    type: "X2",
+    value: [
+      { type: "PalletInstance", value: 50 },
+      { type: "GeneralIndex", value: assetId },
+    ],
+  },
+})
+
+const MODES = ["block", "multiline", "compact"] as const
+
+const renderSummary = (
+  args: Record<string, unknown>,
+  mode: (typeof MODES)[number],
+  signer = SIGNER
+) =>
+  render(
+    <SwapExactTokensForTokens
+      decodedCall={{ pallet: "AssetConversion", method: "swap_exact_tokens_for_tokens", args }}
+      sapi={{ chainId: fx.CHAIN_ID }}
+      payload={{ address: signer }}
+      mode={mode}
+    />
+  )
+
+const swapArgs = (path: unknown[], sendTo = SIGNER) => ({
+  path,
+  amount_in: AMOUNT_IN,
+  amount_out_min: AMOUNT_OUT_MIN,
+  send_to: sendTo,
+  keep_alive: false,
+})
+
+describe("AssetConversion swap_exact_tokens_for_tokens", () => {
+  // `amount_out_min` is denominated in the last hop of the path, so a multi-hop swap that reported
+  // path[1] as the output would name an intermediate token the signer never receives.
+  it.each(MODES)("mode=%s: names the last token of a multi-hop path as the output", (mode) => {
+    const { container } = renderSummary(
+      swapArgs([NATIVE_LOCATION, assetLocation(1984n), assetLocation(1337n)]),
+      mode
+    )
+    const text = container.textContent ?? ""
+
+    expect(text).toContain("USDC")
+    expect(text).not.toContain("USDT")
+  })
+
+  it.each(MODES)("mode=%s: names the second token of a direct path as the output", (mode) => {
+    const { container } = renderSummary(swapArgs([NATIVE_LOCATION, assetLocation(1984n)]), mode)
+    const text = container.textContent ?? ""
+
+    expect(text).toContain("USDT")
+    expect(text).not.toContain("USDC")
+  })
+})

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryAssetConversion.test.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryAssetConversion.test.tsx
@@ -69,6 +69,26 @@ vi.mock("@ui/domains/Asset/TokensAndFiat", () => ({
 }))
 vi.mock("@ui/domains/Asset/TokenLogo", () => ({ TokenLogo: () => null }))
 
+// Account subtree behind SummaryAddressDisplay, stubbed to avoid keyring/state/clipboard side
+// effects while keeping the rendered address readable.
+vi.mock("@ui/state/accounts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ui/state/accounts")>()
+  return { ...actual, useAccountByAddress: () => null }
+})
+vi.mock("@core/domains/keyring/exports", () => ({ getAccountGenesisHash: () => undefined }))
+vi.mock("@ui/util/copyAddress", () => ({ copyAddress: vi.fn() }))
+vi.mock("@ui/domains/Account/AccountIcon", () => ({
+  AccountIcon: () => <span data-testid="account-icon" />,
+}))
+vi.mock("@ui/domains/Account/Address", () => ({
+  Address: ({ address }: { address: string }) => <span data-testid="address">{address}</span>,
+}))
+vi.mock("@ui/components/Tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode; asChild?: boolean }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
 import { SUMMARY_COMPONENTS_ASSET_CONVERSION } from "@ui/domains/Sign/Substrate/summary/calls/SummaryAssetConversion"
 
 const SwapExactTokensForTokens = SUMMARY_COMPONENTS_ASSET_CONVERSION[0][2] as unknown as FC<
@@ -76,6 +96,8 @@ const SwapExactTokensForTokens = SUMMARY_COMPONENTS_ASSET_CONVERSION[0][2] as un
 >
 
 const SIGNER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+const SIGNER_KUSAMA_SS58 = "HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F"
+const OTHER_ACCOUNT = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
 
 const AMOUNT_IN = 5_000_000_000_000n // 500 DOT
 const AMOUNT_OUT_MIN = 1_000_000n // 1 unit of the last token in the path
@@ -136,5 +158,39 @@ describe("AssetConversion swap_exact_tokens_for_tokens", () => {
 
     expect(text).toContain("USDT")
     expect(text).not.toContain("USDC")
+  })
+
+  // `send_to` is the account credited with the swap output, and it is not necessarily the signer.
+  it.each(MODES)("mode=%s: shows the account the output is paid to", (mode) => {
+    const { container } = renderSummary(
+      swapArgs([NATIVE_LOCATION, assetLocation(1984n)], OTHER_ACCOUNT),
+      mode
+    )
+
+    expect(container.textContent ?? "").toContain(OTHER_ACCOUNT)
+  })
+
+  it("warns when the output is paid to an account other than the signer", () => {
+    const { container } = renderSummary(
+      swapArgs([NATIVE_LOCATION, assetLocation(1984n)], OTHER_ACCOUNT),
+      "block"
+    )
+
+    expect(container.textContent ?? "").toContain("not to the signing account")
+  })
+
+  it("does not warn when the output is paid to the signer", () => {
+    const { container } = renderSummary(swapArgs([NATIVE_LOCATION, assetLocation(1984n)]), "block")
+
+    expect(container.textContent ?? "").not.toContain("not to the signing account")
+  })
+
+  it("does not warn when the output is paid to the signer under another ss58 prefix", () => {
+    const { container } = renderSummary(
+      swapArgs([NATIVE_LOCATION, assetLocation(1984n)], SIGNER_KUSAMA_SS58),
+      "block"
+    )
+
+    expect(container.textContent ?? "").not.toContain("not to the signing account")
   })
 })

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryXTokens.test.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryXTokens.test.tsx
@@ -1,3 +1,4 @@
+import { encodeAnyAddress } from "@talismn/crypto"
 import { render } from "@testing-library/react"
 import type { FC, ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
@@ -50,7 +51,7 @@ vi.mock("@ui/domains/Sign/Substrate/util/getChainFromXcmLocation", () => ({
   getChainFromXcmLocation: () => ({ id: "hydration", prefix: 63, name: "Hydration" }),
 }))
 vi.mock("@ui/domains/Sign/Substrate/util/getAddressFromXcmLocation", () => ({
-  getAddressFromXcmLocation: () => "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+  getAddressFromXcmLocation: vi.fn(() => "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"),
 }))
 
 // Surfaces the planck value it is given verbatim, so assertions can read the rendered amounts.
@@ -84,8 +85,12 @@ vi.mock("@ui/components/Tooltip", () => ({
 }))
 
 import { SUMMARY_COMPONENTS_X_TOKENS } from "@ui/domains/Sign/Substrate/summary/calls/SummaryXTokens"
+import { getAddressFromXcmLocation } from "@ui/domains/Sign/Substrate/util/getAddressFromXcmLocation"
 
 const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+// the summary re-encodes the beneficiary for the destination chain, Hydration here
+const BOB_ON_DESTINATION = encodeAnyAddress(BOB, { ss58Format: 63 })
 
 const AMOUNT = 1_000_000_000_000n // 1 ACA
 const FEE = 4_242_424_242_424_242_424n // dwarfs the amount: the whole point of showing it
@@ -160,5 +165,41 @@ describe("XTokens transfer", () => {
     )
 
     expect(amounts).toStrictEqual([String(AMOUNT)])
+  })
+})
+
+describe("cross-chain transfer beneficiary", () => {
+  // The account credited on the destination chain is the only thing separating a self-bridge from a
+  // drain, so naming the destination chain alone is not enough.
+  it.each(MODES)("mode=%s: shows the destination account, not just the chain", (mode) => {
+    const { container } = renderSummary(
+      "transfer",
+      { currency_id: 0, amount: AMOUNT, dest, dest_weight_limit: destWeightLimit },
+      mode
+    )
+
+    expect(container.textContent ?? "").toContain(BOB_ON_DESTINATION)
+  })
+
+  it("warns when the funds are delivered to another account", () => {
+    const { container } = renderSummary(
+      "transfer",
+      { currency_id: 0, amount: AMOUNT, dest, dest_weight_limit: destWeightLimit },
+      "block"
+    )
+
+    expect(container.textContent ?? "").toContain("not to the signing account")
+  })
+
+  it("does not warn on a self-bridge, across ss58 prefixes", () => {
+    vi.mocked(getAddressFromXcmLocation).mockReturnValueOnce(ALICE)
+
+    const { container } = renderSummary(
+      "transfer",
+      { currency_id: 0, amount: AMOUNT, dest, dest_weight_limit: destWeightLimit },
+      "block"
+    )
+
+    expect(container.textContent ?? "").not.toContain("not to the signing account")
   })
 })

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryXTokens.test.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryXTokens.test.tsx
@@ -123,8 +123,9 @@ const MODES = ["block", "multiline", "compact"] as const
 
 describe("XTokens transfer_with_fee", () => {
   // The pallet debits the signer `amount + fee`, so `fee` is a second, caller-controlled debit.
-  // Displaying `amount` alone would understate the transaction by the whole of `fee`.
-  it.each(MODES)("mode=%s: headline shows the total debited, not just the amount", (mode) => {
+  // Showing `amount` alone would understate the transaction by the whole of `fee`, so both are
+  // rendered, each on its own line, in every mode.
+  it.each(MODES)("mode=%s: shows the amount and the fee it is debited on top of", (mode) => {
     const { container } = renderSummary(
       "transfer_with_fee",
       { currency_id: 0, amount: AMOUNT, fee: FEE, dest, dest_weight_limit: destWeightLimit },
@@ -134,21 +135,7 @@ describe("XTokens transfer_with_fee", () => {
       (node) => node.textContent
     )
 
-    expect(amounts).toContain(String(AMOUNT + FEE))
-    expect(amounts).not.toContain(String(AMOUNT))
-  })
-
-  it("block mode breaks the fee out of the total", () => {
-    const { container } = renderSummary(
-      "transfer_with_fee",
-      { currency_id: 0, amount: AMOUNT, fee: FEE, dest, dest_weight_limit: destWeightLimit },
-      "block"
-    )
-    const amounts = Array.from(container.querySelectorAll("[data-testid='tokens-and-fiat']")).map(
-      (node) => node.textContent
-    )
-
-    expect(amounts).toContain(String(AMOUNT + FEE))
+    expect(amounts).toContain(String(AMOUNT))
     expect(amounts).toContain(String(FEE))
   })
 })

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryXTokens.test.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/SummaryXTokens.test.tsx
@@ -1,0 +1,164 @@
+import { render } from "@testing-library/react"
+import type { FC, ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+// The global test setup mocks `useTranslation` only, and these summaries render `<Trans />`.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (value: string) => value,
+    i18n: { changeLanguage: () => Promise.resolve() },
+  }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  Trans: ({ components }: { components?: Record<string, ReactNode>; defaults?: string }) => (
+    <span>
+      {Object.values(components ?? {}).map((child, i) => (
+        <span key={String(i)}>{child}</span>
+      ))}
+    </span>
+  ),
+}))
+
+// getTokenFromCurrency runs for real against these: currency_id 0 resolves the native token.
+vi.mock("@ui/state/chaindata", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ui/state/chaindata")>()
+  const nativeToken = {
+    id: "acala-substrate-native",
+    networkId: "acala",
+    type: "substrate-native",
+    symbol: "ACA",
+    decimals: 12,
+  }
+  const makeNetwork = (id: string) => ({
+    id,
+    name: id === "hydration" ? "Hydration" : "Acala",
+    prefix: id === "hydration" ? 63 : 10,
+    nativeTokenId: "acala-substrate-native",
+    topology: { type: "parachain", paraId: 2000, relayId: "polkadot" },
+  })
+  return {
+    ...actual,
+    useNetworkById: (id: string) => makeNetwork(id),
+    useNetworks: () => [makeNetwork("acala"), makeNetwork("hydration")],
+    useTokens: () => [nativeToken],
+    useToken: () => nativeToken,
+  }
+})
+
+// Stubbed to keep the harness free of papi codegen and MultiLocation decoding, neither of which is
+// what these tests exercise.
+vi.mock("@ui/domains/Sign/Substrate/util/getChainFromXcmLocation", () => ({
+  getChainFromXcmLocation: () => ({ id: "hydration", prefix: 63, name: "Hydration" }),
+}))
+vi.mock("@ui/domains/Sign/Substrate/util/getAddressFromXcmLocation", () => ({
+  getAddressFromXcmLocation: () => "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+}))
+
+// Surfaces the planck value it is given verbatim, so assertions can read the rendered amounts.
+vi.mock("@ui/domains/Asset/TokensAndFiat", () => ({
+  TokensAndFiat: ({ planck }: { planck?: bigint | string }) => (
+    <span data-testid="tokens-and-fiat">{String(planck)}</span>
+  ),
+}))
+vi.mock("@ui/domains/Networks/NetworkLogo", () => ({
+  NetworkLogo: () => <span data-testid="network-logo" />,
+}))
+
+// SummaryCrossChainTransfer statically imports SummaryAddressDisplay, so the account subtree loads
+// in every mode. Stubbed to avoid keyring/state/clipboard module side effects.
+vi.mock("@ui/state/accounts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ui/state/accounts")>()
+  return { ...actual, useAccountByAddress: () => null }
+})
+vi.mock("@core/domains/keyring/exports", () => ({ getAccountGenesisHash: () => undefined }))
+vi.mock("@ui/util/copyAddress", () => ({ copyAddress: vi.fn() }))
+vi.mock("@ui/domains/Account/AccountIcon", () => ({
+  AccountIcon: () => <span data-testid="account-icon" />,
+}))
+vi.mock("@ui/domains/Account/Address", () => ({
+  Address: ({ address }: { address: string }) => <span data-testid="address">{address}</span>,
+}))
+vi.mock("@ui/components/Tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode; asChild?: boolean }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+import { SUMMARY_COMPONENTS_X_TOKENS } from "@ui/domains/Sign/Substrate/summary/calls/SummaryXTokens"
+
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+
+const AMOUNT = 1_000_000_000_000n // 1 ACA
+const FEE = 4_242_424_242_424_242_424n // dwarfs the amount: the whole point of showing it
+
+const getComponent = (method: string) =>
+  SUMMARY_COMPONENTS_X_TOKENS.find(([, m]) => m === method)?.[2] as unknown as FC<
+    Record<string, unknown>
+  >
+
+const dest = { type: "V4", value: { parents: 1, interior: { type: "Here", value: undefined } } }
+const destWeightLimit = { type: "Unlimited", value: undefined }
+
+const renderSummary = (
+  method: "transfer" | "transfer_with_fee",
+  args: Record<string, unknown>,
+  mode: "block" | "multiline" | "compact"
+) => {
+  const Component = getComponent(method)
+  return render(
+    <Component
+      decodedCall={{ pallet: "XTokens", method, args }}
+      sapi={{ chainId: "acala" }}
+      payload={{ address: ALICE }}
+      mode={mode}
+    />
+  )
+}
+
+const MODES = ["block", "multiline", "compact"] as const
+
+describe("XTokens transfer_with_fee", () => {
+  // The pallet debits the signer `amount + fee`, so `fee` is a second, caller-controlled debit.
+  // Displaying `amount` alone would understate the transaction by the whole of `fee`.
+  it.each(MODES)("mode=%s: headline shows the total debited, not just the amount", (mode) => {
+    const { container } = renderSummary(
+      "transfer_with_fee",
+      { currency_id: 0, amount: AMOUNT, fee: FEE, dest, dest_weight_limit: destWeightLimit },
+      mode
+    )
+    const amounts = Array.from(container.querySelectorAll("[data-testid='tokens-and-fiat']")).map(
+      (node) => node.textContent
+    )
+
+    expect(amounts).toContain(String(AMOUNT + FEE))
+    expect(amounts).not.toContain(String(AMOUNT))
+  })
+
+  it("block mode breaks the fee out of the total", () => {
+    const { container } = renderSummary(
+      "transfer_with_fee",
+      { currency_id: 0, amount: AMOUNT, fee: FEE, dest, dest_weight_limit: destWeightLimit },
+      "block"
+    )
+    const amounts = Array.from(container.querySelectorAll("[data-testid='tokens-and-fiat']")).map(
+      (node) => node.textContent
+    )
+
+    expect(amounts).toContain(String(AMOUNT + FEE))
+    expect(amounts).toContain(String(FEE))
+  })
+})
+
+describe("XTokens transfer", () => {
+  it.each(MODES)("mode=%s: shows the amount, with no fee breakdown", (mode) => {
+    const { container } = renderSummary(
+      "transfer",
+      { currency_id: 0, amount: AMOUNT, dest, dest_weight_limit: destWeightLimit },
+      mode
+    )
+    const amounts = Array.from(container.querySelectorAll("[data-testid='tokens-and-fiat']")).map(
+      (node) => node.textContent
+    )
+
+    expect(amounts).toStrictEqual([String(AMOUNT)])
+  })
+})

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/summaryArgsCoverage.test.ts
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/summaryArgsCoverage.test.ts
@@ -19,6 +19,9 @@ const coverage =
     ignored: Record<Exclude<keyof TArgs, TDisplayed[number]>, string>
   ) => ({ displayed: displayed as readonly (string | number | symbol)[], ignored })
 
+const WEIGHT_LIMIT_REASON =
+  "caps destination execution weight; it moves no funds, but too low a limit can strand the transfer on the destination chain. It stays in the raw call view because a raw weight is neither interpretable by the signer nor checkable by us: proving one sufficient needs the destination runtime's own weight for the message, which the source chain cannot answer."
+
 const SUMMARY_ARGS_COVERAGE = {
   "ConvictionVoting.vote": coverage<PolkadotCalls["ConvictionVoting"]["vote"]>()(
     ["poll_index", "vote"],
@@ -80,13 +83,13 @@ const SUMMARY_ARGS_COVERAGE = {
     PolkadotCalls["XcmPallet"]["limited_reserve_transfer_assets"]
   >()(["dest", "beneficiary", "assets"], {
     fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
-    weight_limit: "caps execution weight, it moves no funds",
+    weight_limit: WEIGHT_LIMIT_REASON,
   }),
   "XcmPallet.limited_teleport_assets": coverage<
     PolkadotCalls["XcmPallet"]["limited_teleport_assets"]
   >()(["dest", "beneficiary", "assets"], {
     fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
-    weight_limit: "caps execution weight, it moves no funds",
+    weight_limit: WEIGHT_LIMIT_REASON,
   }),
   "PolkadotXcm.reserve_transfer_assets": coverage<
     PolkadotAssetHubCalls["PolkadotXcm"]["reserve_transfer_assets"]
@@ -97,22 +100,22 @@ const SUMMARY_ARGS_COVERAGE = {
     PolkadotAssetHubCalls["PolkadotXcm"]["limited_reserve_transfer_assets"]
   >()(["dest", "beneficiary", "assets"], {
     fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
-    weight_limit: "caps execution weight, it moves no funds",
+    weight_limit: WEIGHT_LIMIT_REASON,
   }),
   "PolkadotXcm.limited_teleport_assets": coverage<
     PolkadotAssetHubCalls["PolkadotXcm"]["limited_teleport_assets"]
   >()(["dest", "beneficiary", "assets"], {
     fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
-    weight_limit: "caps execution weight, it moves no funds",
+    weight_limit: WEIGHT_LIMIT_REASON,
   }),
 
   "XTokens.transfer": coverage<AcalaCalls["XTokens"]["transfer"]>()(
     ["currency_id", "amount", "dest"],
-    { dest_weight_limit: "caps execution weight, it moves no funds" }
+    { dest_weight_limit: WEIGHT_LIMIT_REASON }
   ),
   "XTokens.transfer_with_fee": coverage<AcalaCalls["XTokens"]["transfer_with_fee"]>()(
     ["currency_id", "amount", "fee", "dest"],
-    { dest_weight_limit: "caps execution weight, it moves no funds" }
+    { dest_weight_limit: WEIGHT_LIMIT_REASON }
   ),
 
   "Assets.transfer": coverage<PolkadotAssetHubCalls["Assets"]["transfer"]>()(

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/summaryArgsCoverage.test.ts
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/summaryArgsCoverage.test.ts
@@ -1,0 +1,185 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import type { AcalaCalls, PolkadotAssetHubCalls, PolkadotCalls } from "@polkadot-api/descriptors"
+import { SUMMARY_COMPONENTS } from "@ui/domains/Sign/Substrate/summary/calls"
+import { describe, expect, it } from "vitest"
+
+/**
+ * A summary component is the only thing most users read before approving a transaction, so an
+ * argument it doesn't render is an argument the signer never sees. This declares, for every
+ * registered call, which arguments the summary shows and which it deliberately leaves out.
+ *
+ * `ignored` must list every argument not in `displayed`, so a runtime upgrade that adds an
+ * argument breaks the typecheck until someone decides whether it belongs on the sign screen.
+ */
+const coverage =
+  <TArgs>() =>
+  <const TDisplayed extends readonly (keyof TArgs)[]>(
+    displayed: TDisplayed,
+    ignored: Record<Exclude<keyof TArgs, TDisplayed[number]>, string>
+  ) => ({ displayed: displayed as readonly (string | number | symbol)[], ignored })
+
+const SUMMARY_ARGS_COVERAGE = {
+  "ConvictionVoting.vote": coverage<PolkadotCalls["ConvictionVoting"]["vote"]>()(
+    ["poll_index", "vote"],
+    {}
+  ),
+  "ConvictionVoting.unlock": coverage<PolkadotCalls["ConvictionVoting"]["unlock"]>()(["class"], {
+    target: "the account whose expired lock is released; the funds stay with that account",
+  }),
+  "ConvictionVoting.delegate": coverage<PolkadotCalls["ConvictionVoting"]["delegate"]>()(
+    ["class", "to", "conviction", "balance"],
+    {}
+  ),
+  "ConvictionVoting.undelegate": coverage<PolkadotCalls["ConvictionVoting"]["undelegate"]>()(
+    ["class"],
+    {}
+  ),
+
+  "NominationPools.join": coverage<PolkadotCalls["NominationPools"]["join"]>()(
+    ["amount", "pool_id"],
+    {}
+  ),
+  "NominationPools.set_claim_permission": coverage<
+    PolkadotCalls["NominationPools"]["set_claim_permission"]
+  >()(["permission"], {}),
+  "NominationPools.withdraw_unbonded": coverage<
+    PolkadotCalls["NominationPools"]["withdraw_unbonded"]
+  >()([], {
+    member_account: "the pool member being withdrawn for; the funds go to that member",
+    num_slashing_spans: "chain bookkeeping, carries no value",
+  }),
+  "NominationPools.bond_extra": coverage<PolkadotCalls["NominationPools"]["bond_extra"]>()(
+    ["extra"],
+    {}
+  ),
+  "NominationPools.claim_payout": coverage<PolkadotCalls["NominationPools"]["claim_payout"]>()(
+    [],
+    {}
+  ),
+
+  "Balances.transfer_keep_alive": coverage<PolkadotCalls["Balances"]["transfer_keep_alive"]>()(
+    ["dest", "value"],
+    {}
+  ),
+  "Balances.transfer_allow_death": coverage<PolkadotCalls["Balances"]["transfer_allow_death"]>()(
+    ["dest", "value"],
+    {}
+  ),
+  "Balances.transfer_all": coverage<PolkadotCalls["Balances"]["transfer_all"]>()(
+    ["dest", "keep_alive"],
+    {}
+  ),
+
+  "XcmPallet.reserve_transfer_assets": coverage<
+    PolkadotCalls["XcmPallet"]["reserve_transfer_assets"]
+  >()(["dest", "beneficiary", "assets"], {
+    fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
+  }),
+  "XcmPallet.limited_reserve_transfer_assets": coverage<
+    PolkadotCalls["XcmPallet"]["limited_reserve_transfer_assets"]
+  >()(["dest", "beneficiary", "assets"], {
+    fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
+    weight_limit: "caps execution weight, it moves no funds",
+  }),
+  "XcmPallet.limited_teleport_assets": coverage<
+    PolkadotCalls["XcmPallet"]["limited_teleport_assets"]
+  >()(["dest", "beneficiary", "assets"], {
+    fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
+    weight_limit: "caps execution weight, it moves no funds",
+  }),
+  "PolkadotXcm.reserve_transfer_assets": coverage<
+    PolkadotAssetHubCalls["PolkadotXcm"]["reserve_transfer_assets"]
+  >()(["dest", "beneficiary", "assets"], {
+    fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
+  }),
+  "PolkadotXcm.limited_reserve_transfer_assets": coverage<
+    PolkadotAssetHubCalls["PolkadotXcm"]["limited_reserve_transfer_assets"]
+  >()(["dest", "beneficiary", "assets"], {
+    fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
+    weight_limit: "caps execution weight, it moves no funds",
+  }),
+  "PolkadotXcm.limited_teleport_assets": coverage<
+    PolkadotAssetHubCalls["PolkadotXcm"]["limited_teleport_assets"]
+  >()(["dest", "beneficiary", "assets"], {
+    fee_asset_item: "selects which of `assets` pays for execution, it moves no extra funds",
+    weight_limit: "caps execution weight, it moves no funds",
+  }),
+
+  "XTokens.transfer": coverage<AcalaCalls["XTokens"]["transfer"]>()(
+    ["currency_id", "amount", "dest"],
+    { dest_weight_limit: "caps execution weight, it moves no funds" }
+  ),
+  "XTokens.transfer_with_fee": coverage<AcalaCalls["XTokens"]["transfer_with_fee"]>()(
+    ["currency_id", "amount", "fee", "dest"],
+    { dest_weight_limit: "caps execution weight, it moves no funds" }
+  ),
+
+  "Assets.transfer": coverage<PolkadotAssetHubCalls["Assets"]["transfer"]>()(
+    ["id", "target", "amount"],
+    {}
+  ),
+  "Assets.transfer_keep_alive": coverage<PolkadotAssetHubCalls["Assets"]["transfer_keep_alive"]>()(
+    ["id", "target", "amount"],
+    {}
+  ),
+  "ForeignAssets.transfer": coverage<PolkadotAssetHubCalls["ForeignAssets"]["transfer"]>()(
+    ["id", "target", "amount"],
+    {}
+  ),
+  "ForeignAssets.transfer_keep_alive": coverage<
+    PolkadotAssetHubCalls["ForeignAssets"]["transfer_keep_alive"]
+  >()(["id", "target", "amount"], {}),
+
+  "AssetConversion.swap_exact_tokens_for_tokens": coverage<
+    PolkadotAssetHubCalls["AssetConversion"]["swap_exact_tokens_for_tokens"]
+  >()(["path", "amount_in", "amount_out_min", "send_to"], {
+    keep_alive: "only decides whether the swap may reap the signer account",
+  }),
+
+  "System.remark": coverage<PolkadotCalls["System"]["remark"]>()(["remark"], {}),
+  "System.remark_with_event": coverage<PolkadotCalls["System"]["remark_with_event"]>()(
+    ["remark"],
+    {}
+  ),
+} as const
+
+const SOURCE_FILES: Record<string, string> = {
+  AssetConversion: "SummaryAssetConversion.tsx",
+  Assets: "SummaryAssets.tsx",
+  Balances: "SummaryBalances.tsx",
+  ConvictionVoting: "SummaryConvictionVoting.tsx",
+  ForeignAssets: "SummaryForeignAssets.tsx",
+  NominationPools: "SummaryNominationPools.tsx",
+  PolkadotXcm: "SummaryXcm.tsx",
+  System: "SummarySystem.tsx",
+  XcmPallet: "SummaryXcm.tsx",
+  XTokens: "SummaryXTokens.tsx",
+}
+
+const CALLS_DIR = resolve(process.cwd(), "src/ui/domains/Sign/Substrate/summary/calls")
+
+const readSource = (pallet: string) =>
+  readFileSync(resolve(CALLS_DIR, SOURCE_FILES[pallet]), "utf8")
+
+const registeredCalls = SUMMARY_COMPONENTS.map(([pallet, method]) => `${pallet}.${method}`)
+
+describe("summary call args coverage", () => {
+  it("declares coverage for every registered summary component", () => {
+    expect(registeredCalls.toSorted()).toStrictEqual(Object.keys(SUMMARY_ARGS_COVERAGE).toSorted())
+  })
+
+  it.each(Object.entries(SUMMARY_ARGS_COVERAGE))("%s renders the args it claims to", (call, {
+    displayed,
+  }) => {
+    const source = readSource(call.split(".")[0] as string)
+
+    for (const arg of displayed) expect(source).toContain(`args.${String(arg)}`)
+  })
+
+  it.each(Object.entries(SUMMARY_ARGS_COVERAGE))("%s explains every arg it leaves out", (_call, {
+    ignored,
+  }) => {
+    for (const reason of Object.values(ignored)) expect(String(reason).length).toBeGreaterThan(0)
+  })
+})

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/summaryArgsCoverage.test.ts
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/calls/__tests__/summaryArgsCoverage.test.ts
@@ -1,8 +1,15 @@
-import { readFileSync } from "node:fs"
-import { resolve } from "node:path"
 import type { AcalaCalls, PolkadotAssetHubCalls, PolkadotCalls } from "@polkadot-api/descriptors"
 import { SUMMARY_COMPONENTS } from "@ui/domains/Sign/Substrate/summary/calls"
 import { describe, expect, it } from "vitest"
+import summaryAssetConversion from "../SummaryAssetConversion.tsx?raw"
+import summaryAssets from "../SummaryAssets.tsx?raw"
+import summaryBalances from "../SummaryBalances.tsx?raw"
+import summaryConvictionVoting from "../SummaryConvictionVoting.tsx?raw"
+import summaryForeignAssets from "../SummaryForeignAssets.tsx?raw"
+import summaryNominationPools from "../SummaryNominationPools.tsx?raw"
+import summarySystem from "../SummarySystem.tsx?raw"
+import summaryXcm from "../SummaryXcm.tsx?raw"
+import summaryXTokens from "../SummaryXTokens.tsx?raw"
 
 /**
  * A summary component is the only thing most users read before approving a transaction, so an
@@ -147,23 +154,18 @@ const SUMMARY_ARGS_COVERAGE = {
   ),
 } as const
 
-const SOURCE_FILES: Record<string, string> = {
-  AssetConversion: "SummaryAssetConversion.tsx",
-  Assets: "SummaryAssets.tsx",
-  Balances: "SummaryBalances.tsx",
-  ConvictionVoting: "SummaryConvictionVoting.tsx",
-  ForeignAssets: "SummaryForeignAssets.tsx",
-  NominationPools: "SummaryNominationPools.tsx",
-  PolkadotXcm: "SummaryXcm.tsx",
-  System: "SummarySystem.tsx",
-  XcmPallet: "SummaryXcm.tsx",
-  XTokens: "SummaryXTokens.tsx",
+const PALLET_SOURCES: Record<string, string> = {
+  AssetConversion: summaryAssetConversion,
+  Assets: summaryAssets,
+  Balances: summaryBalances,
+  ConvictionVoting: summaryConvictionVoting,
+  ForeignAssets: summaryForeignAssets,
+  NominationPools: summaryNominationPools,
+  PolkadotXcm: summaryXcm,
+  System: summarySystem,
+  XcmPallet: summaryXcm,
+  XTokens: summaryXTokens,
 }
-
-const CALLS_DIR = resolve(process.cwd(), "src/ui/domains/Sign/Substrate/summary/calls")
-
-const readSource = (pallet: string) =>
-  readFileSync(resolve(CALLS_DIR, SOURCE_FILES[pallet]), "utf8")
 
 const registeredCalls = SUMMARY_COMPONENTS.map(([pallet, method]) => `${pallet}.${method}`)
 
@@ -175,7 +177,7 @@ describe("summary call args coverage", () => {
   it.each(Object.entries(SUMMARY_ARGS_COVERAGE))("%s renders the args it claims to", (call, {
     displayed,
   }) => {
-    const source = readSource(call.split(".")[0] as string)
+    const source = PALLET_SOURCES[call.split(".")[0] as string] as string
 
     for (const arg of displayed) expect(source).toContain(`args.${String(arg)}`)
   })

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/shared/SummaryCrossChainTransfer.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/shared/SummaryCrossChainTransfer.tsx
@@ -1,12 +1,18 @@
 import type { Address } from "@core/types/base"
 import type { NetworkId, TokenId } from "@talismn/chaindata-provider"
+import { isAddressEqual } from "@talismn/crypto"
 import { ArrowRightIcon } from "@talismn/icons"
 import type { FC } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
 import type { SummaryDisplayMode } from "../../types"
 import { SummaryAddressDisplay } from "./SummaryAddressDisplay"
-import { SummaryContainer, SummaryContent, SummarySeparator } from "./SummaryContainer"
+import {
+  SummaryAlert,
+  SummaryContainer,
+  SummaryContent,
+  SummarySeparator,
+} from "./SummaryContainer"
 import { SummaryLineBreak } from "./SummaryLineBreak"
 import { SummaryNetworkDisplay } from "./SummaryNetworkDisplay"
 import { SummaryTokensAndFiat } from "./SummaryTokensAndFiat"
@@ -36,6 +42,7 @@ export const SummaryCrossChainTransfer: FC<SummaryCrossChainTransferProps> = ({
   const { t } = useTranslation()
 
   const debited = value + (fee ?? 0n)
+  const isSelfTransfer = isAddressEqual(fromAddress, toAddress)
 
   if (mode !== "block")
     return (
@@ -44,9 +51,12 @@ export const SummaryCrossChainTransfer: FC<SummaryCrossChainTransferProps> = ({
         components={{
           Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={debited} mode={mode} />,
           LineBreak: <SummaryLineBreak mode={mode} />,
+          Beneficiary: (
+            <SummaryAddressDisplay address={toAddress} networkId={toNetwork} mode={mode} />
+          ),
           TargetNetwork: <SummaryNetworkDisplay networkId={toNetwork} />,
         }}
-        defaults="Transfer <Tokens /><LineBreak /> to <TargetNetwork />"
+        defaults="Transfer <Tokens /><LineBreak /> to <Beneficiary /><LineBreak /> on <TargetNetwork />"
       />
     )
 
@@ -56,10 +66,13 @@ export const SummaryCrossChainTransfer: FC<SummaryCrossChainTransferProps> = ({
         <Trans
           t={t}
           components={{
+            Beneficiary: (
+              <SummaryAddressDisplay address={toAddress} networkId={toNetwork} mode={mode} />
+            ),
             TargetNetwork: <SummaryNetworkDisplay networkId={toNetwork} />,
             Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={debited} mode={mode} />,
           }}
-          defaults="Transfer <Tokens /><br/> to <TargetNetwork />"
+          defaults="Transfer <Tokens /><br/> to <Beneficiary /><br/> on <TargetNetwork />"
         />
       </SummaryContent>
       {fee !== undefined && (
@@ -90,6 +103,14 @@ export const SummaryCrossChainTransfer: FC<SummaryCrossChainTransferProps> = ({
           <SummaryAddressDisplay address={toAddress} networkId={toNetwork} mode={mode} />
         </div>
       </SummaryContent>
+      {!isSelfTransfer && (
+        <>
+          <SummarySeparator />
+          <SummaryAlert>
+            {t("The funds will be delivered to another account, not to the signing account.")}
+          </SummaryAlert>
+        </>
+      )}
     </SummaryContainer>
   )
 }

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/shared/SummaryCrossChainTransfer.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/shared/SummaryCrossChainTransfer.tsx
@@ -18,6 +18,8 @@ export type SummaryCrossChainTransferProps = {
   toAddress: Address
   tokenId: TokenId
   value: bigint
+  /** debited on top of `value` to pay for execution on the destination chain */
+  fee?: bigint
   mode: SummaryDisplayMode
 }
 
@@ -28,16 +30,19 @@ export const SummaryCrossChainTransfer: FC<SummaryCrossChainTransferProps> = ({
   toAddress,
   tokenId,
   value,
+  fee,
   mode,
 }) => {
   const { t } = useTranslation()
+
+  const debited = value + (fee ?? 0n)
 
   if (mode !== "block")
     return (
       <Trans
         t={t}
         components={{
-          Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={value} mode={mode} />,
+          Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={debited} mode={mode} />,
           LineBreak: <SummaryLineBreak mode={mode} />,
           TargetNetwork: <SummaryNetworkDisplay networkId={toNetwork} />,
         }}
@@ -52,11 +57,25 @@ export const SummaryCrossChainTransfer: FC<SummaryCrossChainTransferProps> = ({
           t={t}
           components={{
             TargetNetwork: <SummaryNetworkDisplay networkId={toNetwork} />,
-            Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={value} mode={mode} />,
+            Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={debited} mode={mode} />,
           }}
           defaults="Transfer <Tokens /><br/> to <TargetNetwork />"
         />
       </SummaryContent>
+      {fee !== undefined && (
+        <>
+          <SummarySeparator />
+          <SummaryContent className="text-xs">
+            <Trans
+              t={t}
+              components={{
+                Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={fee} mode={mode} />,
+              }}
+              defaults="Includes <Tokens /> to pay for execution on the destination chain"
+            />
+          </SummaryContent>
+        </>
+      )}
       <SummarySeparator />
       <SummaryContent className="grid grid-cols-[1fr_2.4rem_1fr] items-center gap-4">
         <div className="flex flex-col items-center gap-2 overflow-hidden">

--- a/apps/extension/src/ui/domains/Sign/Substrate/summary/shared/SummaryCrossChainTransfer.tsx
+++ b/apps/extension/src/ui/domains/Sign/Substrate/summary/shared/SummaryCrossChainTransfer.tsx
@@ -41,24 +41,36 @@ export const SummaryCrossChainTransfer: FC<SummaryCrossChainTransferProps> = ({
 }) => {
   const { t } = useTranslation()
 
-  const debited = value + (fee ?? 0n)
   const isSelfTransfer = isAddressEqual(fromAddress, toAddress)
 
-  if (mode !== "block")
+  if (mode !== "block") {
+    const components = {
+      Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={value} mode={mode} />,
+      LineBreak: <SummaryLineBreak mode={mode} />,
+      Beneficiary: <SummaryAddressDisplay address={toAddress} networkId={toNetwork} mode={mode} />,
+      TargetNetwork: <SummaryNetworkDisplay networkId={toNetwork} />,
+    }
+
+    if (fee === undefined)
+      return (
+        <Trans
+          t={t}
+          components={components}
+          defaults="Transfer <Tokens /><LineBreak /> to <Beneficiary /><LineBreak /> on <TargetNetwork />"
+        />
+      )
+
     return (
       <Trans
         t={t}
         components={{
-          Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={debited} mode={mode} />,
-          LineBreak: <SummaryLineBreak mode={mode} />,
-          Beneficiary: (
-            <SummaryAddressDisplay address={toAddress} networkId={toNetwork} mode={mode} />
-          ),
-          TargetNetwork: <SummaryNetworkDisplay networkId={toNetwork} />,
+          ...components,
+          Fee: <SummaryTokensAndFiat tokenId={tokenId} planck={fee} mode={mode} />,
         }}
-        defaults="Transfer <Tokens /><LineBreak /> to <Beneficiary /><LineBreak /> on <TargetNetwork />"
+        defaults="Transfer <Tokens /><LineBreak /> to <Beneficiary /><LineBreak /> on <TargetNetwork /><LineBreak /> with fee <Fee />"
       />
     )
+  }
 
   return (
     <SummaryContainer>
@@ -70,7 +82,7 @@ export const SummaryCrossChainTransfer: FC<SummaryCrossChainTransferProps> = ({
               <SummaryAddressDisplay address={toAddress} networkId={toNetwork} mode={mode} />
             ),
             TargetNetwork: <SummaryNetworkDisplay networkId={toNetwork} />,
-            Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={debited} mode={mode} />,
+            Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={value} mode={mode} />,
           }}
           defaults="Transfer <Tokens /><br/> to <Beneficiary /><br/> on <TargetNetwork />"
         />
@@ -84,7 +96,7 @@ export const SummaryCrossChainTransfer: FC<SummaryCrossChainTransferProps> = ({
               components={{
                 Tokens: <SummaryTokensAndFiat tokenId={tokenId} planck={fee} mode={mode} />,
               }}
-              defaults="Includes <Tokens /> to pay for execution on the destination chain"
+              defaults="Plus <Tokens /> debited to pay for execution on the destination chain"
             />
           </SummaryContent>
         </>

--- a/apps/extension/src/ui/domains/Sign/Substrate/util/__tests__/getMultiAssetTokenId.test.ts
+++ b/apps/extension/src/ui/domains/Sign/Substrate/util/__tests__/getMultiAssetTokenId.test.ts
@@ -1,0 +1,71 @@
+import type { XcmVersionedAssets } from "@polkadot-api/descriptors"
+import type { DotNetwork } from "@talismn/chaindata-provider"
+import { getMultiAssetTokenId } from "@ui/domains/Sign/Substrate/util/getMultiAssetTokenId"
+import { describe, expect, it } from "vitest"
+
+// Astar is the interesting shape: a parachain whose native token is not the relay's, so `parents`
+// is the only thing distinguishing 100 ASTR from 100 DOT — and their decimals differ.
+const ASTAR = {
+  id: "astar",
+  nativeTokenId: "astar:substrate-native",
+  topology: { type: "parachain", relayId: "polkadot", paraId: 2006 },
+} as unknown as DotNetwork
+
+const POLKADOT = {
+  id: "polkadot",
+  nativeTokenId: "polkadot:substrate-native",
+  topology: { type: "relay" },
+} as unknown as DotNetwork
+
+const VALUE = 1_000_000_000_000n
+
+const assets = (parents: number, interior: unknown) =>
+  ({
+    type: "V3",
+    value: [
+      {
+        id: { type: "Concrete", value: { parents, interior } },
+        fun: { type: "Fungible", value: VALUE },
+      },
+    ],
+  }) as unknown as XcmVersionedAssets
+
+const HERE = { type: "Here", value: undefined }
+const LOCAL_ASSET = {
+  type: "X2",
+  value: [
+    { type: "PalletInstance", value: 50 },
+    { type: "GeneralIndex", value: 1984n },
+  ],
+}
+
+describe("getMultiAssetTokenId", () => {
+  it("resolves a local native asset", () => {
+    expect(getMultiAssetTokenId(assets(0, HERE), ASTAR)).toStrictEqual({
+      tokenId: "astar:substrate-native",
+      value: VALUE,
+    })
+  })
+
+  it("resolves the relay native asset one hop up from a parachain", () => {
+    expect(getMultiAssetTokenId(assets(1, HERE), ASTAR)).toStrictEqual({
+      tokenId: "polkadot:substrate-native",
+      value: VALUE,
+    })
+  })
+
+  it("rejects a parent location on a relay chain, which has no parent", () => {
+    expect(() => getMultiAssetTokenId(assets(1, HERE), POLKADOT)).toThrow("Unknown multi asset")
+  })
+
+  it("resolves a local assets-pallet token", () => {
+    expect(getMultiAssetTokenId(assets(0, LOCAL_ASSET), ASTAR)).toStrictEqual({
+      tokenId: "astar:substrate-assets:1984",
+      value: VALUE,
+    })
+  })
+
+  it("rejects an assets-pallet location that is not local", () => {
+    expect(() => getMultiAssetTokenId(assets(1, LOCAL_ASSET), ASTAR)).toThrow("Unknown multi asset")
+  })
+})

--- a/apps/extension/src/ui/domains/Sign/Substrate/util/__tests__/getPayloadTip.test.ts
+++ b/apps/extension/src/ui/domains/Sign/Substrate/util/__tests__/getPayloadTip.test.ts
@@ -1,0 +1,39 @@
+import type { SignerPayloadJSON, SignerPayloadRaw } from "@core/types/pjsInterop"
+import { getPayloadTip } from "@ui/domains/Sign/Substrate/util/getPayloadTip"
+import { describe, expect, it } from "vitest"
+
+const jsonPayload = (tip: unknown) =>
+  ({
+    genesisHash: "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
+    address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    tip,
+  }) as unknown as SignerPayloadJSON
+
+describe("getPayloadTip", () => {
+  it("reads a hex tip", () => {
+    expect(getPayloadTip(jsonPayload("0x0de0b6b3a7640000"))).toBe(1_000_000_000_000_000_000n)
+  })
+
+  it("reads a decimal tip", () => {
+    expect(getPayloadTip(jsonPayload("42"))).toBe(42n)
+  })
+
+  it.each([undefined, null, "0x00", "0", ""])("treats %s as no tip", (tip) => {
+    expect(getPayloadTip(jsonPayload(tip))).toBe(0n)
+  })
+
+  // a dapp controls this field, so anything it sends must degrade to 0 rather than throw on the
+  // sign screen — and must never come out negative, which would understate the total
+  it.each(["not a number", "0xzz", "-1", {}, []])("degrades %s to no tip", (tip) => {
+    expect(getPayloadTip(jsonPayload(tip))).toBe(0n)
+  })
+
+  it("ignores raw (non-extrinsic) payloads", () => {
+    const raw = { data: "0xdeadbeef", type: "bytes" } as SignerPayloadRaw
+    expect(getPayloadTip(raw)).toBe(0n)
+  })
+
+  it("handles a missing payload", () => {
+    expect(getPayloadTip(null)).toBe(0n)
+  })
+})

--- a/apps/extension/src/ui/domains/Sign/Substrate/util/getMultiAssetTokenId.ts
+++ b/apps/extension/src/ui/domains/Sign/Substrate/util/getMultiAssetTokenId.ts
@@ -1,6 +1,11 @@
 import { log } from "@common/log"
 import type { XcmVersionedAssets } from "@polkadot-api/descriptors"
-import { type DotNetwork, subAssetTokenId, type TokenId } from "@talismn/chaindata-provider"
+import {
+  type DotNetwork,
+  subAssetTokenId,
+  subNativeTokenId,
+  type TokenId,
+} from "@talismn/chaindata-provider"
 
 export const getMultiAssetTokenId = (
   assets: XcmVersionedAssets,
@@ -13,24 +18,32 @@ export const getMultiAssetTokenId = (
 
       if (asset.id.type === "Concrete" && asset.fun.type === "Fungible") {
         const value = asset.fun.value
-        const interior = asset.id.value.interior
-        if (interior.type === "Here" && chain.nativeTokenId) {
-          return { tokenId: chain.nativeTokenId, value }
-        }
-        if (interior.type === "X2") {
-          if (
-            interior.value[0].type === "PalletInstance" &&
-            interior.value[0].value === 50 &&
-            interior.value[1].type === "GeneralIndex"
-          ) {
-            // Assets pallet
-            const assetId = interior.value[1].value
-            const tokenId = subAssetTokenId(chain.id, String(assetId))
+        const { parents, interior } = asset.id.value
 
-            if (!tokenId) throw new Error("Unknown multi asset")
-
-            return { tokenId, value }
+        if (parents === 0) {
+          if (interior.type === "Here" && chain.nativeTokenId) {
+            return { tokenId: chain.nativeTokenId, value }
           }
+          if (interior.type === "X2") {
+            if (
+              interior.value[0].type === "PalletInstance" &&
+              interior.value[0].value === 50 &&
+              interior.value[1].type === "GeneralIndex"
+            ) {
+              // Assets pallet
+              const assetId = interior.value[1].value
+              const tokenId = subAssetTokenId(chain.id, String(assetId))
+
+              if (!tokenId) throw new Error("Unknown multi asset")
+
+              return { tokenId, value }
+            }
+          }
+        }
+
+        // one hop up from a parachain is the relay chain, whose native token is not necessarily ours
+        if (parents === 1 && interior.type === "Here" && chain.topology.type === "parachain") {
+          return { tokenId: subNativeTokenId(chain.topology.relayId), value }
         }
       }
     }

--- a/apps/extension/src/ui/domains/Sign/Substrate/util/getPayloadTip.ts
+++ b/apps/extension/src/ui/domains/Sign/Substrate/util/getPayloadTip.ts
@@ -1,0 +1,22 @@
+import type { SignerPayloadJSON, SignerPayloadRaw } from "@core/types/pjsInterop"
+import { isJsonPayload } from "@core/util/isJsonPayload"
+
+/**
+ * The tip a dapp put on its own payload. It is paid in full to the block author on top of the
+ * inclusion fee, which `TransactionPaymentApi.query_info` does not account for, so the sign screen
+ * has to add it to what it tells the user the transaction costs.
+ *
+ * Returns 0 for anything unparseable, so a malformed tip can never understate the total.
+ */
+export const getPayloadTip = (
+  payload: SignerPayloadJSON | SignerPayloadRaw | null | undefined
+): bigint => {
+  if (!payload || !isJsonPayload(payload) || !payload.tip) return 0n
+
+  try {
+    const tip = BigInt(payload.tip)
+    return tip > 0n ? tip : 0n
+  } catch (_err) {
+    return 0n
+  }
+}


### PR DESCRIPTION
Makes the substrate sign screen state a few things it was leaving implicit.

- XCM/XTokens: beneficiary now on the primary surface (`Transfer <amount> to <account> on <chain>`), with a warning in the expanded view when it isn't the signing account
- `XTokens.transfer_with_fee`: `fee` is debited on top of `amount`, so it's now part of the displayed total and broken out
- `AssetConversion.swap_exact_tokens_for_tokens`: shows `send_to`, and uses the last hop of `path` as output token (multi-hop routes named the wrong one)
- XCM asset locations: resolve `parents` before `interior`, so `{parents: 1, Here}` is the relay's native token instead of the local chain's
- Estimated Fee now includes the dapp-supplied tip
<img width="473" height="662" alt="image" src="https://github.com/user-attachments/assets/d7c9a200-41de-400c-9c0f-e5f9b12a8e77" />

Plus a coverage test that fails the typecheck when a runtime upgrade adds a call argument no summary renders, with a written reason for each argument left out.