### PR TITLE
🐛 Fix custom token details fetch

### DIFF
--- a/apps/extension/src/ui/apps/dashboard/routes/Tokens/AddTokenPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Tokens/AddTokenPage.tsx
@@ -16,7 +16,7 @@ import {
 import { isEthereumAddress } from "@talismn/crypto"
 import { LoaderIcon, SaveIcon } from "@talismn/icons"
 import { sleep } from "@talismn/util"
-import { useField, useForm } from "@tanstack/react-form"
+import { useForm, useStore } from "@tanstack/react-form"
 import { api } from "@ui/api"
 import type { AnalyticsPage } from "@ui/api/analytics"
 import { DashboardLayout } from "@ui/apps/dashboard/layout"
@@ -129,8 +129,14 @@ const AddCustomTokenForm = () => {
     },
   })
 
-  const fldNetworkId = useField({ form, name: "networkId" })
-  const fldContractAddress = useField({ form, name: "contractAddress" })
+  // Read from the form store instead of `useField`: a second `FieldApi` for a name already rendered
+  // by `<form.Field>` takes over `fieldInfo[name].instance`, and form-core then discards the async
+  // validation results of the `<form.Field>` instance which owns the validators.
+  const networkId = useStore(form.store, (s) => s.values.networkId)
+  const isContractAddressValid = useStore(
+    form.store,
+    (s) => s.fieldMeta.contractAddress?.isValid ?? true
+  )
 
   // Fields populated from the token info fetch. They must all be cleared whenever the contract
   // address stops resolving to a new token, else they keep displaying the previous token's info.
@@ -185,7 +191,7 @@ const AddCustomTokenForm = () => {
               spellCheck={false}
               data-lpignore
               autoComplete="off"
-              disabled={!fldNetworkId.state.value}
+              disabled={!networkId}
               placeholder="0xdeadbeef...deadbeef"
               small
               after={
@@ -269,7 +275,7 @@ const AddCustomTokenForm = () => {
                 autoComplete="off"
                 placeholder="TKN"
                 small
-                disabled={!fldContractAddress.state.meta.isValid}
+                disabled={!isContractAddressValid}
               />
             </FormFieldContainer>
           )}
@@ -296,7 +302,7 @@ const AddCustomTokenForm = () => {
                 autoComplete="off"
                 small
                 readOnly
-                disabled={!fldContractAddress.state.meta.isValid}
+                disabled={!isContractAddressValid}
               />
             </FormFieldContainer>
           )}
@@ -329,7 +335,7 @@ const AddCustomTokenForm = () => {
                 autoComplete="off"
                 placeholder="(optional)"
                 small
-                disabled={!fldContractAddress.state.meta.isValid}
+                disabled={!isContractAddressValid}
                 before={
                   <AssetLogo
                     className="mr-2 rounded-full text-[1.875rem]"
@@ -360,7 +366,7 @@ const AddCustomTokenForm = () => {
                 value={field.state.value ?? ""}
                 onChange={(e) => field.handleChange(e.target.value)}
                 autoComplete="off"
-                disabled={!fldContractAddress.state.meta.isValid}
+                disabled={!isContractAddressValid}
                 small
               />
             </FormFieldContainer>

--- a/apps/extension/src/ui/apps/dashboard/routes/Tokens/AddTokenPage.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Tokens/AddTokenPage.tsx
@@ -133,10 +133,11 @@ const AddCustomTokenForm = () => {
   // by `<form.Field>` takes over `fieldInfo[name].instance`, and form-core then discards the async
   // validation results of the `<form.Field>` instance which owns the validators.
   const networkId = useStore(form.store, (s) => s.values.networkId)
-  const isContractAddressValid = useStore(
-    form.store,
-    (s) => s.fieldMeta.contractAddress?.isValid ?? true
-  )
+
+  // The token fields are only meaningful once the contract address resolved to a new token, which
+  // makes `token` the gate for both editing and validating them: validating them earlier would
+  // display "expected string, received undefined" errors next to the contract address error.
+  const hasTokenInfo = useStore(form.store, (s) => !!s.values.token)
 
   // Fields populated from the token info fetch. They must all be cleared whenever the contract
   // address stops resolving to a new token, else they keep displaying the previous token's info.
@@ -258,7 +259,8 @@ const AddCustomTokenForm = () => {
         <form.Field
           name="symbol"
           validators={{
-            onChange: ({ value }) => {
+            onChange: ({ value, fieldApi }) => {
+              if (!fieldApi.form.getFieldValue("token")) return undefined
               const parsed = TokenBaseSchema.shape.symbol.safeParse(value)
               return parsed.success
                 ? undefined
@@ -275,7 +277,7 @@ const AddCustomTokenForm = () => {
                 autoComplete="off"
                 placeholder="TKN"
                 small
-                disabled={!isContractAddressValid}
+                disabled={!hasTokenInfo}
               />
             </FormFieldContainer>
           )}
@@ -284,7 +286,8 @@ const AddCustomTokenForm = () => {
         <form.Field
           name="decimals"
           validators={{
-            onChange: ({ value }) => {
+            onChange: ({ value, fieldApi }) => {
+              if (!fieldApi.form.getFieldValue("token")) return undefined
               const parsed = TokenBaseSchema.shape.decimals.safeParse(value)
               return parsed.success
                 ? undefined
@@ -302,7 +305,7 @@ const AddCustomTokenForm = () => {
                 autoComplete="off"
                 small
                 readOnly
-                disabled={!isContractAddressValid}
+                disabled={!hasTokenInfo}
               />
             </FormFieldContainer>
           )}
@@ -311,7 +314,8 @@ const AddCustomTokenForm = () => {
         <form.Field
           name="coingeckoId"
           validators={{
-            onChange: ({ value }) => {
+            onChange: ({ value, fieldApi }) => {
+              if (!fieldApi.form.getFieldValue("token")) return undefined
               const parsed = TokenBaseSchema.shape.coingeckoId.safeParse(value)
               return parsed.success
                 ? undefined
@@ -335,7 +339,7 @@ const AddCustomTokenForm = () => {
                 autoComplete="off"
                 placeholder="(optional)"
                 small
-                disabled={!isContractAddressValid}
+                disabled={!hasTokenInfo}
                 before={
                   <AssetLogo
                     className="mr-2 rounded-full text-[1.875rem]"
@@ -350,7 +354,8 @@ const AddCustomTokenForm = () => {
         <form.Field
           name="name"
           validators={{
-            onChange: ({ value }) => {
+            onChange: ({ value, fieldApi }) => {
+              if (!fieldApi.form.getFieldValue("token")) return undefined
               const parsed = TokenBaseSchema.shape.name.safeParse(value)
               return parsed.success
                 ? undefined
@@ -366,7 +371,7 @@ const AddCustomTokenForm = () => {
                 value={field.state.value ?? ""}
                 onChange={(e) => field.handleChange(e.target.value)}
                 autoComplete="off"
-                disabled={!isContractAddressValid}
+                disabled={!hasTokenInfo}
                 small
               />
             </FormFieldContainer>

--- a/apps/extension/src/ui/apps/dashboard/routes/Tokens/__tests__/AddTokenPage.test.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Tokens/__tests__/AddTokenPage.test.tsx
@@ -90,4 +90,26 @@ describe("AddTokenPage", () => {
     expect(screen.getByDisplayValue("USD Coin")).toBeTruthy()
     expect(screen.getByDisplayValue("usd-coin")).toBeTruthy()
   })
+
+  test("keeps the token fields disabled and error-free while the contract address is invalid", async () => {
+    mockGetErc20TokenInfo.mockRejectedValue(new Error("not an erc20 contract"))
+
+    selectNetworkAndEnterAddress(USDC_ADDRESS)
+
+    expect(await screen.findByText("Invalid contract address")).toBeTruthy()
+    expect(screen.queryByText(/expected string, received undefined/)).toBeNull()
+    expect(screen.queryByText(/expected number, received undefined/)).toBeNull()
+
+    for (const placeholder of ["TKN", "18", "(optional)", "My Custom Token"])
+      expect((screen.getByPlaceholderText(placeholder) as HTMLInputElement).disabled).toBe(true)
+  })
+
+  test("enables the token fields once the token info is fetched", async () => {
+    selectNetworkAndEnterAddress(USDC_ADDRESS)
+
+    await screen.findByDisplayValue("USDC")
+
+    for (const placeholder of ["TKN", "18", "(optional)", "My Custom Token"])
+      expect((screen.getByPlaceholderText(placeholder) as HTMLInputElement).disabled).toBe(false)
+  })
 })

--- a/apps/extension/src/ui/apps/dashboard/routes/Tokens/__tests__/AddTokenPage.test.tsx
+++ b/apps/extension/src/ui/apps/dashboard/routes/Tokens/__tests__/AddTokenPage.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { of } from "rxjs"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const NETWORK = { id: "8453", platform: "ethereum", name: "Base" }
+const USDC_ADDRESS = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+const EXISTING_TOKEN_ID = `8453:evm-erc20:${USDC_ADDRESS}`
+
+const mockGetToken = vi.fn()
+const mockGetUniswapV2TokenInfo = vi.fn()
+const mockGetErc20TokenInfo = vi.fn()
+
+vi.mock("@ui/apps/dashboard/layout", () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@ui/hooks/useAnalyticsPageView", () => ({ useAnalyticsPageView: () => {} }))
+
+vi.mock("react-router-dom", () => ({ useNavigate: () => vi.fn() }))
+
+vi.mock("@ui/state/chaindata", () => ({
+  useNetworks: () => [NETWORK],
+  getNetworkById$: () => of(NETWORK),
+  getToken$: (tokenId: string) => of(mockGetToken(tokenId)),
+}))
+
+vi.mock("@ui/domains/Networks/NetworkCombo", () => ({
+  NetworkCombo: ({ onChange }: { onChange: (networkId: string) => void }) => (
+    <button type="button" onClick={() => onChange("8453")}>
+      select network
+    </button>
+  ),
+}))
+
+vi.mock("@ui/domains/Asset/AssetLogo", () => ({ AssetLogo: () => null }))
+
+vi.mock("@ui/domains/Ethereum/usePublicClient", () => ({ getExtensionPublicClient: () => ({}) }))
+
+vi.mock("@core/util/getUniswapV2TokenInfo", () => ({
+  getUniswapV2TokenInfo: (...args: unknown[]) => mockGetUniswapV2TokenInfo(...args),
+}))
+
+vi.mock("@core/util/getErc20TokenInfo", () => ({
+  getErc20TokenInfo: (...args: unknown[]) => mockGetErc20TokenInfo(...args),
+}))
+
+import { AddTokenPage } from "../AddTokenPage"
+
+const selectNetworkAndEnterAddress = (address: string) => {
+  render(<AddTokenPage />)
+
+  fireEvent.click(screen.getByText("select network"))
+  fireEvent.change(screen.getByPlaceholderText("0xdeadbeef...deadbeef"), {
+    target: { value: address },
+  })
+}
+
+describe("AddTokenPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetToken.mockReturnValue(null)
+    mockGetUniswapV2TokenInfo.mockRejectedValue(new Error("not a uniswap v2 pair"))
+    mockGetErc20TokenInfo.mockResolvedValue({
+      id: EXISTING_TOKEN_ID,
+      networkId: "8453",
+      type: "evm-erc20",
+      symbol: "USDC",
+      decimals: 6,
+      name: "USD Coin",
+      coingeckoId: "usd-coin",
+    })
+  })
+
+  test("displays the error returned by the contract address validator", async () => {
+    mockGetToken.mockImplementation((tokenId: string) =>
+      tokenId === EXISTING_TOKEN_ID ? { id: tokenId } : null
+    )
+
+    selectNetworkAndEnterAddress(USDC_ADDRESS)
+
+    expect(await screen.findByText("Token already exists")).toBeTruthy()
+  })
+
+  test("populates the token fields from the fetched token info", async () => {
+    selectNetworkAndEnterAddress(USDC_ADDRESS)
+
+    const symbol = await screen.findByDisplayValue("USDC")
+    expect(symbol).toBeTruthy()
+    expect(screen.getByDisplayValue(6)).toBeTruthy()
+    expect(screen.getByDisplayValue("USD Coin")).toBeTruthy()
+    expect(screen.getByDisplayValue("usd-coin")).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/TalismanSociety/talisman-qa/issues/132

Add custom token form swallowed the contract address validator error (e.g. "Token already exists"), leaving Symbol/Decimals blank with confusing zod errors instead.

Cause: the form created a second `FieldApi` per name via bare `useField` alongside `<form.Field>`. React mounts children first, so the validator-less instance won `fieldInfo[name].instance`, and form-core discards async validation results from any other instance.

Fix: read those values from the form store instead of creating competing field instances. Symbol/Decimals/Coingecko ID/Name are also now disabled *and* unvalidated until the contract address resolves to a token, so a contract address error is the only error shown. Regression tests added.