### PR TITLE
🐛 keep auto-lock armed when the stored duration is unusable

### DIFF
--- a/apps/extension/src/core/domains/app/autoLock.ts
+++ b/apps/extension/src/core/domains/app/autoLock.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_AUTO_LOCK_MINUTES = 15
+
+/**
+ * A stored duration that isn't a usable number (`NaN`, `null`, a leftover from an old
+ * settings shape) must not be read as "never lock" — callers fall back to the default.
+ */
+export const isUsableAutoLockDuration = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0

--- a/apps/extension/src/core/domains/app/migrations/autoLock.test.ts
+++ b/apps/extension/src/core/domains/app/migrations/autoLock.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ── Mock dependencies ──────────────────────────────────────────────
+
+vi.mock("../../../config/sentry", () => ({
+  sentry: { captureException: vi.fn() },
+}))
+
+vi.mock("../../../rpcs/chaindata", () => ({ chaindataProvider: {} }))
+vi.mock("../../chains/store.activeChains", () => ({ activeChainsStore: {} }))
+vi.mock("../../ethereum/store.activeEvmNetworks", () => ({ activeEvmNetworksStore: {} }))
+vi.mock("../store.addressBook", () => ({ addressBookStore: {} }))
+
+const settings: Record<string, unknown> = {}
+vi.mock("../store.settings", () => ({
+  settingsStore: {
+    get: vi.fn(async (key: string) => settings[key]),
+    set: vi.fn(async (data: Record<string, unknown>) => {
+      Object.assign(settings, data)
+    }),
+  },
+}))
+
+const legacySettings: Record<string, unknown> = {}
+vi.mock("../../../libs/Store", () => ({
+  StorageProvider: class {
+    async get(key: string) {
+      return legacySettings[key]
+    }
+    async set(data: Record<string, unknown>) {
+      Object.assign(legacySettings, data)
+    }
+    async delete(key: string) {
+      delete legacySettings[key]
+    }
+  },
+}))
+
+// ── Import SUT after mocks ──────────────────────────────────────────
+
+const { migrateAutoLockTimeoutToMinutes, repairAutoLockMinutes } = await import("./index")
+const { settingsStore } = await import("../store.settings")
+
+const context = { password: "test-password" }
+
+describe("auto-lock migrations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const key of Object.keys(settings)) delete settings[key]
+    for (const key of Object.keys(legacySettings)) delete legacySettings[key]
+  })
+
+  describe("migrateAutoLockTimeoutToMinutes", () => {
+    it("converts a stored legacy duration to minutes", async () => {
+      legacySettings.autoLockTimeout = 900
+
+      await migrateAutoLockTimeoutToMinutes.forward.apply(context)
+
+      expect(settingsStore.set).toHaveBeenCalledWith({ autoLockMinutes: 15 })
+    })
+
+    it("keeps a legacy 0 (auto-lock disabled)", async () => {
+      legacySettings.autoLockTimeout = 0
+
+      await migrateAutoLockTimeoutToMinutes.forward.apply(context)
+
+      expect(settingsStore.set).toHaveBeenCalledWith({ autoLockMinutes: 0 })
+    })
+
+    // dividing an absent setting by 60 gave NaN, which persisted as "auto-lock disabled"
+    it("writes nothing when the legacy setting was never stored", async () => {
+      expect(await migrateAutoLockTimeoutToMinutes.forward.apply(context)).toBe(true)
+
+      expect(settingsStore.set).not.toHaveBeenCalled()
+      expect(settings.autoLockMinutes).toBeUndefined()
+    })
+  })
+
+  describe("repairAutoLockMinutes", () => {
+    it.each([
+      ["null", null],
+      ["NaN", Number.NaN],
+      ["undefined", undefined],
+      ["a negative duration", -1],
+      ["a non-number", "15"],
+    ])("restores the default when the stored duration is %s", async (_label, stored) => {
+      settings.autoLockMinutes = stored
+
+      await repairAutoLockMinutes.forward.apply(context)
+
+      expect(settingsStore.set).toHaveBeenCalledWith({ autoLockMinutes: 15 })
+    })
+
+    it("leaves a valid duration untouched", async () => {
+      settings.autoLockMinutes = 5
+
+      await repairAutoLockMinutes.forward.apply(context)
+
+      expect(settingsStore.set).not.toHaveBeenCalled()
+      expect(settings.autoLockMinutes).toBe(5)
+    })
+
+    it("leaves an explicit 0 untouched (user disabled auto-lock)", async () => {
+      settings.autoLockMinutes = 0
+
+      await repairAutoLockMinutes.forward.apply(context)
+
+      expect(settingsStore.set).not.toHaveBeenCalled()
+      expect(settings.autoLockMinutes).toBe(0)
+    })
+  })
+})

--- a/apps/extension/src/core/domains/app/migrations/index.ts
+++ b/apps/extension/src/core/domains/app/migrations/index.ts
@@ -6,6 +6,7 @@ import { StorageProvider } from "../../../libs/Store"
 import { chaindataProvider } from "../../../rpcs/chaindata"
 import { activeChainsStore } from "../../chains/store.activeChains"
 import { activeEvmNetworksStore } from "../../ethereum/store.activeEvmNetworks"
+import { DEFAULT_AUTO_LOCK_MINUTES, isUsableAutoLockDuration } from "../autoLock"
 import { addressBookStore } from "../store.addressBook"
 import { settingsStore } from "../store.settings"
 
@@ -38,9 +39,12 @@ export const hideGetStartedIfFunded: Migration = {
 export const migrateAutoLockTimeoutToMinutes: Migration = {
   forward: new MigrationFunction(async (_) => {
     const legacySettingsStore = new StorageProvider<{ autoLockTimeout: number }>("settings")
-    const currentValue = await legacySettingsStore.get("autoLockTimeout")
-    if (currentValue === 0) await settingsStore.set({ autoLockMinutes: 0 })
-    else await settingsStore.set({ autoLockMinutes: currentValue / 60 })
+    const legacySeconds = await legacySettingsStore.get("autoLockTimeout")
+
+    // an install that never wrote the legacy setting keeps the default
+    if (!isUsableAutoLockDuration(legacySeconds)) return
+
+    await settingsStore.set({ autoLockMinutes: legacySeconds / 60 })
   }),
   backward: new MigrationFunction(async (_) => {
     const currentValue = await settingsStore.get("autoLockMinutes")
@@ -49,6 +53,21 @@ export const migrateAutoLockTimeoutToMinutes: Migration = {
     const legacySettingsStore = new StorageProvider<{ autoLockTimeout: number }>("settings")
     await legacySettingsStore.set({ autoLockTimeout: currentValue * 60 })
   }),
+}
+
+/**
+ * `migrateAutoLockTimeoutToMinutes` used to divide an absent legacy setting by 60, persisting
+ * `NaN` (stored as `null`) as the auto-lock duration, which reads as "auto-lock disabled".
+ * The migration is already recorded as applied on those installs, so the value is repaired here.
+ */
+export const repairAutoLockMinutes: Migration = {
+  forward: new MigrationFunction(async (_) => {
+    const autoLockMinutes = await settingsStore.get("autoLockMinutes")
+    if (isUsableAutoLockDuration(autoLockMinutes)) return
+
+    await settingsStore.set({ autoLockMinutes: DEFAULT_AUTO_LOCK_MINUTES })
+  }),
+  // no way back
 }
 
 export const migrateEnabledTestnets: Migration = {

--- a/apps/extension/src/core/domains/app/store.password.test.ts
+++ b/apps/extension/src/core/domains/app/store.password.test.ts
@@ -201,6 +201,46 @@ describe("PasswordStore autolock timer", () => {
       // No existing alarm → should create one
       expect(chromeMock.alarms.create).toHaveBeenCalledWith(ALARM_NAME, { delayInMinutes: 15 })
     })
+
+    // a corrupted setting must not read as "never lock"
+    it.each([
+      ["NaN", Number.NaN],
+      ["null", null as unknown as number],
+      ["a negative duration", -1],
+      ["a non-number", "15" as unknown as number],
+    ])("falls back to the default duration when minutes is %s", async (_label, minutes) => {
+      store.isLoggedIn.next("TRUE")
+
+      await store.resetAutolockTimer(minutes)
+
+      expect(chromeMock.alarms.create).toHaveBeenCalledWith(ALARM_NAME, { delayInMinutes: 15 })
+    })
+
+    it("still honours an explicit 0 (user disabled auto-lock)", async () => {
+      store.isLoggedIn.next("TRUE")
+
+      await store.resetAutolockTimer(0)
+
+      expect(chromeMock.alarms.create).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("onboarding", () => {
+    it("schedules the alarm when the first password is set", async () => {
+      // mirrors the Extension wiring: the autolock timer is (re)scheduled on every
+      // isLoggedIn transition, which is what covers onboarding — it never calls
+      // resetAutolockTimer itself.
+      store.isLoggedIn.subscribe(() => {
+        store.resetAutolockTimer(15, { preserveExisting: true })
+      })
+
+      await store.setPassword("hashed-password")
+
+      expect(store.isLoggedIn.value).toBe("TRUE")
+      await vi.waitFor(() =>
+        expect(chromeMock.alarms.create).toHaveBeenCalledWith(ALARM_NAME, { delayInMinutes: 15 })
+      )
+    })
   })
 
   describe("alarm listener (auto-lock trigger)", () => {

--- a/apps/extension/src/core/domains/app/store.password.ts
+++ b/apps/extension/src/core/domains/app/store.password.ts
@@ -7,6 +7,7 @@ import { Err, Ok, type Result } from "ts-results"
 import { StorageProvider } from "../../libs/Store"
 import { createNotification } from "../../notifications"
 import { sessionStorage } from "../../util/sessionStorageCompat"
+import { DEFAULT_AUTO_LOCK_MINUTES, isUsableAutoLockDuration } from "./autoLock"
 
 /* ----------------------------------------------------------------
 Contains sensitive data.
@@ -74,8 +75,11 @@ export class PasswordStore extends StorageProvider<PasswordStoreData> {
     // minutes === undefined means settings haven't loaded yet — preserve any existing alarm.
     if (minutes === undefined) return
 
-    // minutes === 0 means the user explicitly disabled auto-lock — clear and stop.
-    if (minutes <= 0) {
+    // Only 0 disables auto-lock. Any other unusable value is a corrupted setting, and must
+    // fall back to the default rather than schedule an alarm that never fires.
+    const delayInMinutes = isUsableAutoLockDuration(minutes) ? minutes : DEFAULT_AUTO_LOCK_MINUTES
+
+    if (delayInMinutes === 0) {
       await chrome.alarms.clear(ALARM_NAME)
       return
     }
@@ -85,12 +89,12 @@ export class PasswordStore extends StorageProvider<PasswordStoreData> {
     // from extending the unlock window.
     if (preserveExisting) {
       const existing = await chrome.alarms.get(ALARM_NAME)
-      if (existing && existing.scheduledTime <= Date.now() + minutes * 60_000) return
+      if (existing && existing.scheduledTime <= Date.now() + delayInMinutes * 60_000) return
     }
 
     // Replace the existing alarm with a fresh one-shot alarm.
     await chrome.alarms.clear(ALARM_NAME)
-    await chrome.alarms.create(ALARM_NAME, { delayInMinutes: minutes })
+    await chrome.alarms.create(ALARM_NAME, { delayInMinutes })
   }
 
   async reset() {

--- a/apps/extension/src/core/domains/app/store.settings.ts
+++ b/apps/extension/src/core/domains/app/store.settings.ts
@@ -3,6 +3,7 @@ import type { TokenRateCurrency } from "@talismn/token-rates"
 
 import { StorageProvider } from "../../libs/Store"
 import type { IdenticonType } from "../accounts/types"
+import { DEFAULT_AUTO_LOCK_MINUTES } from "./autoLock"
 
 export type LedgerTransportType = "usb" | "hid"
 
@@ -46,7 +47,7 @@ const DEFAULT_SETTINGS: SettingsStoreData = {
   hideBalances: false,
   hideDust: false,
   allowNotifications: true,
-  autoLockMinutes: 15,
+  autoLockMinutes: DEFAULT_AUTO_LOCK_MINUTES,
   selectableCurrencies: ["usd", "tao", "eth"],
   selectedCurrency: "usd",
   newFeaturesDismissed: "0",

--- a/apps/extension/src/core/libs/migrations/migrations.ts
+++ b/apps/extension/src/core/libs/migrations/migrations.ts
@@ -11,6 +11,7 @@ import {
   hideGetStartedIfFunded,
   migrateAutoLockTimeoutToMinutes,
   migrateEnabledTestnets,
+  repairAutoLockMinutes,
 } from "../../domains/app/migrations"
 import {
   migrateAssetDiscoveryRollout,
@@ -49,6 +50,7 @@ export const migrations: Migrations = [
   migrateTransactionsV2,
   migrateNftsV2,
   migrateAssetDiscoveryV3,
+  repairAutoLockMinutes,
 ]
 
 // @dev snippet to use in dev console of background worker to remove a migration:


### PR DESCRIPTION
`migrateAutoLockTimeoutToMinutes` divided an absent legacy `autoLockTimeout` by 60 and stored the `NaN`, which read back as "auto-lock disabled".

- migration returns early when the legacy key is unusable
- new `repairAutoLockMinutes` migration heals installs where the old one already ran
- `resetAutolockTimer` falls back to the 15 min default for any unusable duration — only an explicit `0` disables auto-lock

Tests: `migrations/autoLock.test.ts`, plus cases in `store.password.test.ts`.