### PR TITLE
🐛 Transaction status accuracy

### DIFF
--- a/apps/extension/src/core/domains/transactions/cleanupDroppedTransactions.test.ts
+++ b/apps/extension/src/core/domains/transactions/cleanupDroppedTransactions.test.ts
@@ -241,21 +241,23 @@ describe("cleanupDroppedTransactions", () => {
 
       await cleanupAllDroppedTransactions()
 
+      expect(mockChainConnectorSend).toHaveBeenCalledWith("polkadot", "system_accountNextIndex", [
+        "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      ])
       const tx = await db.transactionsV2.get("sub-polkadot-5")
       expect(tx?.status).toBe("error")
     })
 
-    it("marks unknown substrate tx as error when nonce was consumed", async () => {
+    it("leaves substrate tx unknown when nonce was consumed", async () => {
       mockChainConnectorSend.mockResolvedValue(6) // next index = 6, nonce 5 consumed
       await db.transactionsV2.put(makeSubstrateTx(5))
 
       await cleanupAllDroppedTransactions()
 
-      // Even when the nonce was consumed (by this tx or a replacement),
-      // we mark as error because the real-time watcher should have caught
-      // a successful inclusion. Leaving it as "unknown" forever is worse UX.
+      // A consumed nonce doesn't tell us whether it was this extrinsic or another one,
+      // so the tx must not be reported as failed.
       const tx = await db.transactionsV2.get("sub-polkadot-5")
-      expect(tx?.status).toBe("error")
+      expect(tx?.status).toBe("unknown")
     })
 
     it("leaves substrate tx when chain is unavailable (fail-safe)", async () => {
@@ -266,6 +268,35 @@ describe("cleanupDroppedTransactions", () => {
 
       const tx = await db.transactionsV2.get("sub-polkadot-5")
       expect(tx?.status).toBe("unknown")
+    })
+
+    it("leaves substrate tx when the node returns a malformed nonce (fail-safe)", async () => {
+      mockChainConnectorSend.mockResolvedValue("0x05")
+      await db.transactionsV2.put(makeSubstrateTx(5))
+
+      await cleanupAllDroppedTransactions()
+
+      const tx = await db.transactionsV2.get("sub-polkadot-5")
+      expect(tx?.status).toBe("unknown")
+    })
+
+    it("queries the nonce once per account and network", async () => {
+      const otherAccount = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+      mockChainConnectorSend.mockImplementation((_networkId, _method, [address]: [string]) =>
+        Promise.resolve(address === otherAccount ? 9 : 5)
+      )
+      await db.transactionsV2.bulkPut([
+        makeSubstrateTx(5),
+        makeSubstrateTx(3),
+        makeSubstrateTx(9, "unknown", "polkadot", otherAccount),
+      ])
+
+      await cleanupAllDroppedTransactions()
+
+      expect(mockChainConnectorSend).toHaveBeenCalledTimes(2)
+      expect((await db.transactionsV2.get("sub-polkadot-5"))?.status).toBe("error")
+      expect((await db.transactionsV2.get("sub-polkadot-3"))?.status).toBe("unknown")
+      expect((await db.transactionsV2.get("sub-polkadot-9"))?.status).toBe("error")
     })
   })
 

--- a/apps/extension/src/core/domains/transactions/cleanupDroppedTransactions.ts
+++ b/apps/extension/src/core/domains/transactions/cleanupDroppedTransactions.ts
@@ -14,7 +14,7 @@ import type { WalletTransactionDot, WalletTransactionEth, WalletTransactionSol }
  *
  * Platform-specific verification:
  * - EVM: eth_getTransactionByHash — not found means dropped
- * - Substrate: chain reachability check — marks all unknown txs as dropped
+ * - Substrate: system_accountNextIndex — an unconsumed nonce means dropped
  * - Solana: getSignatureStatuses — null means dropped
  *
  * All checks are fail-safe: RPC errors leave the tx as "unknown".
@@ -122,18 +122,23 @@ const cleanupEvmTransactions = async (txs: WalletTransactionEth[]): Promise<void
 const cleanupSubstrateTransactions = async (txs: WalletTransactionDot[]): Promise<void> => {
   if (txs.length === 0) return
 
-  // Group by network: one reachability check per chain
-  const byNetwork = groupBy(txs, (tx) => tx.networkId)
-  for (const [networkId, networkTxs] of byNetwork) {
+  // An extrinsic can't be looked up by its hash once the watcher is gone, so the account nonce
+  // stands in for it. Group by account: one nonce lookup per account.
+  const byAccount = groupBy(txs, (tx) => `${tx.networkId}:${tx.account}`)
+  for (const accountTxs of byAccount.values()) {
+    const { networkId, account } = accountTxs[0]!
     try {
-      // Verify chain is reachable — if unavailable, skip and retry next startup
-      await chainConnector.send(networkId, "system_chain", [])
+      // counts the node's pool as well, so an extrinsic still waiting there raises this nonce too
+      const nextNonce = await chainConnector.send<number>(networkId, "system_accountNextIndex", [
+        account,
+      ])
+      if (!Number.isInteger(nextNonce)) continue
 
-      for (const tx of networkTxs) {
-        // The real-time watcher (90s window) should have caught any successful
-        // inclusion. Since it didn't, treat as dropped so the tx doesn't stay
-        // stuck as "unknown" forever. The user can verify on a block explorer.
-        await updateTransactionStatus(tx.id, "error")
+      for (const tx of accountTxs) {
+        // A nonce the chain hasn't consumed proves the extrinsic never executed. A consumed one
+        // proves nothing — this extrinsic or another one may have taken it — so leave the
+        // transaction "unknown" instead of reporting a transfer that succeeded as failed.
+        if (nextNonce <= tx.nonce) await updateTransactionStatus(tx.id, "error")
       }
     } catch {
       // Chain unavailable — skip

--- a/apps/extension/src/core/domains/transactions/helpers.ts
+++ b/apps/extension/src/core/domains/transactions/helpers.ts
@@ -19,6 +19,9 @@ const DEFAULT_OPTIONS: AddTransactionOptions = {
   label: "Transaction",
 }
 
+const isTerminalStatus = (status: TransactionStatus) =>
+  status === "success" || status === "error" || status === "replaced"
+
 export const addSolTransaction = async (
   networkId: SolNetworkId,
   transaction: SolTransaction,
@@ -36,7 +39,7 @@ export const addSolTransaction = async (
     // terminal status overwritten back to "pending".
     await db.transaction("rw", db.transactionsV2, async () => {
       const existing = await db.transactionsV2.get(signature)
-      if (existing && ["success", "error", "replaced"].includes(existing.status)) return
+      if (existing && isTerminalStatus(existing.status)) return
 
       await db.transactionsV2.put({
         id: signature,
@@ -72,7 +75,7 @@ export const addEvmTransaction = async (
 
     await db.transaction("rw", db.transactionsV2, async () => {
       const existingEvm = await db.transactionsV2.get(hash)
-      if (existingEvm && ["success", "error", "replaced"].includes(existingEvm.status)) return
+      if (existingEvm && isTerminalStatus(existingEvm.status)) return
 
       // Only flag as replacement if there's a pending tx with the same nonce from the same account.
       // Terminated txs (error, unknown, replaced, success) should not trigger the replacement flag —
@@ -125,7 +128,7 @@ export const addSubstrateTransaction = async (
 
     await db.transaction("rw", db.transactionsV2, async () => {
       const existingSub = await db.transactionsV2.get(hash)
-      if (existingSub && ["success", "error", "replaced"].includes(existingSub.status)) return
+      if (existingSub && isTerminalStatus(existingSub.status)) return
 
       await db.transactionsV2.put({
         id: hash,
@@ -157,27 +160,22 @@ export const updateTransactionStatus = async (
   confirmed?: boolean
 ) => {
   try {
-    // this can be called after the tx has been overriden/replaced, check status first
-    const existing = await db.transactionsV2.get(id)
-    if (!existing) return false
-    if (
-      ["success", "error", "replaced"].includes(existing?.status ?? "") &&
-      !!confirmed === !!existing?.confirmed
-    )
-      return false
+    // Atomic read+write: a concurrent writer must not lose its status between the get and the update.
+    return await db.transaction("rw", db.transactionsV2, async () => {
+      // this can be called after the tx has been overriden/replaced, check status first
+      const existing = await db.transactionsV2.get(id)
+      if (!existing) return false
 
-    existing.status = status
-    existing.confirmed = !!confirmed
+      // Only a finalized result may supersede a terminal status, and a finalized one is definitive.
+      if (isTerminalStatus(existing.status) && (existing.confirmed || !confirmed)) return false
 
-    if (existing.platform !== "solana" && blockNumber !== undefined)
-      existing.blockNumber = blockNumber.toString()
+      const tx = { ...existing, status, confirmed: !!confirmed }
+      if (tx.platform !== "solana" && blockNumber !== undefined)
+        tx.blockNumber = blockNumber.toString()
 
-    await db.transactionsV2.update(id, existing)
+      await db.transactionsV2.put(tx)
 
-    if (["success", "error"].includes(status)) {
-      const tx = await db.transactionsV2.get(id)
-
-      if (tx) {
+      if (status === "success" || status === "error") {
         // mark pending transactions with the same nonce as replaced
         await db.transactionsV2
           .filter(filterIsSameNetworkAndAddressTx(tx))
@@ -204,9 +202,9 @@ export const updateTransactionStatus = async (
           )
           .modify({ status: "unknown" })
       }
-    }
 
-    return true
+      return true
+    })
   } catch (err) {
     // biome-ignore lint/suspicious/noConsole: legacy
     console.error("updateTransactionStatus", { err })

--- a/apps/extension/src/core/domains/transactions/updateTransactionStatus.test.ts
+++ b/apps/extension/src/core/domains/transactions/updateTransactionStatus.test.ts
@@ -1,0 +1,124 @@
+import type { WalletTransactionEth } from "@core/domains/transactions/types"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { db } from "../../db"
+import { updateTransactionStatus } from "./helpers"
+
+// --- Helpers ---
+
+const ACCOUNT_A = "0x1111111111111111111111111111111111111111" as `0x${string}`
+const ACCOUNT_B = "0x2222222222222222222222222222222222222222" as `0x${string}`
+const NETWORK_ID = "1"
+
+const makeEvmTx = (
+  nonce: number,
+  status: WalletTransactionEth["status"] = "pending",
+  {
+    networkId = NETWORK_ID,
+    account = ACCOUNT_A,
+    confirmed = false,
+  }: { networkId?: string; account?: `0x${string}`; confirmed?: boolean } = {}
+): WalletTransactionEth => ({
+  id: `${networkId}-${account}-${nonce}`,
+  platform: "ethereum",
+  networkId,
+  account,
+  status,
+  confirmed,
+  payload: { from: account, nonce },
+  hash: `0x${nonce.toString(16).padStart(64, "0")}` as `0x${string}`,
+  nonce,
+  timestamp: Date.now(),
+})
+
+const idOf = (nonce: number, account = ACCOUNT_A, networkId = NETWORK_ID) =>
+  `${networkId}-${account}-${nonce}`
+
+describe("updateTransactionStatus", () => {
+  beforeEach(async () => {
+    await db.transactionsV2.clear()
+  })
+
+  it("returns false for an unknown id", async () => {
+    expect(await updateTransactionStatus("nope", "success")).toBe(false)
+  })
+
+  it("updates a pending tx and stores the block number", async () => {
+    await db.transactionsV2.put(makeEvmTx(5))
+
+    expect(await updateTransactionStatus(idOf(5), "success", 42n, true)).toBe(true)
+
+    const tx = await db.transactionsV2.get(idOf(5))
+    expect(tx?.status).toBe("success")
+    expect(tx?.confirmed).toBe(true)
+    expect(tx?.platform === "ethereum" && tx.blockNumber).toBe("42")
+  })
+
+  it("upgrades an unconfirmed terminal status to confirmed", async () => {
+    await db.transactionsV2.put(makeEvmTx(5, "success"))
+
+    expect(await updateTransactionStatus(idOf(5), "success", undefined, true)).toBe(true)
+
+    const tx = await db.transactionsV2.get(idOf(5))
+    expect(tx?.status).toBe("success")
+    expect(tx?.confirmed).toBe(true)
+  })
+
+  it("keeps a confirmed terminal status immutable", async () => {
+    await db.transactionsV2.put(makeEvmTx(5, "success", { confirmed: true }))
+
+    expect(await updateTransactionStatus(idOf(5), "error")).toBe(false)
+    expect(await updateTransactionStatus(idOf(5), "error", undefined, true)).toBe(false)
+    expect(await updateTransactionStatus(idOf(5), "unknown")).toBe(false)
+
+    const tx = await db.transactionsV2.get(idOf(5))
+    expect(tx?.status).toBe("success")
+    expect(tx?.confirmed).toBe(true)
+  })
+
+  it("refuses an unconfirmed status over an unconfirmed terminal status", async () => {
+    await db.transactionsV2.put(makeEvmTx(5, "success"))
+
+    expect(await updateTransactionStatus(idOf(5), "unknown")).toBe(false)
+
+    const tx = await db.transactionsV2.get(idOf(5))
+    expect(tx?.status).toBe("success")
+  })
+
+  it("keeps the confirmed result when a concurrent writer reports another status", async () => {
+    await db.transactionsV2.put(makeEvmTx(5))
+
+    await Promise.all([
+      updateTransactionStatus(idOf(5), "success", 42n, true),
+      updateTransactionStatus(idOf(5), "unknown"),
+    ])
+
+    const tx = await db.transactionsV2.get(idOf(5))
+    expect(tx?.status).toBe("success")
+    expect(tx?.confirmed).toBe(true)
+  })
+
+  it("marks same-nonce pending txs of the same account as replaced", async () => {
+    await db.transactionsV2.bulkPut([
+      makeEvmTx(5),
+      { ...makeEvmTx(5), id: "speedup" },
+      makeEvmTx(5, "pending", { account: ACCOUNT_B }),
+      makeEvmTx(5, "pending", { networkId: "137" }),
+    ])
+
+    await updateTransactionStatus(idOf(5), "success", undefined, true)
+
+    expect((await db.transactionsV2.get("speedup"))?.status).toBe("replaced")
+    expect((await db.transactionsV2.get(idOf(5, ACCOUNT_B)))?.status).toBe("pending")
+    expect((await db.transactionsV2.get(idOf(5, ACCOUNT_A, "137")))?.status).toBe("pending")
+  })
+
+  it("marks lower-nonce pending txs of the same account as unknown", async () => {
+    await db.transactionsV2.bulkPut([makeEvmTx(5), makeEvmTx(4), makeEvmTx(6)])
+
+    await updateTransactionStatus(idOf(5), "success", undefined, true)
+
+    expect((await db.transactionsV2.get(idOf(4)))?.status).toBe("unknown")
+    expect((await db.transactionsV2.get(idOf(6)))?.status).toBe("pending")
+  })
+})

--- a/apps/extension/src/core/domains/transactions/watchSolanaTransaction.test.ts
+++ b/apps/extension/src/core/domains/transactions/watchSolanaTransaction.test.ts
@@ -1,0 +1,123 @@
+import type { SolTransaction } from "@talismn/solana"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// --- Mocks ---
+
+const SIGNATURE = "sig1"
+const NETWORK_ID = "solana-mainnet"
+
+vi.mock("@talismn/solana", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@talismn/solana")>()),
+  parseTransactionInfo: () => ({ signature: SIGNATURE, address: "acct1", feePayer: "acct1" }),
+  serializeTransaction: () => "serialized",
+}))
+
+vi.mock("@talismn/chaindata-provider", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@talismn/chaindata-provider")>()),
+  getBlockExplorerUrls: () => ["https://explorer.test/tx/sig1"],
+}))
+
+vi.mock("../../rpcs/chaindata", () => ({
+  chaindataProvider: { getNetworkById: vi.fn().mockResolvedValue({ name: "Solana" }) },
+}))
+
+const mockGetSignatureStatuses = vi.fn()
+const mockGetTransaction = vi.fn()
+vi.mock("../../rpcs/chain-connector-sol", () => ({
+  chainConnectorSol: {
+    getRpc: vi.fn().mockResolvedValue({
+      getSignatureStatuses: () => ({ send: () => mockGetSignatureStatuses() }),
+      getTransaction: () => ({ send: () => mockGetTransaction() }),
+    }),
+  },
+}))
+
+const mockCreateNotification = vi.fn()
+vi.mock("../../notifications", () => ({
+  createNotification: (...args: unknown[]) => mockCreateNotification(...args),
+}))
+
+const mockWatchSwapStatus = vi.fn()
+vi.mock("./watchSwapStatus", () => ({
+  watchSwapStatus: (...args: unknown[]) => mockWatchSwapStatus(...args),
+}))
+
+vi.mock("../../config/sentry", () => ({ sentry: { captureException: vi.fn() } }))
+
+import { db } from "../../db"
+import type { WalletTransactionInfo } from "./types"
+import { watchSolanaTransaction } from "./watchSolanaTransaction"
+
+// --- Helpers ---
+
+const TRANSACTION = {} as SolTransaction
+const TX_INFO = { type: "swap" } as unknown as WalletTransactionInfo
+
+const watch = () =>
+  watchSolanaTransaction(NETWORK_ID, TRANSACTION, { notifications: true, txInfo: TX_INFO })
+
+const getTx = () => db.transactionsV2.get(SIGNATURE)
+
+describe("watchSolanaTransaction", () => {
+  beforeEach(async () => {
+    await db.transactionsV2.clear()
+    vi.clearAllMocks()
+    mockGetTransaction.mockResolvedValue({ slot: 100n })
+  })
+
+  it("reports success when the first poll already returns finalized", async () => {
+    mockGetSignatureStatuses.mockResolvedValue({
+      value: [{ confirmationStatus: "finalized", err: null }],
+    })
+
+    await watch()
+
+    await vi.waitFor(async () => {
+      const tx = await getTx()
+      expect(tx?.status).toBe("success")
+      expect(tx?.confirmed).toBe(true)
+    })
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      "success",
+      "Solana",
+      "https://explorer.test/tx/sig1"
+    )
+    expect(mockWatchSwapStatus).toHaveBeenCalledWith(SIGNATURE)
+  })
+
+  it("notifies once when a confirmed tx is later finalized", async () => {
+    mockGetSignatureStatuses
+      .mockResolvedValueOnce({ value: [{ confirmationStatus: "confirmed", err: null }] })
+      .mockResolvedValue({ value: [{ confirmationStatus: "finalized", err: null }] })
+
+    await watch()
+
+    await vi.waitFor(
+      async () => {
+        expect((await getTx())?.confirmed).toBe(true)
+      },
+      { timeout: 10_000 }
+    )
+    expect((await getTx())?.status).toBe("success")
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1)
+    expect(mockWatchSwapStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports a failed tx as error", async () => {
+    mockGetSignatureStatuses.mockResolvedValue({
+      value: [{ confirmationStatus: "finalized", err: { InstructionError: [0, "Custom"] } }],
+    })
+
+    await watch()
+
+    await vi.waitFor(async () => {
+      expect((await getTx())?.status).toBe("error")
+    })
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      "error",
+      "Solana",
+      "https://explorer.test/tx/sig1"
+    )
+    expect(mockWatchSwapStatus).not.toHaveBeenCalled()
+  })
+})

--- a/apps/extension/src/core/domains/transactions/watchSolanaTransaction.ts
+++ b/apps/extension/src/core/domains/transactions/watchSolanaTransaction.ts
@@ -61,27 +61,32 @@ async function watchUntilFinalized(
       // TODO ideally we should check that the current block height (which is not the slot) is still < lastValidBlockHeight
       // but that would be one additional RPC call per poll
 
+      const isFinalized = confirmationStatus === "finalized"
+
       if (err) {
         txStatus = "error"
-        await updateTransactionStatus(signature, txStatus)
+        await updateTransactionStatus(signature, txStatus, undefined, isFinalized)
         if (notificationTxUrl) await createNotification("error", networkName, notificationTxUrl)
         return // we re done
-      } else if (confirmationStatus === "confirmed" && txStatus !== "success") {
+      } else if (isFinalized || confirmationStatus === "confirmed") {
+        // the first poll can already report "finalized", so success is reported from here too
+        const isFirstInclusion = txStatus !== "success"
         txStatus = "success"
 
-        const txDetails = await tryGetTransactionDetails(rpc, signature)
-        await updateTransactionStatus(signature, txStatus, txDetails?.slot)
+        if (isFirstInclusion || isFinalized) {
+          const txDetails = await tryGetTransactionDetails(rpc, signature)
+          await updateTransactionStatus(signature, txStatus, txDetails?.slot, isFinalized)
+        }
 
-        if (notificationTxUrl) await createNotification("success", networkName, notificationTxUrl)
+        if (isFirstInclusion) {
+          if (notificationTxUrl) await createNotification("success", networkName, notificationTxUrl)
 
-        // Start watching exchange status for swap transactions
-        if (txInfo) watchSwapStatus(signature)
+          // Start watching exchange status for swap transactions
+          if (txInfo) watchSwapStatus(signature)
+        }
 
-        // continue polling until finalized
-      } else if (confirmationStatus === "finalized") {
-        const txDetails = await tryGetTransactionDetails(rpc, signature)
-        await updateTransactionStatus(signature, txStatus, txDetails?.slot, true)
-        return // we re done
+        if (isFinalized) return // we re done
+        // else continue polling until finalized
       }
 
       // Wait before next poll


### PR DESCRIPTION
Three fixes to how a transaction's final status is recorded.

- **Substrate cleanup** no longer marks every leftover transaction as failed after a service-worker restart. It reads the account's next nonce: an unconsumed nonce proves the extrinsic never ran (`error`), a consumed one is ambiguous, so the transaction stays `unknown` instead of being reported as failed.
- **`updateTransactionStatus`** now does its read-modify-write inside a Dexie transaction, like the `add*` helpers already do, and its guard is directional — only a finalized result can supersede a terminal status.
- **Solana watcher** treats `finalized` and `confirmed` as one inclusion branch, so a transaction that finalizes on the first poll is recorded as `success` rather than persisted as `pending`.

Tests added for all three.