### PR TITLE
🦺 validate swap provider transaction data

### DIFF
--- a/apps/extension/src/ui/domains/Swap/components/SwapConfirmActions.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapConfirmActions.tsx
@@ -226,6 +226,7 @@ export const SwapConfirmActions: FC<{ containerId: string }> = ({ containerId })
       const transaction = await swapModule.getTransaction({
         fromTokenId,
         fromAddress,
+        fromAmount,
         exchange: exchangeQuote ?? selectedQuote,
         context,
       })

--- a/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/lifi-transaction-guards.spec.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/lifi-transaction-guards.spec.ts
@@ -1,0 +1,253 @@
+import type { Route } from "@lifi/types"
+import { describe, expect, it, vi } from "vitest"
+
+// --- Mocks ---
+
+const { ERC20_ADDRESS, mockGetStepTransaction } = vi.hoisted(() => ({
+  ERC20_ADDRESS: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  mockGetStepTransaction: vi.fn(),
+}))
+
+vi.mock("@lifi/sdk", () => ({
+  createClient: vi.fn(() => ({})),
+  getRoutes: vi.fn(),
+  getStepTransaction: (_client: unknown, ...args: unknown[]) => mockGetStepTransaction(...args),
+  getTokens: vi.fn().mockResolvedValue({
+    tokens: {
+      "1": [
+        {
+          address: "0x0000000000000000000000000000000000000000",
+          chainId: 1,
+          decimals: 18,
+          symbol: "ETH",
+          name: "Ether",
+        },
+        { address: ERC20_ADDRESS, chainId: 1, decimals: 6, symbol: "USDC", name: "USD Coin" },
+      ],
+    },
+  }),
+  getToken: vi.fn(),
+  ChainType: { EVM: "EVM", SVM: "SVM" },
+}))
+
+vi.mock("@core/domains/app/store.remoteConfig", () => ({
+  remoteConfigStore: {
+    get: vi.fn().mockResolvedValue({
+      lifi: { solanaChainId: 1151111081099710 },
+      lifiTalismanTokens: [],
+      lifiCustomFeeTokens: {},
+    }),
+  },
+}))
+
+vi.mock("@ui/domains/Ethereum/usePublicClient", () => ({
+  getExtensionPublicClient: vi.fn(() => ({})),
+}))
+
+// the gas check talks to a node — return the request unchanged so we can observe what was built
+vi.mock("../evm-gas-check", () => ({
+  prepareTransactionRequestWithGasCheck: vi.fn(
+    async (_client: unknown, _feeTokenId: string, request: unknown) => request
+  ),
+}))
+
+const { of } = await import("rxjs")
+
+const EVM_NETWORK = {
+  id: "1",
+  name: "Ethereum",
+  platform: "ethereum",
+  nativeTokenId: "1:evm-native",
+}
+const NATIVE_TOKEN = {
+  id: "1:evm-native",
+  type: "evm-native",
+  decimals: 18,
+  symbol: "ETH",
+  networkId: "1",
+}
+const ERC20_TOKEN = {
+  id: `1:evm-erc20:${ERC20_ADDRESS.toLowerCase()}`,
+  type: "evm-erc20",
+  decimals: 6,
+  symbol: "USDC",
+  networkId: "1",
+  contractAddress: ERC20_ADDRESS,
+}
+
+vi.mock("@ui/state/chaindata", () => ({
+  getNetworkById$: vi.fn(() => of(EVM_NETWORK)),
+  getNetworksMapById$: vi.fn(() => of({ "1": EVM_NETWORK })),
+  getToken$: vi.fn(() => of(NATIVE_TOKEN)),
+  getTokensMap$: vi.fn(() =>
+    of({ [NATIVE_TOKEN.id]: NATIVE_TOKEN, [ERC20_TOKEN.id]: ERC20_TOKEN })
+  ),
+}))
+
+const { lifiSwapModule } = await import("../lifi-swap-module")
+
+// --- Test helpers ---
+
+const FROM_ADDRESS = "0x70045A9F59A354550EC0272f73AAe03B01Fb8a7a"
+const ROUTER_ADDRESS = "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+const APPROVAL_ADDRESS = "0x1111111254EEB25477B68fb85Ed929f73A960582"
+
+const NATIVE_TOKEN_ID = NATIVE_TOKEN.id
+const ERC20_TOKEN_ID = ERC20_TOKEN.id
+
+const ONE_ETH = 1_000_000_000_000_000_000n
+const ONE_USDC = 1_000_000n
+
+const makeRoute = (fromAmount: bigint): Route =>
+  ({
+    id: "route-1",
+    fromChainId: 1,
+    toChainId: 1,
+    fromAmount: fromAmount.toString(),
+    toAmount: "950000000000000000",
+    toAmountMin: "940000000000000000",
+    steps: [
+      {
+        id: "step-1",
+        type: "lifi" as const,
+        tool: "1inch",
+        toolDetails: { key: "1inch", name: "1inch", logoURI: "https://logo" },
+        action: {
+          fromChainId: 1,
+          toChainId: 1,
+          fromAmount: fromAmount.toString(),
+          fromToken: { address: "0x0", chainId: 1, decimals: 18, symbol: "ETH" },
+          toToken: { address: "0x0", chainId: 1, decimals: 18, symbol: "ETH" },
+        },
+        estimate: {
+          tool: "1inch",
+          fromAmount: fromAmount.toString(),
+          toAmount: "950000000000000000",
+          toAmountMin: "940000000000000000",
+          approvalAddress: APPROVAL_ADDRESS,
+          executionDuration: 30,
+          feeCosts: [],
+          gasCosts: [],
+        },
+        includedSteps: [],
+      },
+    ],
+  }) as unknown as Route
+
+const makeQuote = (fromAmount: bigint) => ({
+  protocol: "lifi" as const,
+  decentralisationScore: 2,
+  outputAmountBN: 950_000_000_000_000_000n,
+  inputAmountBN: fromAmount,
+  fees: [],
+  timeInSec: 30,
+  providerLogo: "",
+  providerName: "LI.FI",
+  data: makeRoute(fromAmount),
+})
+
+/** Set what the provider returns from `getStepTransaction`. */
+const givenProviderTransaction = (txRequest: Record<string, unknown>) =>
+  mockGetStepTransaction.mockResolvedValue({
+    transactionRequest: {
+      from: FROM_ADDRESS,
+      to: ROUTER_ADDRESS,
+      data: "0x1234",
+      chainId: 1,
+      value: "0x0",
+      gasLimit: "0x5208",
+      ...txRequest,
+    },
+  })
+
+const getTransaction = (fromTokenId = NATIVE_TOKEN_ID, fromAmount = ONE_ETH) =>
+  lifiSwapModule.getTransaction({
+    fromTokenId,
+    fromAddress: FROM_ADDRESS,
+    fromAmount,
+    exchange: makeQuote(fromAmount),
+    context: { platform: "ethereum" },
+  })
+
+/** The module resolves assets from a cache populated by `getFromAssets`. */
+const seedAssetCache = () => lifiSwapModule.getFromAssets(new AbortController().signal)
+
+// --- Tests ---
+
+describe("lifi getTransaction — provider transaction guards", () => {
+  it("builds the transaction when the provider response matches the swap", async () => {
+    await seedAssetCache()
+    givenProviderTransaction({ value: `0x${ONE_ETH.toString(16)}` })
+
+    const result = await getTransaction()
+
+    expect(result?.platform).toBe("ethereum")
+    expect(result?.platform === "ethereum" && result.transaction.to).toBe(ROUTER_ADDRESS)
+  })
+
+  it("accepts an erc20 swap carrying no native value", async () => {
+    await seedAssetCache()
+    givenProviderTransaction({ value: "0x0" })
+
+    const result = await getTransaction(ERC20_TOKEN_ID, ONE_USDC)
+
+    expect(result?.platform).toBe("ethereum")
+  })
+
+  it("rejects a native value above the amount the user entered", async () => {
+    await seedAssetCache()
+    givenProviderTransaction({ value: `0x${(ONE_ETH + 1n).toString(16)}` })
+
+    await expect(getTransaction()).rejects.toThrow("Unexpected transaction amount")
+  })
+
+  it("rejects a native value carried by an erc20 swap", async () => {
+    await seedAssetCache()
+    givenProviderTransaction({ value: `0x${ONE_ETH.toString(16)}` })
+
+    await expect(getTransaction(ERC20_TOKEN_ID, ONE_USDC)).rejects.toThrow(
+      "Unexpected transaction amount"
+    )
+  })
+
+  it("rejects calldata aimed at the token being swapped", async () => {
+    await seedAssetCache()
+    givenProviderTransaction({ value: "0x0", to: ERC20_ADDRESS })
+
+    await expect(getTransaction(ERC20_TOKEN_ID, ONE_USDC)).rejects.toThrow(
+      "Unexpected transaction target"
+    )
+  })
+
+  it("rejects a transaction for a different chain", async () => {
+    await seedAssetCache()
+    givenProviderTransaction({ value: "0x0", chainId: 137 })
+
+    await expect(getTransaction()).rejects.toThrow("Unexpected chain")
+  })
+
+  it("rejects a transaction for a different sender", async () => {
+    await seedAssetCache()
+    givenProviderTransaction({ value: "0x0", from: "0x0000000000000000000000000000000000000bad" })
+
+    await expect(getTransaction()).rejects.toThrow("Invalid sender address")
+  })
+})
+
+describe("lifi getApprovalInfo — allowance bound", () => {
+  it("approves the amount the user entered, not the amount the route echoes back", async () => {
+    await seedAssetCache()
+
+    const approval = lifiSwapModule.getApprovalInfo?.({
+      fromTokenId: ERC20_TOKEN_ID,
+      toTokenId: NATIVE_TOKEN_ID,
+      fromAmount: ONE_USDC,
+      fromAddress: FROM_ADDRESS,
+      toAddress: FROM_ADDRESS,
+      // the provider inflates the route amount to the victim's whole balance
+      quoteData: makeQuote(999_999_999_999n),
+    })
+
+    expect(approval?.amount).toBe(ONE_USDC)
+  })
+})

--- a/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/provider-transaction-guards.spec.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/__tests__/provider-transaction-guards.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  assertDepositAmountWithinInput,
+  assertNativeValueWithinInput,
+} from "../provider-transaction-guards"
+
+describe("assertDepositAmountWithinInput", () => {
+  // 1.5 tokens with 18 decimals
+  const fromAmount = 1_500_000_000_000_000_000n
+  const decimals = 18
+
+  it("accepts the exact amount the user entered", () => {
+    expect(() =>
+      assertDepositAmountWithinInput({ depositAmount: 1.5, fromAmount, decimals })
+    ).not.toThrow()
+  })
+
+  it("accepts a smaller amount", () => {
+    expect(() =>
+      assertDepositAmountWithinInput({ depositAmount: 1.4999, fromAmount, decimals })
+    ).not.toThrow()
+  })
+
+  it("rejects an amount larger than the user entered", () => {
+    expect(() =>
+      assertDepositAmountWithinInput({ depositAmount: 1.500001, fromAmount, decimals })
+    ).toThrow("Quote changed")
+  })
+
+  it("rejects a wildly larger amount", () => {
+    expect(() =>
+      assertDepositAmountWithinInput({ depositAmount: 1000, fromAmount, decimals })
+    ).toThrow("Quote changed")
+  })
+
+  it("rejects a non-numeric amount instead of comparing false", () => {
+    expect(() =>
+      assertDepositAmountWithinInput({ depositAmount: "not a number", fromAmount, decimals })
+    ).toThrow("Quote changed")
+  })
+
+  it("rejects NaN and Infinity", () => {
+    expect(() =>
+      assertDepositAmountWithinInput({ depositAmount: Number.NaN, fromAmount, decimals })
+    ).toThrow("Quote changed")
+    expect(() =>
+      assertDepositAmountWithinInput({
+        depositAmount: Number.POSITIVE_INFINITY,
+        fromAmount,
+        decimals,
+      })
+    ).toThrow("Quote changed")
+  })
+
+  it("rejects a negative amount", () => {
+    expect(() =>
+      assertDepositAmountWithinInput({ depositAmount: -1, fromAmount, decimals })
+    ).toThrow("Quote changed")
+  })
+
+  it("compares against the user amount at full precision", () => {
+    // 6 decimals — a value one unit above the input must not survive float rounding
+    expect(() =>
+      assertDepositAmountWithinInput({
+        depositAmount: "1000.000001",
+        fromAmount: 1_000_000_000n,
+        decimals: 6,
+      })
+    ).toThrow("Quote changed")
+  })
+})
+
+describe("assertNativeValueWithinInput", () => {
+  const fromAmount = 1_000_000_000_000_000_000n
+
+  it("accepts a native swap spending exactly the entered amount", () => {
+    expect(() =>
+      assertNativeValueWithinInput({ value: fromAmount, fromAmount, isNativeInput: true })
+    ).not.toThrow()
+  })
+
+  it("accepts a native swap spending less", () => {
+    expect(() =>
+      assertNativeValueWithinInput({ value: fromAmount - 1n, fromAmount, isNativeInput: true })
+    ).not.toThrow()
+  })
+
+  it("rejects a native swap spending more than the entered amount", () => {
+    expect(() =>
+      assertNativeValueWithinInput({ value: fromAmount + 1n, fromAmount, isNativeInput: true })
+    ).toThrow("Unexpected transaction amount")
+  })
+
+  it("accepts an erc20 swap carrying no native value", () => {
+    expect(() =>
+      assertNativeValueWithinInput({ value: 0n, fromAmount, isNativeInput: false })
+    ).not.toThrow()
+  })
+
+  it("rejects an erc20 swap carrying any native value", () => {
+    expect(() =>
+      assertNativeValueWithinInput({ value: 1n, fromAmount, isNativeInput: false })
+    ).toThrow("Unexpected transaction amount")
+  })
+})

--- a/apps/extension/src/ui/domains/Swap/swap-modules/common.swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/common.swap-module.ts
@@ -92,6 +92,8 @@ export type SwapTransactionContext =
 export type GetTransactionParams = {
   fromTokenId: TokenId
   fromAddress: string
+  /** amount entered by the user, and the only amount shown on the confirmation screen */
+  fromAmount: bigint
   exchange: unknown // specific exchange type varies per module
   context: SwapTransactionContext
 }

--- a/apps/extension/src/ui/domains/Swap/swap-modules/lifi-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/lifi-swap-module.ts
@@ -16,7 +16,11 @@ import {
   solToken2022TokenId,
   type TokenList,
 } from "@talismn/chaindata-provider"
-import { setTransactionBlockhash, transactionFromBytes } from "@talismn/solana"
+import {
+  parseTransactionInfo,
+  setTransactionBlockhash,
+  transactionFromBytes,
+} from "@talismn/solana"
 import { getExtensionPublicClient } from "@ui/domains/Ethereum/usePublicClient"
 import { getNetworkById$, getNetworksMapById$, getToken$, getTokensMap$ } from "@ui/state/chaindata"
 import BigNumber from "bignumber.js"
@@ -35,6 +39,7 @@ import {
 } from "./common.swap-module"
 import { prepareTransactionRequestWithGasCheck } from "./evm-gas-check"
 import { getLifiTalismanFee as getTalismanFee, LIFI_PROTOCOL_FEE as LIFI_FEE } from "./fee-utils"
+import { assertNativeValueWithinInput } from "./provider-transaction-guards"
 
 const apiUrl = "https://lifi.talisman.xyz/v1"
 const PROTOCOL: SupportedSwapProtocol = "lifi" as const
@@ -523,8 +528,8 @@ const getQuote = async (params: QuoteParams, signal: AbortSignal): Promise<BaseQ
 const getApprovalInfo = (
   params: QuoteParams & { quoteData: BaseQuote | BaseQuote[] | null }
 ): ApprovalInfo => {
-  const { fromTokenId, fromAddress, selectedSubProtocol, quoteData } = params
-  if (!fromTokenId || !fromAddress) return null
+  const { fromTokenId, fromAddress, fromAmount, selectedSubProtocol, quoteData } = params
+  if (!fromTokenId || !fromAddress || !fromAmount) return null
   const fromAsset = resolveAsset(fromTokenId)
   if (!quoteData || !fromAsset?.contractAddress) return null
 
@@ -540,7 +545,9 @@ const getApprovalInfo = (
 
   return {
     contractAddress: step.estimate.approvalAddress,
-    amount: BigInt(lifiData.fromAmount),
+    // the route echoes back the amount we asked it to quote — approve the amount the user
+    // entered instead, so an inflated echo cannot widen the allowance we grant
+    amount: fromAmount,
     tokenAddress: fromAsset.contractAddress,
     chainId: step.action.fromChainId,
     fromAddress,
@@ -552,7 +559,7 @@ const getTransaction = async (
   params: GetTransactionParams
 ): Promise<SwapModuleTransaction | null> => {
   try {
-    const { fromTokenId, fromAddress, exchange: quoteData, context } = params
+    const { fromTokenId, fromAddress, fromAmount, exchange: quoteData, context } = params
     const selectedQuote = quoteData as BaseQuote<lifiSdk.Route> | undefined
     if (!selectedQuote?.data) {
       throw new Error("Please select the quote again")
@@ -584,6 +591,11 @@ const getTransaction = async (
 
       let transaction = transactionFromBytes(txBytes)
 
+      // the fee payer is the account we are about to sign with, so a transaction naming
+      // anyone else is not the one the user is confirming
+      const { feePayer } = parseTransactionInfo(transaction)
+      if (feePayer !== fromAddress) throw new Error("Invalid sender address")
+
       // Refresh the blockhash — the one from getStepTransaction may expire before the user
       // clicks "Confirm Swap". Other swap modules (stealthex, simpleswap) do the same.
       const rpc = context.platform === "solana" ? context.rpc : undefined
@@ -608,6 +620,24 @@ const getTransaction = async (
 
     if (txRequest.from.toLowerCase() !== fromAddress.toLowerCase())
       throw new Error("Invalid sender address")
+
+    // the transaction must run on the network holding the token the user is swapping,
+    // not on some other network we happen to know about
+    if (txRequest.chainId.toString() !== fromAsset.chainId) throw new Error("Unexpected chain")
+
+    // a swap is executed by LI.FI's router — calldata aimed at the token contract itself can
+    // only be a transfer or an approval made in the user's name
+    if (
+      fromAsset.contractAddress &&
+      txRequest.to.toLowerCase() === fromAsset.contractAddress.toLowerCase()
+    )
+      throw new Error("Unexpected transaction target from provider. Please try again.")
+
+    assertNativeValueWithinInput({
+      value: BigInt(txRequest.value),
+      fromAmount,
+      isNativeInput: !fromAsset.contractAddress,
+    })
 
     const knownEvmNetworks = await firstValueFrom(getNetworksMapById$({ platform: "ethereum" }))
     const evmNetwork = knownEvmNetworks[txRequest.chainId.toString()]

--- a/apps/extension/src/ui/domains/Swap/swap-modules/provider-transaction-guards.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/provider-transaction-guards.ts
@@ -1,0 +1,41 @@
+import { planckToTokens } from "@talismn/util"
+import BigNumber from "bignumber.js"
+
+/**
+ * Swap providers return the amount to send in their own response, but the confirmation
+ * screen only ever shows the amount the user entered. Any larger amount would leave the
+ * account without having been displayed, so it is rejected rather than sent.
+ *
+ * Non-finite and negative amounts are rejected too — a comparison against them is always
+ * false, which would let a malformed response through.
+ */
+export const assertDepositAmountWithinInput = (params: {
+  depositAmount: BigNumber.Value
+  fromAmount: bigint
+  decimals: number
+}) => {
+  const { depositAmount, fromAmount, decimals } = params
+
+  const amount = BigNumber(depositAmount)
+  const maxAmount = BigNumber(planckToTokens(fromAmount.toString(), decimals) ?? "0")
+
+  if (!amount.isFinite() || amount.isNegative() || amount.isGreaterThan(maxAmount))
+    throw new Error("Quote changed. Please try again.")
+}
+
+/**
+ * A swap of an ERC20 token spends no native token, and a swap of the native token cannot
+ * spend more than the amount the user entered. The provider supplies `value` alongside the
+ * calldata, so without this bound a swap of a worthless token could carry away the account's
+ * native balance.
+ */
+export const assertNativeValueWithinInput = (params: {
+  value: bigint
+  fromAmount: bigint
+  isNativeInput: boolean
+}) => {
+  const { value, fromAmount, isNativeInput } = params
+
+  if (isNativeInput ? value > fromAmount : value !== 0n)
+    throw new Error("Unexpected transaction amount from provider. Please try again.")
+}

--- a/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/simpleswap-swap-module.ts
@@ -33,6 +33,7 @@ import {
   estimateDepositGas,
 } from "./deposit-swap-transactions"
 import { getSimpleSwapApiKey as getApiKeyFromUtils, getSimpleSwapTalismanFee } from "./fee-utils"
+import { assertDepositAmountWithinInput } from "./provider-transaction-guards"
 import simpleswapLogo from "./simpleswap-logo.svg?url"
 
 const PROTOCOL: SupportedSwapProtocol = "simpleswap"
@@ -554,12 +555,11 @@ const createExchange = async (params: ExchangeParams): Promise<SwapExchange | nu
       )
       throw new Error("Incorrect currencies from provider. Please try again later")
     }
-    if (
-      BigNumber(exchange.expected_amount).isGreaterThan(
-        planckToTokens(fromAmount.toString(), fromAsset.decimals) ?? "0"
-      )
-    )
-      throw new Error("Quote changed. Please try again.")
+    assertDepositAmountWithinInput({
+      depositAmount: exchange.expected_amount,
+      fromAmount,
+      decimals: fromAsset.decimals,
+    })
     if (exchange.address_to !== formattedToAddress)
       throw new Error("Incorrect destination address from provider. Please try again later")
 
@@ -579,6 +579,12 @@ const getTransaction = async (
 
   const exchange = params.exchange as Exchange | undefined
   if (!exchange?.address_from) throw new Error("Missing exchange")
+
+  assertDepositAmountWithinInput({
+    depositAmount: exchange.expected_amount,
+    fromAmount: params.fromAmount,
+    decimals: fromAsset.decimals,
+  })
 
   const deposit: DepositInfo = {
     depositAddress: exchange.address_from,

--- a/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
+++ b/apps/extension/src/ui/domains/Swap/swap-modules/stealthex-swap-module.ts
@@ -37,6 +37,7 @@ import {
   getStealthexAdditionalFeePercent,
   getStealthexTalismanTotalFee,
 } from "./fee-utils"
+import { assertDepositAmountWithinInput } from "./provider-transaction-guards"
 import type {
   paths as StealthexApi,
   SchemaCurrency as StealthexCurrency,
@@ -514,7 +515,13 @@ const createExchange = async (params: ExchangeParams): Promise<SwapExchange | nu
       exchange.withdrawal.symbol !== to.symbol
     )
       throw new Error("Incorrect currencies from provider. Please try again later")
-    if (exchange.deposit.amount > fromAmountNum) throw new Error("Quote changed. Please try again.")
+    // `deposit.expected_amount` is the amount we will actually send — `deposit.amount` is what
+    // StealthEX has received so far, which is always 0 before the deposit is made
+    assertDepositAmountWithinInput({
+      depositAmount: exchange.deposit.expected_amount,
+      fromAmount,
+      decimals: fromAsset.decimals,
+    })
     if (exchange.withdrawal.address !== formattedToAddress)
       throw new Error("Incorrect destination address from provider. Please try again later")
 
@@ -534,6 +541,12 @@ const getTransaction = async (
 
   const exchange = params.exchange as StealthexExchange | undefined
   if (!exchange?.deposit?.address) throw new Error("Missing exchange")
+
+  assertDepositAmountWithinInput({
+    depositAmount: exchange.deposit.expected_amount,
+    fromAmount: params.fromAmount,
+    decimals: fromAsset.decimals,
+  })
 
   const deposit: DepositInfo = {
     depositAddress: exchange.deposit.address,


### PR DESCRIPTION
Swap modules now check provider responses against the amount the user entered, which is the only amount the confirm screen displays.

- shared guards in `provider-transaction-guards.ts`, fail-closed on non-finite/negative amounts
- StealthEX checked `deposit.amount` ("amount received", always `0` on a new exchange) instead of `deposit.expected_amount`, the field it actually sends — fixed, and SimpleSwap now shares the same guard
- LI.FI EVM: bind `chainId` to the swapped token's network, reject calldata aimed at the token contract itself, bound `value` (≤ input for a native swap, `0` for an ERC20 swap)
- LI.FI Solana: fee payer must be the signing account
- `getApprovalInfo` approves the user's amount rather than the route's echo

21 new tests.