### PR TITLE
Ramp, swap & token rates api tests

### DIFF
--- a/.github/workflows/api-health.yml
+++ b/.github/workflows/api-health.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   api-health:
     name: "API health checks"
-    timeout-minutes: 5
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -27,6 +27,7 @@ jobs:
         env:
           TDA_API_KEY: ${{ secrets.TDA_API_KEY }}
           SN45_API_KEY: ${{ secrets.SN45_API_KEY }}
+          SIMPLESWAP_API_KEY: ${{ secrets.SIMPLESWAP_API_KEY }}
 
       - name: Upload test report
         uses: actions/upload-artifact@v7

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -164,7 +164,7 @@
     "postinstall": "mkdir -p ~/.talisman-dev/chrome-data && wxt prepare",
     "chore:update-translations": "pnpm exec i18next --silent --config i18next-parser.config.cjs",
     "chore:download-translations": "pnpm tsx scripts/download-translations.ts",
-    "chore:codegen:stealthex-swaps": "openapi-typescript https://stealthex.talisman.xyz/docs/openapi.json --export-type --root-types -o src/ui/domains/Swap/swap-modules/stealthex.api.d.ts",
+    "chore:codegen:stealthex-swaps": "pnpm dlx --package=openapi-typescript@7.13.0 --package=typescript@5.9.3 -- openapi-typescript https://api.stealthex.io/docs/openapi.json --export-type --root-types -o src/ui/domains/Swap/swap-modules/stealthex.api.d.ts",
     "chore:generate-clients:sn45": "pnpm dlx swagger-typescript-api@13.6.2 generate -p https://sn45api.talisman.xyz/openapi.json -o ./src/core/domains/bittensor/sn45 -n Sn45Api --api-class-name Sn45Api",
     "chore:generate-clients:tda": "pnpm dlx swagger-typescript-api@13.6.2 generate -p https://tda.talisman.xyz/openapi.json -o ./src/core/domains/bittensor/tao-data -n TaoDataApi --api-class-name TaoDataApi",
     "chore:generate-clients:wrc": "pnpm dlx swagger-typescript-api@13.6.2 generate -p https://wrc.talisman.xyz/openapi.json -o ./src/core/domains/app/remote-config -n RemoteConfigApi --api-class-name RemoteConfigApi",

--- a/playwright/api-tests/helpers.ts
+++ b/playwright/api-tests/helpers.ts
@@ -1,0 +1,116 @@
+/// <reference types="node" />
+
+import { type APIRequestContext, type APIResponse, expect, test } from "@playwright/test"
+
+/** Attach a parsed body to the report, so a failed cron run is diagnosable from the Discord zip. */
+export const attachJson = (name: string, body: unknown) =>
+  test.info().attach(name, {
+    body: JSON.stringify(body, null, 2),
+    contentType: "application/json",
+  })
+
+/** Attach status + raw text, for error paths where the body may not be JSON. */
+export const attachRaw = async (name: string, response: APIResponse) =>
+  test.info().attach(name, {
+    body: `${redactUrl(response.url())}\nStatus: ${response.status()}\n${await response.text()}`,
+    contentType: "text/plain",
+  })
+
+/**
+ * Third-party quote endpoints region-gate with 403 and throttle with 429. Neither means
+ * the contract broke, so skip instead of failing — a red daily run should mean "the API
+ * changed", not "the CI runner is in the wrong country".
+ */
+export const skipIfUnavailable = (response: APIResponse, what: string) => {
+  const status = response.status()
+  if (status !== 403 && status !== 429) return
+
+  const reason = status === 403 ? "region-gated" : "rate-limited"
+  test.info().annotations.push({ type: "unavailable", description: `${what}: ${status} ${reason}` })
+  test.skip(true, `${what} returned ${status} (${reason})`)
+}
+
+const SENSITIVE_QUERY_PARAMS = [
+  "api_key",
+  "apikey",
+  "key",
+  "token",
+  "access_token",
+  "secret",
+  "signature",
+]
+
+/**
+ * Some providers take their credential as a query param (SimpleSwap uses `api_key`), and failure
+ * messages end up in the report zip that api-health.yml posts to Discord. Redact before rendering
+ * any URL into a message or an attachment.
+ */
+const redactUrl = (url: string) => {
+  try {
+    const parsed = new URL(url)
+    for (const [name] of [...parsed.searchParams]) {
+      if (SENSITIVE_QUERY_PARAMS.includes(name.toLowerCase())) parsed.searchParams.set(name, "***")
+    }
+    return parsed.toString()
+  } catch {
+    // not a parseable URL — nothing to redact, and nothing worth throwing over
+    return url
+  }
+}
+
+/** A 5xx always means the API is broken, whatever the endpoint. */
+export const expectNoServerError = (response: APIResponse) =>
+  expect(response.status(), `${redactUrl(response.url())} must not return 5xx`).toBeLessThan(500)
+
+export const expectFiniteNumber = (value: unknown, label: string) => {
+  const num = Number(value)
+  expect(num, `${label} must be numeric (got ${JSON.stringify(value)})`).not.toBeNaN()
+  expect(Number.isFinite(num), `${label} must be finite (got ${JSON.stringify(value)})`).toBe(true)
+}
+
+export const expectPositiveNumber = (value: unknown, label: string) => {
+  expectFiniteNumber(value, label)
+  expect(Number(value), `${label} must be > 0`).toBeGreaterThan(0)
+}
+
+export const expectNonNegativeNumber = (value: unknown, label: string) => {
+  expectFiniteNumber(value, label)
+  expect(Number(value), `${label} must be >= 0`).toBeGreaterThanOrEqual(0)
+}
+
+const REMOTE_CONFIG_URL = "https://wrc.talisman.xyz/config"
+
+type RemoteConfigSwaps = {
+  lifiTalismanTokens: string[]
+  curatedTokens: string[]
+  simpleswapApiKey: string
+}
+
+let swapsConfigCache: Promise<RemoteConfigSwaps> | undefined
+
+/**
+ * The wallet reads every swap setting from the remote config at runtime
+ * (see apps/extension/src/core/domains/app/remote-config/fetchRemoteConfig.ts), so tests that
+ * need to know which tokens/networks are actually offered read the same source instead of
+ * duplicating the list. Cached per worker — the config does not change during a run.
+ */
+export const getRemoteConfigSwaps = (request: APIRequestContext) => {
+  swapsConfigCache ??= (async () => {
+    const response = await request.get(REMOTE_CONFIG_URL)
+    expect(response.ok(), "remote config must be reachable").toBeTruthy()
+    const config = (await response.json()) as { swaps: RemoteConfigSwaps }
+    return config.swaps
+  })()
+
+  return swapsConfigCache
+}
+
+/** Talisman token id -> EVM chain id, for the `evm-native` entries of `swaps.curatedTokens`. */
+export const evmChainIdsFromCuratedTokens = (curatedTokens: string[]) => [
+  ...new Set(
+    curatedTokens
+      .filter((tokenId) => tokenId.endsWith(":evm-native"))
+      .map((tokenId) => Number(tokenId.split(":")[0]))
+      .filter((chainId) => Number.isInteger(chainId))
+  ),
+]

--- a/playwright/api-tests/ramp.spec.ts
+++ b/playwright/api-tests/ramp.spec.ts
@@ -1,0 +1,265 @@
+/// <reference types="node" />
+
+import { expect, test } from "@playwright/test"
+
+import {
+  attachJson,
+  attachRaw,
+  expectNonNegativeNumber,
+  expectNoServerError,
+  expectPositiveNumber,
+  skipIfUnavailable,
+} from "./helpers"
+
+const RAMP_API_URL = "https://ramp-api.talisman.xyz"
+const HOST_API = `${RAMP_API_URL}/api/host-api/v3`
+
+// ETH on Ethereum — Ramp's `<CHAIN>_<SYMBOL>` asset id, used by useRampCryptoAsset
+const TEST_ASSET = "ETH_ETH"
+const TEST_CURRENCY = "USD"
+const TEST_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+
+type QuoteForMethod = {
+  fiatCurrency: string
+  cryptoAmount: string
+  fiatValue: number
+  baseRampFee: number
+  appliedFee: number
+}
+
+/** The quote endpoints return one entry per payment/payout method, plus a shared `asset` key. */
+const quoteMethodEntries = (body: Record<string, unknown>) =>
+  Object.entries(body).filter(
+    (entry): entry is [string, QuoteForMethod] =>
+      entry[0] !== "asset" &&
+      typeof entry[1] === "object" &&
+      entry[1] !== null &&
+      "cryptoAmount" in (entry[1] as Record<string, unknown>)
+  )
+
+test.describe("Ramp API", () => {
+  test.describe.configure({ retries: 2 })
+
+  test("GET /currencies returns fiat currencies with availability flags", async ({ request }) => {
+    const response = await request.get(`${HOST_API}/currencies`, { failOnStatusCode: false })
+    skipIfUnavailable(response, "GET /currencies")
+
+    const body = await response.json()
+    await attachJson("currencies-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    expect(Array.isArray(body)).toBeTruthy()
+    expect(body.length).toBeGreaterThan(0)
+
+    for (const currency of body) {
+      expect(typeof currency.fiatCurrency).toBe("string")
+      expect(typeof currency.name).toBe("string")
+      // useRampCurrencies feeds the currency picker, which filters on these two booleans
+      expect(typeof currency.onrampAvailable).toBe("boolean")
+      expect(typeof currency.offrampAvailable).toBe("boolean")
+    }
+
+    const usd = body.find((c: { fiatCurrency: string }) => c.fiatCurrency === TEST_CURRENCY)
+    expect(usd, "USD must be offered").toBeDefined()
+    expect(usd.onrampAvailable).toBe(true)
+  })
+
+  /**
+   * `PARTNER_NAME: Talisman` is the proof that the proxy is applying Talisman's host config.
+   * If it drops, users get an unbranded widget and Talisman stops earning its host fee cut.
+   */
+  test("GET /assets returns Talisman's host config and buyable assets", async ({ request }) => {
+    const response = await request.get(`${HOST_API}/assets?currencyCode=${TEST_CURRENCY}`, {
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "GET /assets")
+
+    const body = await response.json()
+    await attachJson("buy-assets-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    expect(body.currencyCode).toBe(TEST_CURRENCY)
+    expect(Array.isArray(body.assets)).toBeTruthy()
+    expect(body.assets.length).toBeGreaterThan(0)
+
+    const partnerName = body.enabledFeatures?.find(
+      (feature: { name: string }) => feature.name === "PARTNER_NAME"
+    )
+    expect(partnerName, "PARTNER_NAME feature must be enabled").toBeDefined()
+    expect(partnerName.params?.partnerName).toBe("Talisman")
+
+    expectPositiveNumber(body.minPurchaseAmount, "minPurchaseAmount")
+    expectPositiveNumber(body.maxPurchaseAmount, "maxPurchaseAmount")
+    expect(Number(body.maxPurchaseAmount)).toBeGreaterThan(Number(body.minPurchaseAmount))
+    expectNonNegativeNumber(body.minFeePercent, "minFeePercent")
+    expectNonNegativeNumber(body.maxFeePercent, "maxFeePercent")
+
+    const eth = body.assets.find(
+      (asset: { symbol: string; chain: string }) => asset.symbol === "ETH" && asset.chain === "ETH"
+    )
+    expect(eth, "ETH on Ethereum must be buyable").toBeDefined()
+    expect(eth.decimals).toBe(18)
+    expect(eth.type).toBe("NATIVE")
+    expectPositiveNumber(eth.price?.[TEST_CURRENCY], "ETH price in USD")
+  })
+
+  test("GET /offramp/assets returns sellable assets", async ({ request }) => {
+    const response = await request.get(`${HOST_API}/offramp/assets?currencyCode=${TEST_CURRENCY}`, {
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "GET /offramp/assets")
+
+    const body = await response.json()
+    await attachJson("sell-assets-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    expect(body.currencyCode).toBe(TEST_CURRENCY)
+    expect(Array.isArray(body.assets)).toBeTruthy()
+    expect(body.assets.length).toBeGreaterThan(0)
+  })
+
+  test("POST /onramp/quote/all returns a quote per payment method", async ({ request }) => {
+    const response = await request.post(`${HOST_API}/onramp/quote/all`, {
+      data: { fiatCurrency: TEST_CURRENCY, cryptoAssetSymbol: TEST_ASSET, fiatValue: 100 },
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "POST /onramp/quote/all")
+
+    const body = await response.json()
+    await attachJson("buy-quote-response", body)
+
+    expect(response.ok()).toBeTruthy()
+
+    const methods = quoteMethodEntries(body)
+    expect(methods.length, "at least one payment method must be quoted").toBeGreaterThan(0)
+
+    for (const [method, quote] of methods) {
+      expect(quote.fiatCurrency, `${method} fiatCurrency`).toBe(TEST_CURRENCY)
+      expect(quote.fiatValue, `${method} fiatValue`).toBe(100)
+
+      // cryptoAmount is a plancks string, consumed as-is by the buy form
+      expect(quote.cryptoAmount, `${method} cryptoAmount must be a string`).toEqual(
+        expect.any(String)
+      )
+      expect(quote.cryptoAmount, `${method} cryptoAmount must be an integer string`).toMatch(
+        /^\d+$/
+      )
+      expect(BigInt(quote.cryptoAmount), `${method} cryptoAmount`).toBeGreaterThan(0n)
+
+      expectPositiveNumber(quote.baseRampFee, `${method} baseRampFee`)
+      expectPositiveNumber(quote.appliedFee, `${method} appliedFee`)
+      // appliedFee includes Talisman's host cut on top of Ramp's base fee
+      expect(
+        quote.appliedFee,
+        `${method} appliedFee must cover baseRampFee`
+      ).toBeGreaterThanOrEqual(quote.baseRampFee)
+      expect(quote.appliedFee, `${method} appliedFee must be below the purchase`).toBeLessThan(100)
+    }
+  })
+
+  test("POST /offramp/quote/all returns a quote per payout method", async ({ request }) => {
+    const response = await request.post(`${HOST_API}/offramp/quote/all`, {
+      data: {
+        fiatCurrency: TEST_CURRENCY,
+        cryptoAssetSymbol: TEST_ASSET,
+        cryptoAmount: "100000000000000000", // 0.1 ETH
+      },
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "POST /offramp/quote/all")
+
+    const body = await response.json()
+    await attachJson("sell-quote-response", body)
+
+    expect(response.ok()).toBeTruthy()
+
+    expect(body.asset, "the quote must describe the asset").toBeDefined()
+    expect(body.asset.symbol).toBe("ETH")
+    expect(body.asset.decimals).toBe(18)
+    expectPositiveNumber(body.asset.price?.[TEST_CURRENCY], "ETH price in USD")
+
+    const methods = quoteMethodEntries(body)
+    expect(methods.length, "at least one payout method must be quoted").toBeGreaterThan(0)
+
+    for (const [method, quote] of methods) {
+      expect(quote.fiatCurrency, `${method} fiatCurrency`).toBe(TEST_CURRENCY)
+      expect(quote.cryptoAmount, `${method} cryptoAmount`).toBe("100000000000000000")
+      expectPositiveNumber(quote.fiatValue, `${method} fiatValue`)
+      expectNonNegativeNumber(quote.baseRampFee, `${method} baseRampFee`)
+      expectNonNegativeNumber(quote.appliedFee, `${method} appliedFee`)
+    }
+  })
+
+  /**
+   * Covers getRampBuyUrl / getRampSellUrl (src/ui/domains/Ramps/ramp/helpers.ts) without opening
+   * the widget: the proxy must sign the URL and keep Talisman's host branding on it.
+   */
+  test("GET /talisman/getSignedBuySellUrl returns a signed Ramp widget URL", async ({
+    request,
+  }) => {
+    const params = new URLSearchParams({
+      defaultFlow: "ONRAMP",
+      hideExitButton: "true",
+      selectedCountryCode: "US",
+      swapAsset: TEST_ASSET,
+      userAddress: TEST_ADDRESS,
+      fiatCurrency: TEST_CURRENCY,
+      fiatValue: "100",
+    })
+
+    const response = await request.get(`${RAMP_API_URL}/talisman/getSignedBuySellUrl?${params}`, {
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "GET /talisman/getSignedBuySellUrl")
+
+    const body = await response.json()
+    await attachJson("signed-url-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    expect(typeof body.url, "the response must carry a url").toBe("string")
+
+    const url = new URL(body.url)
+    expect(url.host).toBe("app.ramp.network")
+
+    // the proxy's own host config must survive
+    expect(url.searchParams.get("hostAppName")).toBe("Talisman")
+    expect(url.searchParams.get("hostLogoUrl")).toBeTruthy()
+
+    // and our parameters must be echoed unchanged
+    expect(url.searchParams.get("swapAsset")).toBe(TEST_ASSET)
+    expect(url.searchParams.get("fiatCurrency")).toBe(TEST_CURRENCY)
+    expect(url.searchParams.get("userAddress")).toBe(TEST_ADDRESS)
+    expect(url.searchParams.get("defaultFlow")).toBe("ONRAMP")
+  })
+
+  test.describe("Invalid parameter handling", () => {
+    test("unknown currencyCode does not 5xx", async ({ request }) => {
+      const response = await request.get(`${HOST_API}/assets?currencyCode=NOTACURRENCY`, {
+        failOnStatusCode: false,
+      })
+      await attachRaw("invalid-currency-response", response)
+      expectNoServerError(response)
+    })
+
+    test("unknown cryptoAssetSymbol on a quote does not 5xx", async ({ request }) => {
+      const response = await request.post(`${HOST_API}/onramp/quote/all`, {
+        data: {
+          fiatCurrency: TEST_CURRENCY,
+          cryptoAssetSymbol: "NOPE_NOPE",
+          fiatValue: 100,
+        },
+        failOnStatusCode: false,
+      })
+      await attachRaw("invalid-asset-response", response)
+      expectNoServerError(response)
+    })
+
+    test("non-existent endpoint returns 404, not 5xx", async ({ request }) => {
+      const response = await request.get(`${RAMP_API_URL}/nonexistent-endpoint`, {
+        failOnStatusCode: false,
+      })
+      await attachRaw("nonexistent-response", response)
+      expectNoServerError(response)
+    })
+  })
+})

--- a/playwright/api-tests/swap-lifi.spec.ts
+++ b/playwright/api-tests/swap-lifi.spec.ts
@@ -1,0 +1,279 @@
+/// <reference types="node" />
+
+import { expect, test } from "@playwright/test"
+
+import {
+  attachJson,
+  attachRaw,
+  evmChainIdsFromCuratedTokens,
+  expectNoServerError,
+  expectPositiveNumber,
+  getRemoteConfigSwaps,
+  skipIfUnavailable,
+} from "./helpers"
+
+const LIFI_API_URL = "https://lifi.talisman.xyz/v1"
+
+// the proxy injects swaps.lifiApiKey, so no credential is needed here
+const INTEGRATOR = "talisman"
+
+const ETHEREUM_CHAIN_ID = 1
+
+/**
+ * Networks the swap UI would visibly lose if LI.FI dropped them: Ethereum, Base, Arbitrum,
+ * Optimism, Polygon and BSC. All verified as supported at the time of writing.
+ */
+const CORE_EVM_CHAIN_IDS = [ETHEREUM_CHAIN_ID, 8453, 42161, 10, 137, 56]
+const NATIVE_ETH = "0x0000000000000000000000000000000000000000"
+const USDC_ETHEREUM = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+/** `1:evm-erc20:0xabc…` -> `{ chainId: 1, address: "0xabc…" }` */
+const parseEvmTokenId = (tokenId: string) => {
+  const [networkId, , address] = tokenId.split(":")
+  return { chainId: Number(networkId), address }
+}
+
+test.describe("LI.FI Swap API", () => {
+  test.describe.configure({ retries: 2 })
+
+  /**
+   * LI.FI is the EVM/SVM swap provider, so losing one of these chains removes same-chain and
+   * bridged swaps for it entirely (StealthEX/SimpleSwap only cover deposit-style swaps).
+   *
+   * The curated list from the remote config is reported as an annotation rather than asserted:
+   * `swaps.curatedTokens` is provider-agnostic — it only orders the "Popular" tab in the token
+   * picker (swap-services/token-filtering.ts) and legitimately includes chains served by the other
+   * providers (e.g. Moonbeam), so a gap there is information, not a failure.
+   */
+  test("GET /chains covers the core EVM networks", async ({ request }) => {
+    const [response, swaps] = await Promise.all([
+      request.get(`${LIFI_API_URL}/chains`, { failOnStatusCode: false }),
+      getRemoteConfigSwaps(request),
+    ])
+    skipIfUnavailable(response, "GET /chains")
+
+    const body = await response.json()
+    await attachJson("chains-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    expect(Array.isArray(body.chains)).toBeTruthy()
+    expect(body.chains.length).toBeGreaterThan(0)
+
+    for (const chain of body.chains.slice(0, 20)) {
+      expect(typeof chain.id).toBe("number")
+      expect(typeof chain.key).toBe("string")
+      expect(typeof chain.name).toBe("string")
+      expect(chain.chainType, "chainType drives the EVM/SVM split").toBeTruthy()
+    }
+
+    const supported = new Set<number>(body.chains.map((chain: { id: number }) => chain.id))
+
+    const missing = CORE_EVM_CHAIN_IDS.filter((chainId) => !supported.has(chainId))
+    expect(missing, `LI.FI no longer supports core networks: ${missing}`).toHaveLength(0)
+
+    // informational: which curated chains LI.FI does not route
+    const uncovered = evmChainIdsFromCuratedTokens(swaps.curatedTokens).filter(
+      (chainId) => !supported.has(chainId)
+    )
+    test.info().annotations.push({
+      type: "curated-not-on-lifi",
+      description: uncovered.length ? uncovered.join(", ") : "none",
+    })
+  })
+
+  test("GET /tokens returns EVM and SVM token lists", async ({ request }) => {
+    // mirrors getTokens(client, { chainTypes: [EVM, SVM] }) in lifi-swap-module.ts
+    const response = await request.get(`${LIFI_API_URL}/tokens?chainTypes=EVM,SVM`, {
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "GET /tokens")
+
+    expect(response.ok()).toBeTruthy()
+    const body = await response.json()
+
+    expect(body.tokens, "tokens must be keyed by chain id").toBeDefined()
+    const chainIds = Object.keys(body.tokens)
+    expect(chainIds.length).toBeGreaterThan(0)
+    await attachJson("tokens-chain-ids", chainIds)
+
+    const ethereumTokens = body.tokens[String(ETHEREUM_CHAIN_ID)]
+    expect(Array.isArray(ethereumTokens)).toBeTruthy()
+    expect(ethereumTokens.length, "Ethereum must have a token list").toBeGreaterThan(0)
+
+    const token = ethereumTokens[0]
+    for (const field of ["chainId", "address", "symbol", "name", "decimals", "priceUSD"]) {
+      expect(token, `token entries must expose ${field}`).toHaveProperty(field)
+    }
+  })
+
+  test("GET /token resolves a known ERC20", async ({ request }) => {
+    const response = await request.get(
+      `${LIFI_API_URL}/token?chain=${ETHEREUM_CHAIN_ID}&token=${USDC_ETHEREUM}`,
+      { failOnStatusCode: false }
+    )
+    skipIfUnavailable(response, "GET /token")
+
+    const body = await response.json()
+    await attachJson("token-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    expect(body.chainId).toBe(ETHEREUM_CHAIN_ID)
+    expect(body.symbol).toBe("USDC")
+    expect(body.decimals).toBe(6)
+    expectPositiveNumber(body.priceUSD, "USDC priceUSD")
+  })
+
+  /**
+   * swaps.lifiTalismanTokens drives the fee discount in fee-utils.ts. If LI.FI stops resolving one
+   * of them, the discount silently stops applying — the swap still works, at the wrong fee.
+   */
+  test("GET /token resolves every lifiTalismanTokens entry", async ({ request }) => {
+    const swaps = await getRemoteConfigSwaps(request)
+    expect(swaps.lifiTalismanTokens.length, "remote config must list fee tokens").toBeGreaterThan(0)
+    await attachJson("lifi-talisman-tokens", swaps.lifiTalismanTokens)
+
+    for (const tokenId of swaps.lifiTalismanTokens) {
+      const { chainId, address } = parseEvmTokenId(tokenId)
+
+      const response = await request.get(
+        `${LIFI_API_URL}/token?chain=${chainId}&token=${address}`,
+        { failOnStatusCode: false }
+      )
+      skipIfUnavailable(response, `GET /token (${tokenId})`)
+
+      expect(response.ok(), `${tokenId} must resolve (got ${response.status()})`).toBeTruthy()
+      const body = await response.json()
+      expect(body.chainId, `${tokenId} chainId`).toBe(chainId)
+      expect(String(body.address).toLowerCase(), `${tokenId} address`).toBe(address.toLowerCase())
+      expect(typeof body.decimals, `${tokenId} decimals`).toBe("number")
+    }
+  })
+
+  test("GET /tools lists exchanges and bridges", async ({ request }) => {
+    const response = await request.get(`${LIFI_API_URL}/tools`, { failOnStatusCode: false })
+    skipIfUnavailable(response, "GET /tools")
+
+    const body = await response.json()
+    await attachJson(
+      "tools-response",
+      Object.fromEntries(Object.entries(body).map(([key, value]) => [key, (value as []).length]))
+    )
+
+    expect(response.ok()).toBeTruthy()
+    expect(Array.isArray(body.exchanges)).toBeTruthy()
+    expect(Array.isArray(body.bridges)).toBeTruthy()
+    expect(body.exchanges.length, "at least one exchange must be available").toBeGreaterThan(0)
+    expect(body.bridges.length, "at least one bridge must be available").toBeGreaterThan(0)
+  })
+
+  test("POST /advanced/routes returns routable quotes", async ({ request }) => {
+    const response = await request.post(`${LIFI_API_URL}/advanced/routes`, {
+      data: {
+        fromChainId: ETHEREUM_CHAIN_ID,
+        fromAmount: "1000000000000000000", // 1 ETH
+        fromTokenAddress: NATIVE_ETH,
+        toChainId: ETHEREUM_CHAIN_ID,
+        toTokenAddress: USDC_ETHEREUM,
+        options: { integrator: INTEGRATOR },
+      },
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "POST /advanced/routes")
+
+    const body = await response.json()
+    expect(response.ok()).toBeTruthy()
+    expect(Array.isArray(body.routes)).toBeTruthy()
+    expect(body.routes.length, "1 ETH -> USDC must be routable").toBeGreaterThan(0)
+    await attachJson("routes-response", body.routes[0])
+
+    for (const route of body.routes) {
+      expect(route.fromAmount, "fromAmount must be echoed").toBe("1000000000000000000")
+      expectPositiveNumber(route.toAmount, "route toAmount")
+      expect(Array.isArray(route.steps)).toBeTruthy()
+      expect(route.steps.length, "a route must have at least one step").toBeGreaterThan(0)
+
+      for (const step of route.steps) {
+        // the quote UI renders toolDetails (name + logo) for every step
+        expect(step.toolDetails, "each step must carry toolDetails").toBeDefined()
+        expect(typeof step.toolDetails.name).toBe("string")
+        expect(step.estimate, "each step must carry an estimate").toBeDefined()
+      }
+    }
+  })
+
+  test("GET /quote returns a transaction request", async ({ request }) => {
+    const params = new URLSearchParams({
+      fromChain: String(ETHEREUM_CHAIN_ID),
+      toChain: String(ETHEREUM_CHAIN_ID),
+      fromToken: NATIVE_ETH,
+      toToken: USDC_ETHEREUM,
+      fromAmount: "1000000000000000000",
+      fromAddress: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      integrator: INTEGRATOR,
+    })
+
+    const response = await request.get(`${LIFI_API_URL}/quote?${params}`, {
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "GET /quote")
+
+    const body = await response.json()
+    expect(response.ok()).toBeTruthy()
+    await attachJson("quote-response", { estimate: body.estimate, action: body.action })
+
+    expect(body.estimate, "the quote must carry an estimate").toBeDefined()
+    expectPositiveNumber(body.estimate.toAmount, "estimate toAmount")
+    expect(body.transactionRequest, "the quote must carry a transactionRequest").toBeDefined()
+    expect(body.transactionRequest.data, "transactionRequest must carry calldata").toBeTruthy()
+  })
+
+  test.describe("Invalid parameter handling", () => {
+    /**
+     * fetchLifiStatus (core/domains/transactions/watchSwapStatus.ts) throws on a non-ok response,
+     * so this must stay a clean 4xx with a JSON body — a 5xx or an HTML error page would surface
+     * as an unhandled failure in the transaction watcher.
+     */
+    test("GET /status with a bogus txHash returns 4xx JSON, not 5xx", async ({ request }) => {
+      const response = await request.get(`${LIFI_API_URL}/status?txHash=0x0`, {
+        failOnStatusCode: false,
+      })
+      await attachRaw("status-bogus-response", response)
+
+      expectNoServerError(response)
+      expect(response.status(), "a bogus hash must be a client error").toBeGreaterThanOrEqual(400)
+      expect(response.headers()["content-type"]).toContain("application/json")
+    })
+
+    test("GET /token with an invalid chain does not 5xx", async ({ request }) => {
+      const response = await request.get(`${LIFI_API_URL}/token?chain=notachain&token=ETH`, {
+        failOnStatusCode: false,
+      })
+      await attachRaw("token-invalid-chain-response", response)
+      expectNoServerError(response)
+    })
+
+    test("POST /advanced/routes with an unknown token does not 5xx", async ({ request }) => {
+      const response = await request.post(`${LIFI_API_URL}/advanced/routes`, {
+        data: {
+          fromChainId: ETHEREUM_CHAIN_ID,
+          fromAmount: "1000000000000000000",
+          fromTokenAddress: NATIVE_ETH,
+          toChainId: ETHEREUM_CHAIN_ID,
+          toTokenAddress: "0x000000000000000000000000000000000000dead",
+          options: { integrator: INTEGRATOR },
+        },
+        failOnStatusCode: false,
+      })
+      await attachRaw("routes-unknown-token-response", response)
+      expectNoServerError(response)
+    })
+
+    test("non-existent endpoint returns 404, not 5xx", async ({ request }) => {
+      const response = await request.get(`${LIFI_API_URL}/nonexistent-endpoint`, {
+        failOnStatusCode: false,
+      })
+      await attachRaw("nonexistent-response", response)
+      expectNoServerError(response)
+    })
+  })
+})

--- a/playwright/api-tests/swap-simpleswap.spec.ts
+++ b/playwright/api-tests/swap-simpleswap.spec.ts
@@ -1,0 +1,228 @@
+/// <reference types="node" />
+
+import { expect, test } from "@playwright/test"
+
+import {
+  attachJson,
+  attachRaw,
+  expectNoServerError,
+  expectPositiveNumber,
+  skipIfUnavailable,
+} from "./helpers"
+
+/**
+ * SimpleSwap is the only swap provider Talisman calls directly, without a talisman.xyz proxy
+ * (see simpleswap-swap-module.ts), so it is also the only one that needs a credential here.
+ * The extension reads the key from the remote config at runtime; the test uses a CI secret so a
+ * failure points at the API rather than at a remote-config change.
+ */
+const SIMPLESWAP_API_URL = "https://api.simpleswap.io"
+const SIMPLESWAP_API_KEY = process.env.SIMPLESWAP_API_KEY
+
+/**
+ * ETH -> USDC on Ethereum. Both sides are assets the wallet actually holds (they are in
+ * `swaps.curatedTokens` in the remote config), so the fixture exercises a route a user can really
+ * take — unlike BTC, which the wallet does not support at all.
+ */
+const FROM = "eth"
+const TO = "usdc"
+
+const withKey = (path: string, params: Record<string, string> = {}) =>
+  `${SIMPLESWAP_API_URL}/${path}?${new URLSearchParams({
+    api_key: SIMPLESWAP_API_KEY ?? "",
+    ...params,
+  })}`
+
+// The credential travels in the query string and traces record full request URLs, while
+// api-health.yml zips playwright-report/ and posts it to Discord on failure. `trace` can only be
+// overridden per file (not per describe), so the opt-out lives here.
+test.use({ trace: "off" })
+
+test.describe("SimpleSwap API", () => {
+  test.describe.configure({ retries: 2 })
+
+  // fork PRs and local runs without the secret skip rather than fail
+  test.skip(
+    !SIMPLESWAP_API_KEY,
+    "SIMPLESWAP_API_KEY is not set — add it to apps/extension/.env or the repo secrets"
+  )
+
+  test("GET /get_all_currencies returns the swappable currency list", async ({ request }) => {
+    const response = await request.get(withKey("get_all_currencies"), { failOnStatusCode: false })
+    skipIfUnavailable(response, "GET /get_all_currencies")
+
+    expect(response.ok()).toBeTruthy()
+    const body = await response.json()
+
+    expect(Array.isArray(body)).toBeTruthy()
+    expect(body.length, "the currency list must not be empty").toBeGreaterThan(0)
+    await attachJson("all-currencies-sample", body.slice(0, 3))
+
+    for (const currency of body.slice(0, 20)) {
+      expect(typeof currency.symbol).toBe("string")
+      expect(typeof currency.network).toBe("string")
+      expect(typeof currency.name).toBe("string")
+    }
+
+    const from = body.find((c: { symbol: string }) => c.symbol === FROM)
+    expect(from, `${FROM} must be swappable`).toBeDefined()
+    // getSwappableAssets keys assets on symbol + network, so both must be present
+    expect(from.network).toBeTruthy()
+  })
+
+  test("GET /get_pairs returns the symbols routable from the source asset", async ({ request }) => {
+    const response = await request.get(withKey("get_pairs", { fixed: "false", symbol: FROM }), {
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "GET /get_pairs")
+
+    expect(response.ok()).toBeTruthy()
+    const body = await response.json()
+    await attachJson("pairs-sample", Array.isArray(body) ? body.slice(0, 10) : body)
+
+    // the module treats this as a flat list of destination symbols
+    expect(Array.isArray(body)).toBeTruthy()
+    expect(body.length, `${FROM} must route to at least one currency`).toBeGreaterThan(0)
+    for (const symbol of body.slice(0, 20)) expect(typeof symbol).toBe("string")
+    expect(body, `${FROM} -> ${TO} must be routable`).toContain(TO)
+  })
+
+  test("GET /get_ranges returns a usable minimum", async ({ request }) => {
+    const response = await request.get(
+      withKey("get_ranges", { fixed: "false", currency_from: FROM, currency_to: TO }),
+      { failOnStatusCode: false }
+    )
+    skipIfUnavailable(response, "GET /get_ranges")
+
+    const body = await response.json()
+    await attachJson("ranges-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    // the swap form blocks amounts below `min`, so a missing/zero min would let invalid swaps through
+    expectPositiveNumber(body.min, `${FROM} -> ${TO} min`)
+
+    if (body.max !== null && body.max !== undefined) {
+      expectPositiveNumber(body.max, `${FROM} -> ${TO} max`)
+      expect(Number(body.max)).toBeGreaterThanOrEqual(Number(body.min))
+    }
+  })
+
+  /**
+   * This endpoint answers with a bare JSON string (e.g. `"3.18927951"`), not an object. The module
+   * consumes it as such, so a change to an object shape would break quotes with no network error.
+   */
+  test("GET /get_estimated returns a bare numeric string", async ({ request }) => {
+    const response = await request.get(
+      withKey("get_estimated", {
+        fixed: "false",
+        currency_from: FROM,
+        currency_to: TO,
+        amount: "0.1",
+      }),
+      { failOnStatusCode: false }
+    )
+    skipIfUnavailable(response, "GET /get_estimated")
+
+    const body = await response.json()
+    await attachJson("estimated-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    expect(typeof body, "the estimate must be a bare JSON string, not an object").toBe("string")
+    expectPositiveNumber(body, `${FROM} -> ${TO} estimated amount`)
+  })
+
+  test.describe("Auth and invalid parameter handling", () => {
+    /**
+     * A regression to 200 here would mean the endpoint stopped requiring a key — i.e. Talisman's
+     * quota is open to anyone who finds the URL.
+     */
+    test("an invalid api_key is rejected with 401", async ({ request }) => {
+      const response = await request.get(
+        `${SIMPLESWAP_API_URL}/get_all_currencies?api_key=not-a-real-key`,
+        { failOnStatusCode: false }
+      )
+      await attachRaw("invalid-key-response", response)
+      expect(response.status(), "auth must still be enforced").toBe(401)
+    })
+
+    test("a missing api_key is rejected", async ({ request }) => {
+      const response = await request.get(`${SIMPLESWAP_API_URL}/get_all_currencies`, {
+        failOnStatusCode: false,
+      })
+      await attachRaw("missing-key-response", response)
+      expectNoServerError(response)
+      expect(response.status()).toBeGreaterThanOrEqual(400)
+    })
+
+    /**
+     * fetchSimpleswapStatus (core/domains/transactions/watchSwapStatus.ts) throws on a non-ok
+     * response, so an unknown exchange id must stay a clean 404.
+     */
+    test("GET /get_exchange with an unknown id returns 404, not 5xx", async ({ request }) => {
+      const response = await request.get(
+        withKey("get_exchange", { id: "definitely-not-an-exchange-id" }),
+        { failOnStatusCode: false }
+      )
+      await attachRaw("unknown-exchange-response", response)
+
+      expectNoServerError(response)
+      expect(response.status()).toBe(404)
+    })
+
+    /**
+     * Known upstream issue: SimpleSwap answers an unsupported pair with 500, not 4xx. It matters
+     * here because getEstimate in simpleswap-swap-module.ts returns `res.json()` without checking
+     * `res.ok`, so the error body flows straight into the quote path. Left as fixme to report if
+     * SimpleSwap starts returning a proper client error.
+     */
+    test.fixme("an unsupported pair on get_estimated does not 5xx", async ({ request }) => {
+      const response = await request.get(
+        withKey("get_estimated", {
+          fixed: "false",
+          currency_from: "notacoin",
+          currency_to: "alsonotacoin",
+          amount: "1",
+        }),
+        { failOnStatusCode: false }
+      )
+      await attachRaw("unsupported-pair-response", response)
+      expectNoServerError(response)
+    })
+
+    /**
+     * The property the module actually depends on while the 500 above stands: a failed estimate
+     * must not be shaped like a successful one. getEstimate returns the parsed body either way, so
+     * if an error ever came back as a bare numeric string it would be quoted as a real rate.
+     */
+    test("a failed estimate is distinguishable from a successful one", async ({ request }) => {
+      const response = await request.get(
+        withKey("get_estimated", {
+          fixed: "false",
+          currency_from: "notacoin",
+          currency_to: "alsonotacoin",
+          amount: "1",
+        }),
+        { failOnStatusCode: false }
+      )
+      await attachRaw("unsupported-pair-response", response)
+
+      expect(response.ok(), "an unsupported pair must not report success").toBeFalsy()
+
+      const body = await response.json()
+      expect(
+        typeof body,
+        "an error body must not be a bare numeric string, which is the success shape"
+      ).not.toBe("string")
+    })
+
+    test("non-existent endpoint returns 404, not 5xx", async ({ request }) => {
+      const response = await request.get(withKey("nonexistent_endpoint"), {
+        failOnStatusCode: false,
+      })
+      await attachRaw("nonexistent-response", response)
+      expectNoServerError(response)
+    })
+  })
+
+  // Out of scope on purpose: POST /create_exchange creates a real exchange record at the provider.
+})

--- a/playwright/api-tests/swap-stealthex.spec.ts
+++ b/playwright/api-tests/swap-stealthex.spec.ts
@@ -1,0 +1,247 @@
+/// <reference types="node" />
+
+import { expect, test } from "@playwright/test"
+
+import {
+  attachJson,
+  attachRaw,
+  expectNoServerError,
+  expectPositiveNumber,
+  skipIfUnavailable,
+} from "./helpers"
+
+const STEALTHEX_API_URL = "https://stealthex.talisman.xyz"
+
+/**
+ * getAllCurrencies in stealthex-swap-module.ts pages with limit=250 and stops as soon as a page
+ * returns fewer than 250 items. If the provider ever changes its page size, the asset list is
+ * silently truncated at the first page — hence the exact assertion below.
+ */
+const PAGE_SIZE = 250
+
+/**
+ * ETH on Ethereum -> USDC on Ethereum. Both sides are assets the wallet actually holds (they are in
+ * `swaps.curatedTokens` in the remote config), so the fixture exercises a route a user can really
+ * take — unlike BTC, which the wallet does not support at all. Note StealthEX names Ethereum
+ * `mainnet` for the native coin but `eth` for tokens on it.
+ */
+const ROUTE = {
+  from: { network: "mainnet", symbol: "eth" },
+  to: { network: "eth", symbol: "usdc" },
+}
+
+test.describe("StealthEX Swap API", () => {
+  test.describe.configure({ retries: 2 })
+
+  test("GET /v4/currencies returns a full page of 250 currencies", async ({ request }) => {
+    const response = await request.get(
+      `${STEALTHEX_API_URL}/v4/currencies?limit=${PAGE_SIZE}&offset=0`,
+      { failOnStatusCode: false }
+    )
+    skipIfUnavailable(response, "GET /v4/currencies")
+
+    expect(response.ok()).toBeTruthy()
+    const body = await response.json()
+    await attachJson("currencies-sample", Array.isArray(body) ? body.slice(0, 3) : body)
+
+    expect(Array.isArray(body)).toBeTruthy()
+    expect(body, `the pagination loop assumes a page size of ${PAGE_SIZE}`).toHaveLength(PAGE_SIZE)
+
+    for (const currency of body.slice(0, 20)) {
+      expect(typeof currency.symbol).toBe("string")
+      expect(typeof currency.network).toBe("string")
+      expect(Array.isArray(currency.rates), "rates drives fixed/floating support").toBeTruthy()
+      expect(Array.isArray(currency.features)).toBeTruthy()
+    }
+  })
+
+  test("GET /v4/currencies honours offset", async ({ request }) => {
+    const [first, second] = await Promise.all([
+      request.get(`${STEALTHEX_API_URL}/v4/currencies?limit=${PAGE_SIZE}&offset=0`, {
+        failOnStatusCode: false,
+      }),
+      request.get(`${STEALTHEX_API_URL}/v4/currencies?limit=${PAGE_SIZE}&offset=${PAGE_SIZE}`, {
+        failOnStatusCode: false,
+      }),
+    ])
+    skipIfUnavailable(first, "GET /v4/currencies (page 1)")
+    skipIfUnavailable(second, "GET /v4/currencies (page 2)")
+
+    expect(first.ok()).toBeTruthy()
+    expect(second.ok()).toBeTruthy()
+
+    const page1 = await first.json()
+    const page2 = await second.json()
+    expect(page2.length, "a second page must exist").toBeGreaterThan(0)
+    await attachJson("pagination-boundary", { page1End: page1.at(-1), page2Start: page2[0] })
+
+    const key = (c: { symbol: string; network: string }) => `${c.symbol}:${c.network}`
+    const page1Keys = new Set(page1.map(key))
+    const overlap = page2.filter((c: { symbol: string; network: string }) => page1Keys.has(key(c)))
+
+    // a broken offset would replay page 1 and make the loop drop every currency past the first page
+    expect(overlap, `offset=${PAGE_SIZE} must not repeat page 1`).toHaveLength(0)
+  })
+
+  test("GET /v4/currencies/:symbol/:network returns available routes on demand", async ({
+    request,
+  }) => {
+    const response = await request.get(
+      `${STEALTHEX_API_URL}/v4/currencies/${ROUTE.from.symbol}/${ROUTE.from.network}?include_available_routes=true`,
+      { failOnStatusCode: false }
+    )
+    skipIfUnavailable(response, "GET /v4/currencies/:symbol/:network")
+
+    expect(response.ok()).toBeTruthy()
+    const body = await response.json()
+    await attachJson("currency-detail", {
+      ...body,
+      available_routes: body.available_routes?.slice(0, 5),
+    })
+
+    expect(body.symbol).toBe(ROUTE.from.symbol)
+    expect(body.network).toBe(ROUTE.from.network)
+    expect(Array.isArray(body.available_routes)).toBeTruthy()
+    expect(
+      body.available_routes.length,
+      `${ROUTE.from.symbol} must have destinations`
+    ).toBeGreaterThan(0)
+
+    for (const route of body.available_routes.slice(0, 20)) {
+      expect(typeof route.symbol).toBe("string")
+      expect(typeof route.network).toBe("string")
+      expect(Array.isArray(route.rates)).toBeTruthy()
+    }
+
+    const target = body.available_routes.find(
+      (route: { symbol: string; network: string }) =>
+        route.symbol === ROUTE.to.symbol && route.network === ROUTE.to.network
+    )
+    expect(target, `${ROUTE.from.symbol} -> ${ROUTE.to.symbol} must be routable`).toBeDefined()
+  })
+
+  test("available_routes is omitted unless requested", async ({ request }) => {
+    const response = await request.get(
+      `${STEALTHEX_API_URL}/v4/currencies/${ROUTE.from.symbol}/${ROUTE.from.network}`,
+      { failOnStatusCode: false }
+    )
+    skipIfUnavailable(response, "GET /v4/currencies/:symbol/:network (no flag)")
+
+    expect(response.ok()).toBeTruthy()
+    const body = await response.json()
+    await attachJson("currency-detail-no-routes", body)
+
+    // getPairs passes include_available_routes explicitly; the payload would be huge by default
+    expect(body.available_routes, "routes must be opt-in").toBeUndefined()
+  })
+
+  test("POST /v4/rates/range returns the swappable range", async ({ request }) => {
+    const response = await request.post(`${STEALTHEX_API_URL}/v4/rates/range`, {
+      data: { route: ROUTE, estimation: "direct", rate: "floating" },
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "POST /v4/rates/range")
+
+    const body = await response.json()
+    await attachJson("range-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    // getRange feeds the swap form's minimum; a zero/missing min lets invalid swaps through
+    expectPositiveNumber(body.min_amount, `${ROUTE.from.symbol} -> ${ROUTE.to.symbol} min_amount`)
+
+    if (body.max_amount !== null && body.max_amount !== undefined) {
+      expectPositiveNumber(body.max_amount, "max_amount")
+      expect(Number(body.max_amount)).toBeGreaterThanOrEqual(Number(body.min_amount))
+    }
+  })
+
+  test("POST /v4/rates/estimated-amount returns a quote", async ({ request }) => {
+    const response = await request.post(`${STEALTHEX_API_URL}/v4/rates/estimated-amount`, {
+      data: { route: ROUTE, amount: 0.1, estimation: "direct", rate: "floating" },
+      failOnStatusCode: false,
+    })
+    skipIfUnavailable(response, "POST /v4/rates/estimated-amount")
+
+    const body = await response.json()
+    await attachJson("estimate-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    expectPositiveNumber(body.estimated_amount, "estimated_amount")
+  })
+
+  test.describe("Error handling", () => {
+    /**
+     * The module surfaces errors as `${error.err.kind}: ${error.err.details}`. If the envelope is
+     * ever renamed, every swap error message in the UI becomes "undefined: undefined".
+     */
+    test("errors use the { err: { kind, details } } envelope", async ({ request }) => {
+      const response = await request.post(`${STEALTHEX_API_URL}/v4/rates/range`, {
+        data: {
+          route: { from: { network: "mainnet", symbol: "notacoin" }, to: ROUTE.to },
+          estimation: "direct",
+          rate: "floating",
+        },
+        failOnStatusCode: false,
+      })
+      await attachRaw("error-envelope-response", response)
+
+      expectNoServerError(response)
+      expect(response.status(), "an unknown symbol is a client error").toBeGreaterThanOrEqual(400)
+
+      const body = await response.json()
+      expect(body.err, "the error envelope must carry `err`").toBeDefined()
+      expect(typeof body.err.kind, "err.kind is rendered in the UI").toBe("string")
+      expect(body.err).toHaveProperty("details")
+    })
+
+    /**
+     * fetchStealthexStatus (core/domains/transactions/watchSwapStatus.ts) throws on a non-ok
+     * response, so an unknown exchange id must stay a clean 404.
+     */
+    test("GET /v4/exchanges/:id with an unknown id returns 404, not 5xx", async ({ request }) => {
+      const response = await request.get(
+        `${STEALTHEX_API_URL}/v4/exchanges/definitely-not-an-exchange-id`,
+        { failOnStatusCode: false }
+      )
+      await attachRaw("unknown-exchange-response", response)
+
+      expectNoServerError(response)
+      expect(response.status()).toBe(404)
+    })
+
+    /**
+     * Known issue: any unrouted path makes the proxy worker throw (Cloudflare "Error 1101:
+     * Worker threw exception") instead of returning 404. Same root cause as the openapi.json
+     * failure below. Routed paths behave correctly — see the 404 assertion above.
+     */
+    test.fixme("non-existent endpoint returns 404, not 5xx", async ({ request }) => {
+      const response = await request.get(`${STEALTHEX_API_URL}/v4/nonexistent-endpoint`, {
+        failOnStatusCode: false,
+      })
+      await attachRaw("nonexistent-response", response)
+      expectNoServerError(response)
+    })
+  })
+
+  /**
+   * Known issue: both /openapi.json and /docs/openapi.json return 500 (the proxy worker throws on
+   * unrouted paths — see the fixme above), which breaks `pnpm chore:codegen:stealthex-swaps`: the
+   * types in apps/extension/src/ui/domains/Swap/swap-modules/stealthex.api.d.ts cannot be
+   * regenerated. Left as fixme so it reports as soon as the proxy serves the spec again.
+   */
+  test.fixme("OpenAPI spec is accessible for client codegen", async ({ request }) => {
+    const response = await request.get(`${STEALTHEX_API_URL}/openapi.json`, {
+      failOnStatusCode: false,
+    })
+    await attachRaw("openapi-response", response)
+
+    expect(response.ok()).toBeTruthy()
+    const spec = await response.json()
+    expect(spec).toHaveProperty("paths")
+    expect(spec.paths).toHaveProperty("/v4/currencies")
+    expect(spec.paths).toHaveProperty("/v4/rates/range")
+    expect(spec.paths).toHaveProperty("/v4/rates/estimated-amount")
+  })
+
+  // Out of scope on purpose: POST /v4/exchanges creates a real exchange record at the provider.
+})

--- a/playwright/api-tests/token-rates.spec.ts
+++ b/playwright/api-tests/token-rates.spec.ts
@@ -1,0 +1,218 @@
+/// <reference types="node" />
+
+import { type APIRequestContext, expect, test } from "@playwright/test"
+
+import {
+  attachJson,
+  attachRaw,
+  expectFiniteNumber,
+  expectNonNegativeNumber,
+  expectNoServerError,
+  expectPositiveNumber,
+} from "./helpers"
+
+const COINS_API_URL = "https://coins.talisman.xyz"
+
+/**
+ * To save bandwidth the API returns values positionally, without property names:
+ * `[[[price, marketCap, change24h], ...perCurrency], ...perCoingeckoId]`.
+ * See `RawTokenRates` / `parseTokenRatesFromApi` in packages/token-rates/src/TokenRates.ts.
+ */
+type RawTokenRates = ([number | null, number | null, number | null] | null)[][]
+
+/**
+ * Mirrors SUPPORTED_CURRENCIES in packages/token-rates/src/types.ts, minus `tao`:
+ * coingecko has no TAO vs-currency, so the wallet derives it from usd and never asks for it
+ * (see the `hasVsTao` branch in TokenRates.ts).
+ */
+const API_CURRENCY_IDS = [
+  "btc",
+  "eth",
+  "dot",
+  "usd",
+  "cny",
+  "eur",
+  "gbp",
+  "cad",
+  "aud",
+  "nzd",
+  "jpy",
+  "rub",
+  "krw",
+  "idr",
+  "php",
+  "thb",
+  "vnd",
+  "inr",
+  "try",
+  "sgd",
+] as const
+
+const fetchRates = (
+  request: APIRequestContext,
+  coingeckoIds: string[],
+  currencyIds: readonly string[]
+) =>
+  request.post(`${COINS_API_URL}/token-rates`, {
+    data: { coingeckoIds, currencyIds },
+    failOnStatusCode: false,
+  })
+
+test.describe("Token Rates API", () => {
+  test.describe.configure({ retries: 2 })
+
+  test("POST /token-rates returns a coingeckoId x currency matrix", async ({ request }) => {
+    const coingeckoIds = ["polkadot", "bittensor", "ethereum"]
+    const currencyIds = ["usd", "eur", "btc"]
+
+    const response = await fetchRates(request, coingeckoIds, currencyIds)
+    const body = (await response.json()) as RawTokenRates
+    await attachJson("token-rates-response", body)
+
+    expect(response.ok()).toBeTruthy()
+    expect(Array.isArray(body)).toBeTruthy()
+    expect(body).toHaveLength(coingeckoIds.length)
+
+    for (const [idx, rates] of body.entries()) {
+      expect(
+        Array.isArray(rates),
+        `row ${idx} (${coingeckoIds[idx]}) must be an array`
+      ).toBeTruthy()
+      expect(rates, `row ${idx} (${coingeckoIds[idx]})`).toHaveLength(currencyIds.length)
+
+      for (const [curIdx, rate] of rates.entries()) {
+        // a cell may legitimately be null, but when present it is always a 3-tuple
+        if (rate === null) continue
+        expect(rate, `${coingeckoIds[idx]}/${currencyIds[curIdx]} must be a 3-tuple`).toHaveLength(
+          3
+        )
+      }
+    }
+  })
+
+  /**
+   * The single most important guarantee of this API: rows/cells are matched back to ids purely
+   * by index (parseTokenRatesFromApi). If the backend ever reorders them, every price in the
+   * wallet silently belongs to the wrong token — no error, no failed request.
+   */
+  test("row order follows the requested coingeckoId order", async ({ request }) => {
+    const currencyIds = ["usd"]
+
+    const forward = await fetchRates(request, ["bittensor", "polkadot"], currencyIds)
+    const reversed = await fetchRates(request, ["polkadot", "bittensor"], currencyIds)
+    expect(forward.ok()).toBeTruthy()
+    expect(reversed.ok()).toBeTruthy()
+
+    const forwardBody = (await forward.json()) as RawTokenRates
+    const reversedBody = (await reversed.json()) as RawTokenRates
+    await attachJson("order-forward", forwardBody)
+    await attachJson("order-reversed", reversedBody)
+
+    const taoForward = forwardBody[0]?.[0]?.[0]
+    const dotForward = forwardBody[1]?.[0]?.[0]
+    const dotReversed = reversedBody[0]?.[0]?.[0]
+    const taoReversed = reversedBody[1]?.[0]?.[0]
+
+    expectPositiveNumber(taoForward, "bittensor/usd (first position)")
+    expectPositiveNumber(dotForward, "polkadot/usd (second position)")
+
+    // TAO is worth orders of magnitude more than DOT, so a swapped mapping is unmistakable
+    expect(Number(taoForward)).toBeGreaterThan(Number(dotForward))
+
+    // same ids, opposite request order -> the values must follow the request, not the response slot
+    expect(Number(dotReversed)).toBeCloseTo(Number(dotForward), 1)
+    expect(Number(taoReversed)).toBeCloseTo(Number(taoForward), 1)
+  })
+
+  test("cell values are valid price / marketCap / change24h triples", async ({ request }) => {
+    const response = await fetchRates(request, ["polkadot", "ethereum"], ["usd", "eur"])
+    expect(response.ok()).toBeTruthy()
+    const body = (await response.json()) as RawTokenRates
+    await attachJson("triples-response", body)
+
+    for (const [idx, rates] of body.entries()) {
+      for (const [curIdx, rate] of rates.entries()) {
+        if (rate === null) continue
+        const label = `row ${idx} currency ${curIdx}`
+        const [price, marketCap, change24h] = rate
+
+        expectPositiveNumber(price, `${label} price`)
+        if (marketCap !== null) expectNonNegativeNumber(marketCap, `${label} marketCap`)
+        if (change24h !== null) expectFiniteNumber(change24h, `${label} change24h`)
+      }
+    }
+  })
+
+  /**
+   * Guards against a currency silently disappearing upstream: the wallet offers all of these in
+   * the currency picker, and a dropped one renders as a blank fiat value everywhere.
+   */
+  test("every supported currency resolves for a major token", async ({ request }) => {
+    const response = await fetchRates(request, ["polkadot"], API_CURRENCY_IDS)
+    expect(response.ok()).toBeTruthy()
+    const body = (await response.json()) as RawTokenRates
+    await attachJson("all-currencies-response", body)
+
+    expect(body).toHaveLength(1)
+    const rates = body[0]
+    expect(rates).toHaveLength(API_CURRENCY_IDS.length)
+
+    const missing = API_CURRENCY_IDS.filter((_, idx) => {
+      const price = rates[idx]?.[0]
+      return price === null || price === undefined
+    })
+    expect(missing, `currencies with no price: ${missing.join(", ")}`).toHaveLength(0)
+  })
+
+  /**
+   * The wallet's whole TAO-denominated display is computed from bittensor/usd
+   * (the `hasVsTao` branch in TokenRates.ts). No bittensor/usd rate -> every TAO balance breaks.
+   */
+  test("bittensor/usd is resolvable (TAO display depends on it)", async ({ request }) => {
+    const response = await fetchRates(request, ["bittensor"], ["usd"])
+    expect(response.ok()).toBeTruthy()
+    const body = (await response.json()) as RawTokenRates
+    await attachJson("bittensor-usd-response", body)
+
+    expect(body).toHaveLength(1)
+    expect(body[0]).toHaveLength(1)
+    expectPositiveNumber(body[0]?.[0]?.[0], "bittensor/usd price")
+  })
+
+  test("unknown coingeckoId keeps the row positions intact", async ({ request }) => {
+    const coingeckoIds = ["polkadot", "definitely-not-a-real-coin", "ethereum"]
+    const response = await fetchRates(request, coingeckoIds, ["usd"])
+    await attachRaw("unknown-id-response", response)
+
+    expectNoServerError(response)
+    if (!response.ok()) return
+
+    const body = (await response.json()) as RawTokenRates
+    expect(body, "the unknown id must not collapse the array").toHaveLength(coingeckoIds.length)
+
+    // the known ids must still land on their requested indexes
+    expectPositiveNumber(body[0]?.[0]?.[0], "polkadot/usd at index 0")
+    expectPositiveNumber(body[2]?.[0]?.[0], "ethereum/usd at index 2")
+  })
+
+  test("empty and malformed requests do not 5xx", async ({ request }) => {
+    const empty = await fetchRates(request, [], [])
+    await attachRaw("empty-request-response", empty)
+    expectNoServerError(empty)
+
+    const malformed = await request.post(`${COINS_API_URL}/token-rates`, {
+      data: { coingeckoIds: "not-an-array", currencyIds: 42 },
+      failOnStatusCode: false,
+    })
+    await attachRaw("malformed-request-response", malformed)
+    expectNoServerError(malformed)
+  })
+
+  test("non-existent endpoint returns 404, not 5xx", async ({ request }) => {
+    const response = await request.get(`${COINS_API_URL}/nonexistent-endpoint`, {
+      failOnStatusCode: false,
+    })
+    await attachRaw("nonexistent-response", response)
+    expectNoServerError(response)
+  })
+})


### PR DESCRIPTION
Adds API health tests for the money paths that had no coverage: token rates, on/off-ramp, and the
three swap providers. 48 tests across 5 new specs, plus a shared helper module.

Repair chore:codegen:stealthex-swaps, which was broken by two independent
causes — fixing either one alone would not have been enough:

- Our proxy at stealthex.talisman.xyz returns 500 for /docs/openapi.json; it
  throws on any unrouted path. StealthEX serves the same spec publicly and
  unauthenticated at api.stealthex.io/docs/openapi.json, as a superset of what
  we had generated.
- openapi-typescript@7.13.0 peers typescript ^5.x while this repo is on 7.0.2,
  so `import ts from "typescript"` yields no .factory and the tool crashed on
  any spec, not just this one. No published version supports TS 7 yet.

Now runs via pnpm dlx with TypeScript 5 pinned in an isolated environment — the
same pattern the sibling chore:generate-clients:* scripts already use — leaving
Repair chore:codegen:stealthex-swaps, which was broken by two independent
causes — fixing either one alone would not have been enough: