### PR TITLE
🐛 Allow swap output tokens on account-incompatible networks

### DIFF
--- a/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
+++ b/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
@@ -238,15 +238,19 @@ const TokenRow: FC<TokenRowProps> = ({
 
 const DEFAULT_FILTER = () => true
 
+/**
+ * "usable" (default) shows only active tokens on networks that a wallet account can sign for.
+ * "all" also includes inactive tokens and account-incompatible networks, e.g. when the tokens may be sent to an external recipient.
+ */
+export type TokenPickerScope = "usable" | "all"
+
 type TokensListProps = {
   address?: Address
   selected?: TokenId
   search?: string
   selectedNetworkId?: string | null
   allowUntransferable?: boolean
-  ownedOnly?: boolean
-  activeOnly?: boolean
-  accountCompatibleOnly?: boolean
+  tokenScope?: TokenPickerScope
   showEmptyBalances?: boolean
   isInitializing?: boolean
   /** these tokens will always be sorted to the top of the list */
@@ -262,9 +266,7 @@ const TokensList: FC<TokensListProps> = ({
   search,
   selectedNetworkId,
   allowUntransferable,
-  ownedOnly,
-  activeOnly = true,
-  accountCompatibleOnly = true,
+  tokenScope = "usable",
   showEmptyBalances,
   isInitializing,
   priorityTokens,
@@ -275,13 +277,13 @@ const TokensList: FC<TokensListProps> = ({
   const { t } = useTranslation()
   const account = useAccountByAddress(address)
   const accounts = useAccounts()
-  const allTokens = useTokens({ activeOnly, includeTestnets: true })
+  const allTokens = useTokens({ activeOnly: tokenScope === "usable", includeTestnets: true })
   const activeTokens = useTokens({ activeOnly: true, includeTestnets: true })
   const tokenRatesMap = useTokenRatesMap()
   const networksMap = useNetworksMapById()
 
   const isBalancesInitializing = useIsBalanceInitializing()
-  const balances = useBalances(ownedOnly ? "owned" : "all")
+  const balances = useBalances("owned")
   const currency = useSelectedCurrency()
 
   // Capture the selected token at mount time so the sort order stays stable.
@@ -308,11 +310,11 @@ const TokensList: FC<TokensListProps> = ({
       const network = networksMap[token.networkId]
       if (!network) return false
       if (account) return isAccountCompatibleWithNetwork(network, account)
-      if (!accountCompatibleOnly) return true
+      if (tokenScope === "all") return true
 
       return compatibleNetworkIds.has(token.networkId)
     },
-    [account, accountCompatibleOnly, compatibleNetworkIds, networksMap]
+    [account, tokenScope, compatibleNetworkIds, networksMap]
   )
 
   const activeTokenIds = useMemo(() => new Set(activeTokens.map((t) => t.id)), [activeTokens])
@@ -535,10 +537,7 @@ type TokenPickerProps = {
   selected?: TokenId
   initialSearch?: string
   allowUntransferable?: boolean
-  ownedOnly?: boolean
-  activeOnly?: boolean
-  /** Set to false to include tokens from networks that no wallet account can sign for, e.g. when the tokens may be sent to an external recipient */
-  accountCompatibleOnly?: boolean
+  tokenScope?: TokenPickerScope
   isInitializing?: boolean
   className?: string
   showEmptyBalances?: boolean
@@ -558,9 +557,7 @@ export const TokenPicker: FC<TokenPickerProps> = ({
   selected,
   initialSearch = "",
   allowUntransferable,
-  ownedOnly,
-  activeOnly,
-  accountCompatibleOnly,
+  tokenScope,
   isInitializing,
   className,
   showEmptyBalances,
@@ -627,15 +624,13 @@ export const TokenPicker: FC<TokenPickerProps> = ({
           search={deferredSearch}
           selectedNetworkId={selectedNetworkId}
           allowUntransferable={allowUntransferable}
-          ownedOnly={ownedOnly}
           isInitializing={isInitializing}
           priorityTokens={priorityTokens}
           tokenFilter={tokenFilter}
           onAvailableNetworksChange={networkFilterContainerId ? setAvailableNetworks : undefined}
           onSelect={onSelect}
           showEmptyBalances={showEmptyBalances}
-          activeOnly={activeOnly ?? !showEmptyBalances}
-          accountCompatibleOnly={accountCompatibleOnly}
+          tokenScope={tokenScope}
         />
       </ScrollContainer>
       {!!networkFilterContainerId && (

--- a/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
+++ b/apps/extension/src/ui/domains/Asset/TokenPicker.tsx
@@ -246,6 +246,7 @@ type TokensListProps = {
   allowUntransferable?: boolean
   ownedOnly?: boolean
   activeOnly?: boolean
+  accountCompatibleOnly?: boolean
   showEmptyBalances?: boolean
   isInitializing?: boolean
   /** these tokens will always be sorted to the top of the list */
@@ -263,6 +264,7 @@ const TokensList: FC<TokensListProps> = ({
   allowUntransferable,
   ownedOnly,
   activeOnly = true,
+  accountCompatibleOnly = true,
   showEmptyBalances,
   isInitializing,
   priorityTokens,
@@ -305,11 +307,12 @@ const TokensList: FC<TokensListProps> = ({
     (token: Token) => {
       const network = networksMap[token.networkId]
       if (!network) return false
-      if (!account) return compatibleNetworkIds.has(token.networkId)
+      if (account) return isAccountCompatibleWithNetwork(network, account)
+      if (!accountCompatibleOnly) return true
 
-      return isAccountCompatibleWithNetwork(network, account)
+      return compatibleNetworkIds.has(token.networkId)
     },
-    [account, compatibleNetworkIds, networksMap]
+    [account, accountCompatibleOnly, compatibleNetworkIds, networksMap]
   )
 
   const activeTokenIds = useMemo(() => new Set(activeTokens.map((t) => t.id)), [activeTokens])
@@ -534,6 +537,8 @@ type TokenPickerProps = {
   allowUntransferable?: boolean
   ownedOnly?: boolean
   activeOnly?: boolean
+  /** Set to false to include tokens from networks that no wallet account can sign for, e.g. when the tokens may be sent to an external recipient */
+  accountCompatibleOnly?: boolean
   isInitializing?: boolean
   className?: string
   showEmptyBalances?: boolean
@@ -555,6 +560,7 @@ export const TokenPicker: FC<TokenPickerProps> = ({
   allowUntransferable,
   ownedOnly,
   activeOnly,
+  accountCompatibleOnly,
   isInitializing,
   className,
   showEmptyBalances,
@@ -629,6 +635,7 @@ export const TokenPicker: FC<TokenPickerProps> = ({
           onSelect={onSelect}
           showEmptyBalances={showEmptyBalances}
           activeOnly={activeOnly ?? !showEmptyBalances}
+          accountCompatibleOnly={accountCompatibleOnly}
         />
       </ScrollContainer>
       {!!networkFilterContainerId && (

--- a/apps/extension/src/ui/domains/Earn/yieldxyz/enter/steps/YieldxyzEnterStepToken.tsx
+++ b/apps/extension/src/ui/domains/Earn/yieldxyz/enter/steps/YieldxyzEnterStepToken.tsx
@@ -31,8 +31,6 @@ export const YieldxyzEnterStepToken: FC = () => {
     >
       <TokenPicker
         tokenFilter={tokenFilter}
-        allowUntransferable={false}
-        ownedOnly
         selected={pickerTokenId ?? undefined}
         onSelect={onPickerTokenChanged}
       />

--- a/apps/extension/src/ui/domains/SendFunds/SendFundsTokenPicker.tsx
+++ b/apps/extension/src/ui/domains/SendFunds/SendFundsTokenPicker.tsx
@@ -29,7 +29,6 @@ export const SendFundsTokenPicker = () => {
 
   return (
     <TokenPicker
-      ownedOnly
       address={from}
       initialSearch={tokenSymbol}
       selected={tokenId}

--- a/apps/extension/src/ui/domains/Swap/components/SelectTokenButton.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SelectTokenButton.tsx
@@ -27,10 +27,19 @@ type Props = {
   priorityMode?: "buy" | "sell"
   /** Hide inactive tokens and tokens from inactive networks */
   activeOnly?: boolean
+  /** Set to false to include tokens from networks that no wallet account can sign for, e.g. when the tokens may be sent to an external recipient */
+  accountCompatibleOnly?: boolean
 }
 
 export const SelectTokenButton: React.FC<Props> = memo(
-  ({ allowedTokenIds, selectedTokenId, onSelectTokenId, priorityMode, activeOnly }) => {
+  ({
+    allowedTokenIds,
+    selectedTokenId,
+    onSelectTokenId,
+    priorityMode,
+    activeOnly,
+    accountCompatibleOnly,
+  }) => {
     const { open, close, isOpen } = useOpenClose()
 
     const handleSelect = useCallback(
@@ -50,6 +59,7 @@ export const SelectTokenButton: React.FC<Props> = memo(
           allowedTokenIds={allowedTokenIds}
           priorityMode={priorityMode}
           activeOnly={activeOnly}
+          accountCompatibleOnly={accountCompatibleOnly}
           onSelect={handleSelect}
           onDismiss={close}
         />
@@ -64,6 +74,7 @@ const TokenPickerModal: FC<{
   allowedTokenIds: string[] | undefined
   priorityMode?: "buy" | "sell"
   activeOnly?: boolean
+  accountCompatibleOnly?: boolean
   onSelect: (tokenId: TokenId) => void
   onDismiss: () => void
 }> = ({ isOpen, ...contentProps }) => {
@@ -79,9 +90,18 @@ const TokenPickerModalContent: FC<{
   allowedTokenIds: string[] | undefined
   priorityMode?: "buy" | "sell"
   activeOnly?: boolean
+  accountCompatibleOnly?: boolean
   onSelect: (tokenId: TokenId) => void
   onDismiss: () => void
-}> = ({ tokenId, allowedTokenIds, priorityMode, activeOnly, onSelect, onDismiss }) => {
+}> = ({
+  tokenId,
+  allowedTokenIds,
+  priorityMode,
+  activeOnly,
+  accountCompatibleOnly,
+  onSelect,
+  onDismiss,
+}) => {
   const { t } = useTranslation()
   const remoteConfig = useRemoteConfig()
 
@@ -154,6 +174,7 @@ const TokenPickerModalContent: FC<{
         allowUntransferable
         ownedOnly
         activeOnly={activeOnly}
+        accountCompatibleOnly={accountCompatibleOnly}
         isInitializing={!allowedTokenIds}
         networkFilterContainerId={PICKER_CONTAINER_ID}
         priorityTokens={priorityTokens}

--- a/apps/extension/src/ui/domains/Swap/components/SelectTokenButton.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SelectTokenButton.tsx
@@ -5,7 +5,7 @@ import { Drawer } from "@ui/components/Drawer"
 import { Modal } from "@ui/components/Modal"
 import { WizardModalDialog } from "@ui/components/WizardModalDialog"
 import { TokenLogo } from "@ui/domains/Asset/TokenLogo"
-import { TokenPicker } from "@ui/domains/Asset/TokenPicker"
+import { TokenPicker, type TokenPickerScope } from "@ui/domains/Asset/TokenPicker"
 import { NetworkLogo } from "@ui/domains/Networks/NetworkLogo"
 import { useOpenClose } from "@ui/hooks/useOpenClose"
 import { useNetworkById, useToken, useTokensMap } from "@ui/state/chaindata"
@@ -25,21 +25,11 @@ type Props = {
   onSelectTokenId: (tokenId: string) => void
   /** Used to determine which tokens should be prioritized to the top of the list */
   priorityMode?: "buy" | "sell"
-  /** Hide inactive tokens and tokens from inactive networks */
-  activeOnly?: boolean
-  /** Set to false to include tokens from networks that no wallet account can sign for, e.g. when the tokens may be sent to an external recipient */
-  accountCompatibleOnly?: boolean
+  tokenScope?: TokenPickerScope
 }
 
 export const SelectTokenButton: React.FC<Props> = memo(
-  ({
-    allowedTokenIds,
-    selectedTokenId,
-    onSelectTokenId,
-    priorityMode,
-    activeOnly,
-    accountCompatibleOnly,
-  }) => {
+  ({ allowedTokenIds, selectedTokenId, onSelectTokenId, priorityMode, tokenScope }) => {
     const { open, close, isOpen } = useOpenClose()
 
     const handleSelect = useCallback(
@@ -58,8 +48,7 @@ export const SelectTokenButton: React.FC<Props> = memo(
           tokenId={selectedTokenId ?? null}
           allowedTokenIds={allowedTokenIds}
           priorityMode={priorityMode}
-          activeOnly={activeOnly}
-          accountCompatibleOnly={accountCompatibleOnly}
+          tokenScope={tokenScope}
           onSelect={handleSelect}
           onDismiss={close}
         />
@@ -73,8 +62,7 @@ const TokenPickerModal: FC<{
   tokenId: TokenId | null
   allowedTokenIds: string[] | undefined
   priorityMode?: "buy" | "sell"
-  activeOnly?: boolean
-  accountCompatibleOnly?: boolean
+  tokenScope?: TokenPickerScope
   onSelect: (tokenId: TokenId) => void
   onDismiss: () => void
 }> = ({ isOpen, ...contentProps }) => {
@@ -89,19 +77,10 @@ const TokenPickerModalContent: FC<{
   tokenId: TokenId | null
   allowedTokenIds: string[] | undefined
   priorityMode?: "buy" | "sell"
-  activeOnly?: boolean
-  accountCompatibleOnly?: boolean
+  tokenScope?: TokenPickerScope
   onSelect: (tokenId: TokenId) => void
   onDismiss: () => void
-}> = ({
-  tokenId,
-  allowedTokenIds,
-  priorityMode,
-  activeOnly,
-  accountCompatibleOnly,
-  onSelect,
-  onDismiss,
-}) => {
+}> = ({ tokenId, allowedTokenIds, priorityMode, tokenScope, onSelect, onDismiss }) => {
   const { t } = useTranslation()
   const remoteConfig = useRemoteConfig()
 
@@ -172,9 +151,7 @@ const TokenPickerModalContent: FC<{
       <TokenPicker
         selected={tokenId ?? undefined}
         allowUntransferable
-        ownedOnly
-        activeOnly={activeOnly}
-        accountCompatibleOnly={accountCompatibleOnly}
+        tokenScope={tokenScope}
         isInitializing={!allowedTokenIds}
         networkFilterContainerId={PICKER_CONTAINER_ID}
         priorityTokens={priorityTokens}

--- a/apps/extension/src/ui/domains/Swap/components/SwapForm.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapForm.tsx
@@ -114,7 +114,6 @@ export const SwapForm = () => {
                 selectedTokenId={fromTokenId}
                 allowedTokenIds={fromAssetIds}
                 priorityMode="sell"
-                activeOnly
               />
             }
             tokenAmount={<InputFromAmount />}
@@ -144,7 +143,7 @@ export const SwapForm = () => {
                 selectedTokenId={toTokenId}
                 allowedTokenIds={toAssetIds}
                 priorityMode="buy"
-                accountCompatibleOnly={false}
+                tokenScope="all"
               />
             }
             tokenAmount={<ToAmountDisplay />}

--- a/apps/extension/src/ui/domains/Swap/components/SwapForm.tsx
+++ b/apps/extension/src/ui/domains/Swap/components/SwapForm.tsx
@@ -144,6 +144,7 @@ export const SwapForm = () => {
                 selectedTokenId={toTokenId}
                 allowedTokenIds={toAssetIds}
                 priorityMode="buy"
+                accountCompatibleOnly={false}
               />
             }
             tokenAmount={<ToAmountDisplay />}


### PR DESCRIPTION
Output token picker no longer filters out tokens on networks incompatible with the selected account. Also merges the token picker filter flags into a single `tokenScope` prop.

- Fixes https://github.com/TalismanSociety/talisman-qa/issues/133