### PR TITLE
✨ derive block explorer labels from a brand allowlist, support bittensor.ai routes

### DIFF
--- a/.changeset/block-explorer-label-allowlist.md
+++ b/.changeset/block-explorer-label-allowlist.md
@@ -1,0 +1,5 @@
+---
+"@talismn/chaindata-provider": patch
+---
+
+Derive block explorer labels from a brand allowlist and support bittensor.ai explorer routes

--- a/packages/chaindata-provider/src/getBlockExplorerUrls.test.ts
+++ b/packages/chaindata-provider/src/getBlockExplorerUrls.test.ts
@@ -36,12 +36,12 @@ const BITTENSOR = {
 
 const EXPLORER_WITH_BASE_PATH = {
   id: "bittensor",
-  blockExplorerUrls: ["https://bittensor.ai/chain"],
+  blockExplorerUrls: ["https://bittensor.ai/explorer"],
 } as unknown as Network
 
 const EXPLORER_WITH_BASE_PATH_TRAILING_SLASH = {
   id: "bittensor",
-  blockExplorerUrls: ["https://bittensor.ai/chain/"],
+  blockExplorerUrls: ["https://bittensor.ai/explorer/"],
 } as unknown as Network
 
 const EXPLORER_BITTENSOR_AI = {
@@ -51,7 +51,7 @@ const EXPLORER_BITTENSOR_AI = {
 
 const BITTENSOR_BOTH_EXPLORERS = {
   id: "bittensor",
-  blockExplorerUrls: ["https://taostats.io", "https://bittensor.ai/chain"],
+  blockExplorerUrls: ["https://taostats.io", "https://bittensor.ai/explorer"],
 } as unknown as Network
 
 describe("getExplorerUrls", () => {
@@ -175,7 +175,7 @@ describe("getExplorerUrls", () => {
     })
 
     expect(urls).toContain(
-      "https://bittensor.ai/chain/account/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+      "https://bittensor.ai/explorer/account/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
     )
   })
 
@@ -185,7 +185,7 @@ describe("getExplorerUrls", () => {
       id: 6036407,
     })
 
-    expect(urls).toContain("https://bittensor.ai/chain/block/6036407")
+    expect(urls).toContain("https://bittensor.ai/explorer/block/6036407")
   })
 
   it("explorer with base path - transaction", () => {
@@ -194,7 +194,7 @@ describe("getExplorerUrls", () => {
       id: "0xabc123",
     })
 
-    expect(urls).toContain("https://bittensor.ai/chain/tx/0xabc123")
+    expect(urls).toContain("https://bittensor.ai/explorer/extrinsic/0xabc123")
   })
 
   it("explorer with base path - extrinsic", () => {
@@ -204,7 +204,7 @@ describe("getExplorerUrls", () => {
       extrinsicIndex: 12,
     })
 
-    expect(urls).toContain("https://bittensor.ai/chain/extrinsic/6035238-12")
+    expect(urls).toContain("https://bittensor.ai/explorer/extrinsic/6035238-12")
   })
 
   it("explorer with base path and trailing slash - account", () => {
@@ -214,7 +214,7 @@ describe("getExplorerUrls", () => {
     })
 
     expect(urls).toContain(
-      "https://bittensor.ai/chain/account/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+      "https://bittensor.ai/explorer/account/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
     )
   })
 
@@ -224,7 +224,7 @@ describe("getExplorerUrls", () => {
       id: 6036407,
     })
 
-    expect(urls).toContain("https://bittensor.ai/chain/block/6036407")
+    expect(urls).toContain("https://bittensor.ai/explorer/block/6036407")
   })
 
   it("explorer with base path and trailing slash - extrinsic", () => {
@@ -234,7 +234,7 @@ describe("getExplorerUrls", () => {
       extrinsicIndex: 12,
     })
 
-    expect(urls).toContain("https://bittensor.ai/chain/extrinsic/6035238-12")
+    expect(urls).toContain("https://bittensor.ai/explorer/extrinsic/6035238-12")
   })
 
   it("explorer.bittensor.ai - account", () => {
@@ -273,7 +273,18 @@ describe("getExplorerUrls", () => {
       id: "0xabc123",
     })
 
-    expect(urls).toContain("https://explorer.bittensor.ai/tx/0xabc123")
+    expect(urls).toContain("https://explorer.bittensor.ai/extrinsic/0xabc123")
+  })
+
+  it("explorer.bittensor.ai - extrinsic unknown (hash)", () => {
+    const urls = getBlockExplorerUrls(EXPLORER_BITTENSOR_AI, {
+      type: "extrinsic-unknown",
+      hash: "0x10fc44f825ff94feec5d2fab00341e22556a3e55617089204715652eb5280d45",
+    })
+
+    expect(urls).toContain(
+      "https://explorer.bittensor.ai/extrinsic/0x10fc44f825ff94feec5d2fab00341e22556a3e55617089204715652eb5280d45"
+    )
   })
 
   it("explorer.bittensor.ai - address (contract)", () => {
@@ -294,7 +305,7 @@ describe("getExplorerUrls", () => {
     })
 
     expect(urls).toContain("https://taostats.io/block/6036407/extrinsics")
-    expect(urls).toContain("https://bittensor.ai/chain/block/6036407")
+    expect(urls).toContain("https://bittensor.ai/explorer/block/6036407")
     expect(urls.length).toBe(2)
   })
 
@@ -308,7 +319,7 @@ describe("getExplorerUrls", () => {
       "https://taostats.io/account/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
     )
     expect(urls).toContain(
-      "https://bittensor.ai/chain/account/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+      "https://bittensor.ai/explorer/account/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
     )
     expect(urls.length).toBe(2)
   })
@@ -321,26 +332,40 @@ describe("getExplorerUrls", () => {
     })
 
     expect(urls).toContain("https://taostats.io/extrinsic/6035238-0012")
-    expect(urls).toContain("https://bittensor.ai/chain/extrinsic/6035238-12")
+    expect(urls).toContain("https://bittensor.ai/explorer/extrinsic/6035238-12")
     expect(urls.length).toBe(2)
+  })
+
+  it("rejects non-http(s) explorer urls", () => {
+    const network = {
+      id: "evil",
+      blockExplorerUrls: ["javascript:alert(1)//", "ftp://explorer.example.org"],
+    } as unknown as Network
+
+    expect(getBlockExplorerUrls(network, { type: "block", id: 1 })).toEqual([])
   })
 })
 
 describe("getBlockExplorerLabel", () => {
-  it("returns Bittensor.ai for explorer.bittensor.ai explorer", () => {
+  it("returns the branded name for allowlisted explorers", () => {
+    expect(getBlockExplorerLabel("https://polkadot.subscan.io")).toBe("Subscan")
+    expect(getBlockExplorerLabel("https://polkadot.statescan.io/")).toBe("Statescan")
+    expect(getBlockExplorerLabel("https://etherscan.io")).toBe("Etherscan")
+    expect(getBlockExplorerLabel("https://optimistic.etherscan.io")).toBe("Etherscan")
+    expect(getBlockExplorerLabel("https://moonbeam.moonscan.io")).toBe("Moonscan")
+    expect(getBlockExplorerLabel("https://polygonscan.com")).toBe("PolygonScan")
+    expect(getBlockExplorerLabel("https://arbiscan.io/")).toBe("Arbiscan")
+    expect(getBlockExplorerLabel("https://basescan.org")).toBe("BaseScan")
+    expect(getBlockExplorerLabel("https://bscscan.com")).toBe("BscScan")
+    expect(getBlockExplorerLabel("https://bittensor.ai/explorer")).toBe("Bittensor.ai")
     expect(getBlockExplorerLabel("https://explorer.bittensor.ai")).toBe("Bittensor.ai")
   })
 
-  it("returns Bittensor.ai for bittensor.ai explorer", () => {
-    expect(getBlockExplorerLabel("https://bittensor.ai/chain")).toBe("Bittensor.ai")
-  })
-
-  it("returns Polkadot.js for polkadot.js.org explorer", () => {
-    expect(getBlockExplorerLabel("https://polkadot.js.org/apps")).toBe("Polkadot.js")
-  })
-
-  it("returns startCase hostname for standard explorers", () => {
-    expect(getBlockExplorerLabel("https://etherscan.io")).toBe("Etherscan")
-    expect(getBlockExplorerLabel("https://taostats.io")).toBe("Taostats")
+  it("returns Explorer for anything not in the allowlist", () => {
+    expect(getBlockExplorerLabel("https://taostats.io")).toBe("Explorer")
+    expect(getBlockExplorerLabel("https://polkadot.js.org/apps")).toBe("Explorer")
+    expect(getBlockExplorerLabel("https://eth.blockscout.com/")).toBe("Explorer")
+    expect(getBlockExplorerLabel("https://explorer.solana.com/?cluster=testnet")).toBe("Explorer")
+    expect(getBlockExplorerLabel("https://solscan.io")).toBe("Explorer")
   })
 })

--- a/packages/chaindata-provider/src/getBlockExplorerUrls.ts
+++ b/packages/chaindata-provider/src/getBlockExplorerUrls.ts
@@ -1,4 +1,4 @@
-import { startCase, uniq } from "lodash-es"
+import { uniq } from "lodash-es"
 
 import type { Network } from "./chaindata"
 
@@ -52,6 +52,8 @@ const getExplorerUrl = (
   }
 
   const url = new URL(explorerUrl)
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null
+
   const host = getExplorerHost(url)
   const path = getQueryPath(query, host)
 
@@ -67,7 +69,7 @@ const getExplorerUrl = (
       url.hash = path
       break
     default: {
-      // preserve any base path from the explorer URL (e.g., /chain in https://bittensor.ai/chain)
+      // preserve any base path from the explorer URL (e.g., /explorer in https://bittensor.ai/explorer)
       const basePath = url.pathname.replace(/\/$/, "")
       url.pathname = basePath + path
       break
@@ -112,6 +114,13 @@ const getQueryPath = (query: BlockExplorerQuery, host: ExplorerHost): string | n
         case "taostats.io":
           return `/transaction/${query.id}`
         case "subscan.io":
+          // subscan's /tx/ path only resolves EVM transactions; substrate
+          // extrinsic hashes need /extrinsic/ (no network uses subscan as its
+          // EVM explorer, all subscan explorers in chaindata are substrate)
+          return `/extrinsic/${query.id}`
+        case "bittensor.ai":
+          // bittensor.ai resolves extrinsics by hash (a substrate tx "hash"
+          // is the extrinsic hash); chaindata carries the /explorer base path
           return `/extrinsic/${query.id}`
         default:
           return `/tx/${query.id}`
@@ -171,6 +180,7 @@ const getQueryPath = (query: BlockExplorerQuery, host: ExplorerHost): string | n
     case "extrinsic-unknown": {
       switch (host) {
         case "subscan.io":
+        case "bittensor.ai":
           return `/extrinsic/${query.hash}`
         default:
           return null
@@ -181,18 +191,26 @@ const getQueryPath = (query: BlockExplorerQuery, host: ExplorerHost): string | n
   }
 }
 
-export const getBlockExplorerLabel = (blockExplorerUrl: string): string => {
-  const url = new URL(blockExplorerUrl)
-  const host = getExplorerHost(url)
+/**
+ * Allowlist of explorer host → branded name, used verbatim in "View on {name}"
+ * CTAs. Only explorers whose branding we've verified belong here; everything
+ * else falls back to the generic "Explorer". Keys are effective domains as
+ * returned by getExplorerHost. This map must never encode per-network
+ * overrides — the label depends on the explorer URL and nothing else.
+ */
+const EXPLORER_BRANDS: Record<string, string> = {
+  "subscan.io": "Subscan",
+  "statescan.io": "Statescan",
+  "etherscan.io": "Etherscan",
+  "moonscan.io": "Moonscan",
+  "polygonscan.com": "PolygonScan",
+  "arbiscan.io": "Arbiscan",
+  "basescan.org": "BaseScan",
+  "bscscan.com": "BscScan",
+  "bittensor.ai": "Bittensor.ai",
+}
 
-  switch (host) {
-    case "polkadot.js":
-      return "Polkadot.js"
-    case "bittensor.ai":
-      return "Bittensor.ai"
-    default: {
-      const parts = url.hostname.split(".")
-      return parts.length === 2 ? startCase(parts[0]) : host
-    }
-  }
+export const getBlockExplorerLabel = (blockExplorerUrl: string): string => {
+  const host = getExplorerHost(new URL(blockExplorerUrl))
+  return EXPLORER_BRANDS[host] ?? "Explorer"
 }


### PR DESCRIPTION
Port of the mobile app's block explorer handling so the two implementations are back in lockstep:

- `getBlockExplorerLabel` is now an explorer-host -> branded-name allowlist (Subscan, Statescan, Etherscan, Moonscan, PolygonScan, Arbiscan, BaseScan, BscScan, Bittensor.ai) falling back to "Explorer" for every other host, so the label depends on the explorer URL and nothing else.
- bittensor.ai paths corrected to the site's live routes (verified against the deployed site): everything lives under the `/explorer` base path, extrinsics resolve by hash and by blockNumber-index, accounts at `/account`. Transaction and extrinsic-unknown queries map to `/extrinsic/<hash>` instead of the stale `/tx/<hash>` from the old /chain layout.
- non-http(s) explorer URLs are rejected instead of linkified (previously a mobile-only hardening).

Pairs with https://github.com/TalismanSociety/chaindata/pull/229