### PR TITLE
✨ Root weights in validator picker

### DIFF
--- a/apps/extension/src/ui/components/Tooltip.tsx
+++ b/apps/extension/src/ui/components/Tooltip.tsx
@@ -34,6 +34,8 @@ interface TooltipOptions {
   open?: boolean
   onOpenChange?: (open: boolean) => void
   delay?: number
+  /** Keeps the tooltip open while the cursor travels to its content, so it can hold buttons or links */
+  interactive?: boolean
 }
 
 /** Needed because of https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189 */
@@ -49,6 +51,7 @@ function useTooltip({
   open: controlledOpen,
   onOpenChange: setControlledOpen,
   delay = 250,
+  interactive = false,
 }: TooltipOptions = {}): UseTooltipReturnType {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(initialOpen)
 
@@ -84,7 +87,7 @@ function useTooltip({
     enabled: controlledOpen == null,
     // safePolygon keeps the tooltip open while the cursor moves between the trigger and floating element,
     // preventing flicker when the tooltip overlaps the trigger (e.g. center placement)
-    handleClose: isCenter ? safePolygon() : undefined,
+    handleClose: isCenter || interactive ? safePolygon() : undefined,
     delay: {
       open: delay,
       // delay on close has side-effects, don't use it
@@ -113,7 +116,7 @@ type ContextType = ReturnType<typeof useTooltip> | null
 
 const TooltipContext = createContext<ContextType>(null)
 
-const useTooltipContext = (): NonNullable<ContextType> => {
+export const useTooltipContext = (): NonNullable<ContextType> => {
   const context = useContext(TooltipContext)
 
   if (context == null) {

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorValidatorSelect.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorValidatorSelect.tsx
@@ -2,6 +2,7 @@ import { BittensorValidatorPicker } from "@ui/domains/TaoDashboard/subnet/swap/B
 import { useCallback } from "react"
 import { useTranslation } from "react-i18next"
 
+import { STAKING_MODAL_CONTENT_CONTAINER_ID } from "../../../shared/ModalContent"
 import { BittensorStakingModalHeader } from "../../components/BittensorModalHeader"
 import { BittensorModalLayout } from "../../components/BittensorModalLayout"
 import { useBittensorBondModal } from "../../hooks/useBittensorBondModal"
@@ -37,6 +38,7 @@ export const BittensorValidatorSelect = () => {
         networkId={networkId}
         netuid={netuid}
         hotkey={hotkey}
+        containerId={STAKING_MODAL_CONTENT_CONTAINER_ID}
         onSelect={handleSubmit}
       />
     </BittensorModalLayout>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorValidatorSelect.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorBondModal/Forms/BittensorValidatorSelect.tsx
@@ -40,6 +40,7 @@ export const BittensorValidatorSelect = () => {
         hotkey={hotkey}
         containerId={STAKING_MODAL_CONTENT_CONTAINER_ID}
         onSelect={handleSubmit}
+        onClose={close}
       />
     </BittensorModalLayout>
   )

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeValidatorModal/Forms/ChangeValidatorSelect.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeValidatorModal/Forms/ChangeValidatorSelect.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "react-i18next"
 
 import type { BondOption as BondOptionType } from "../../../hooks/bittensor/types"
 import { useCombinedBittensorValidatorsData } from "../../../hooks/bittensor/useCombinedBittensorValidatorsData"
+import { STAKING_MODAL_CONTENT_CONTAINER_ID } from "../../../shared/ModalContent"
 import { BittensorStakingModalHeader } from "../../components/BittensorModalHeader"
 import { BittensorModalLayout } from "../../components/BittensorModalLayout"
 import {
@@ -161,6 +162,7 @@ export const ChangeValidatorSelect = () => {
                 selectedHotkey={newHotkey ?? currentHotkey}
                 isLoading={isLoading}
                 showRootWeights={netuid === ROOT_NETUID}
+                containerId={STAKING_MODAL_CONTENT_CONTAINER_ID}
                 onSelect={handleSubmit}
               />
             )}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeValidatorModal/Forms/ChangeValidatorSelect.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeValidatorModal/Forms/ChangeValidatorSelect.tsx
@@ -164,6 +164,7 @@ export const ChangeValidatorSelect = () => {
                 showRootWeights={netuid === ROOT_NETUID}
                 containerId={STAKING_MODAL_CONTENT_CONTAINER_ID}
                 onSelect={handleSubmit}
+                onClose={close}
               />
             )}
             {isError && (

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeValidatorModal/Forms/ChangeValidatorSelect.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeValidatorModal/Forms/ChangeValidatorSelect.tsx
@@ -25,6 +25,7 @@ import {
   ValidatorSortMethodButton,
 } from "../../components/ValidatorPicker"
 import { useBittensorChangeValidatorWizard } from "../../hooks/useBittensorChangeValidatorWizard"
+import { ROOT_NETUID } from "../../utils/constants"
 import { sortValidatorOptions, type ValidatorSortValue } from "../../utils/validatorSorting"
 
 export const ChangeValidatorSelect = () => {
@@ -159,6 +160,7 @@ export const ChangeValidatorSelect = () => {
                 validators={displayedValidators}
                 selectedHotkey={newHotkey ?? currentHotkey}
                 isLoading={isLoading}
+                showRootWeights={netuid === ROOT_NETUID}
                 onSelect={handleSubmit}
               />
             )}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -115,7 +115,7 @@ export const RootWeightsStat: FC<{
 
   if (!breakdown)
     return (
-      <Tooltip>
+      <Tooltip placement="left">
         <TooltipTrigger asChild>
           <div className="flex items-center gap-2">
             <PieChartIcon />
@@ -127,7 +127,7 @@ export const RootWeightsStat: FC<{
     )
 
   return (
-    <Tooltip>
+    <Tooltip placement="left">
       <TooltipTrigger asChild>
         <div className="flex items-center gap-2">
           <PieChartIcon />

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -5,7 +5,6 @@ import {
   type TokenId,
 } from "@talismn/chaindata-provider"
 import { PieChartIcon } from "@talismn/icons"
-import { Button } from "@ui/components/Button"
 import { Modal } from "@ui/components/Modal"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
 import { SearchInputControlled } from "@ui/components/SearchInputControlled"
@@ -27,14 +26,21 @@ const SLICE_COLORS = [
   "#8b8bf9",
   "#f55cb1",
   "#ffb056",
-  "#5cd8ff",
   "#7bdca4",
   "#ffe45c",
   "#e08bff",
+  "#5cd8ff",
 ]
 const OTHERS_COLOR = "#5a5a5a"
 
-type DonutSlice = { label: string; percent: number; color: string; tokenId?: TokenId }
+type DonutSlice = {
+  label: string
+  code: string
+  name?: string
+  percent: number
+  color: string
+  tokenId?: TokenId
+}
 
 const useSubnetTokensByNetuid = (networkId: DotNetworkId | undefined) => {
   const tokens = useTokens()
@@ -62,29 +68,39 @@ const useRootWeightsSlices = (networkId: DotNetworkId | undefined, hotkey: strin
     const raw = weights ? getRootWeightsBreakdown(weights) : null
     if (!raw) return null
 
-    const getLabel = (netuid: number) => {
-      if (netuid === ROOT_NETUID) return "TAO"
-      const name = subnetTokens.get(netuid)?.subnetName
-      return name ? `SN${netuid} ${name}` : `SN${netuid}`
-    }
+    const getCode = (netuid: number) => (netuid === ROOT_NETUID ? "TAO" : `SN${netuid}`)
+    const getName = (netuid: number) =>
+      netuid === ROOT_NETUID ? undefined : subnetTokens.get(netuid)?.subnetName
 
     const getTokenId = (netuid: number) => {
       if (netuid === ROOT_NETUID) return networkId ? subNativeTokenId(networkId) : undefined
       return subnetTokens.get(netuid)?.id
     }
 
-    const toDonutSlice = ({ netuid, ratio }: { netuid: number; ratio: number }, index: number) => ({
-      label: getLabel(netuid),
-      percent: ratio * 100,
-      color: SLICE_COLORS[index] ?? OTHERS_COLOR,
-      tokenId: getTokenId(netuid),
-    })
+    const toDonutSlice = (
+      { netuid, ratio }: { netuid: number; ratio: number },
+      index: number
+    ): DonutSlice => {
+      const code = getCode(netuid)
+      const name = getName(netuid)
+      return {
+        label: name ? `${code} ${name}` : code,
+        code,
+        name,
+        percent: ratio * 100,
+        color: SLICE_COLORS[index] ?? OTHERS_COLOR,
+        tokenId: getTokenId(netuid),
+      }
+    }
 
     const topSlices = raw.topSlices.map<DonutSlice>(toDonutSlice)
     const othersPercent = raw.othersRatio * 100
     const slices =
       othersPercent >= 0.05
-        ? [...topSlices, { label: t("Others"), percent: othersPercent, color: OTHERS_COLOR }]
+        ? [
+            ...topSlices,
+            { label: t("Others"), code: t("Others"), percent: othersPercent, color: OTHERS_COLOR },
+          ]
         : topSlices
 
     return {
@@ -132,22 +148,30 @@ const RootWeightsDonut: FC<{ subnetCount: number; slices: DonutSlice[] }> = ({
   )
 }
 
-const SliceRow: FC<{
-  slice: DonutSlice
-  decimals?: number
-  withLogo?: boolean
-  className?: string
-}> = ({ slice, decimals = 1, withLogo, className }) => (
-  <div className={cn("flex w-full items-center justify-between gap-4", className)}>
+const SliceLabel: FC<{ slice: DonutSlice }> = ({ slice }) => (
+  <div className="truncate">
+    <span className="text-body">{slice.code}</span>
+    {slice.name && <span className="text-body-secondary"> {slice.name}</span>}
+  </div>
+)
+
+const SliceRow: FC<{ slice: DonutSlice }> = ({ slice }) => (
+  <div className="flex w-full items-center justify-between gap-4">
     <div className="flex min-w-0 items-center gap-3">
-      {withLogo ? (
-        <TokenLogo tokenId={slice.tokenId} className="size-10 shrink-0" />
-      ) : (
-        <div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: slice.color }} />
-      )}
-      <div className="truncate text-body-secondary">{slice.label}</div>
+      <div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: slice.color }} />
+      <SliceLabel slice={slice} />
     </div>
-    <div className="shrink-0 text-body">{slice.percent.toFixed(decimals)}%</div>
+    <div className="shrink-0 text-body">{slice.percent.toFixed(1)}%</div>
+  </div>
+)
+
+const RootWeightRow: FC<{ slice: DonutSlice }> = ({ slice }) => (
+  <div className="flex w-full items-center justify-between gap-4 p-3 px-12 text-sm hover:bg-grey-800">
+    <div className="flex min-w-0 items-center gap-3">
+      <TokenLogo tokenId={slice.tokenId} className="size-10 shrink-0" />
+      <SliceLabel slice={slice} />
+    </div>
+    <div className="shrink-0 text-body">{slice.percent.toFixed(2)}%</div>
   </div>
 )
 
@@ -229,24 +253,19 @@ export const RootWeightsViewAllModal: FC<{
             autoFocus
           />
         </div>
-        <ScrollContainer className="grow" innerClassName="flex flex-col">
-          {filteredSlices.map((slice) => (
-            <SliceRow
-              key={slice.label}
-              slice={slice}
-              decimals={2}
-              withLogo
-              className="p-3 px-12 text-sm hover:bg-grey-800"
-            />
-          ))}
-          {!filteredSlices.length && (
-            <div className="py-8 text-center text-body-secondary">{t("No subnets found")}</div>
-          )}
-        </ScrollContainer>
-        <div className="shrink-0 px-12 pb-12">
-          <Button fullWidth onClick={onDismiss}>
-            {t("Close")}
-          </Button>
+        <div className="flex w-full grow flex-col gap-2 overflow-hidden">
+          <div className="flex justify-between px-12 text-body-disabled text-sm">
+            <div>{t("Subnet")}</div>
+            <div>{t("Share")}</div>
+          </div>
+          <ScrollContainer className="grow" innerClassName="flex flex-col bg-grey-900">
+            {filteredSlices.map((slice) => (
+              <RootWeightRow key={slice.label} slice={slice} />
+            ))}
+            {!filteredSlices.length && (
+              <div className="py-8 text-center text-body-secondary">{t("No subnets found")}</div>
+            )}
+          </ScrollContainer>
         </div>
       </WizardModalDialog>
     </Modal>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -1,0 +1,125 @@
+import type { DotNetworkId } from "@talismn/chaindata-provider"
+import { PieChartIcon } from "@talismn/icons"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
+import { type FC, useMemo } from "react"
+import { useTranslation } from "react-i18next"
+
+import { useBittensorRootWeights } from "../hooks/useBittensorRootWeights"
+import { ROOT_NETUID } from "../utils/constants"
+import { getRootWeightsBreakdown } from "../utils/rootWeights"
+
+const SLICE_COLORS = [
+  "#d5ff5c",
+  "#8b8bf9",
+  "#f55cb1",
+  "#ffb056",
+  "#5cd8ff",
+  "#7bdca4",
+  "#ffe45c",
+  "#e08bff",
+]
+const OTHERS_COLOR = "#5a5a5a"
+
+type DonutSlice = { label: string; percent: number; color: string }
+
+const RootWeightsDonut: FC<{ subnetCount: number; slices: DonutSlice[] }> = ({
+  subnetCount,
+  slices,
+}) => {
+  let startPercent = 0
+
+  return (
+    <div className="relative shrink-0">
+      {/* r chosen so the circumference is 100: dash lengths are percentages */}
+      <svg className="size-32" viewBox="0 0 36 36">
+        {slices.map((slice) => {
+          const dashOffset = 25 - startPercent
+          startPercent += slice.percent
+          return (
+            <circle
+              key={slice.label}
+              cx="18"
+              cy="18"
+              r="15.9155"
+              fill="none"
+              stroke={slice.color}
+              strokeWidth="3"
+              strokeDasharray={`${slice.percent} ${100 - slice.percent}`}
+              strokeDashoffset={dashOffset}
+            />
+          )
+        })}
+      </svg>
+      <div className="absolute inset-0 flex items-center justify-center text-body text-sm">
+        {subnetCount}
+      </div>
+    </div>
+  )
+}
+
+export const RootWeightsStat: FC<{
+  networkId: DotNetworkId | undefined
+  hotkey: string
+}> = ({ networkId, hotkey }) => {
+  const { t } = useTranslation()
+  const { data: weights, isLoading, isError } = useBittensorRootWeights(networkId, hotkey)
+
+  const breakdown = useMemo(() => {
+    const raw = weights ? getRootWeightsBreakdown(weights) : null
+    if (!raw) return null
+
+    const topSlices = raw.topSlices.map<DonutSlice>(({ netuid, ratio }, index) => ({
+      label: netuid === ROOT_NETUID ? "TAO" : `SN${netuid}`,
+      percent: ratio * 100,
+      color: SLICE_COLORS[index] ?? OTHERS_COLOR,
+    }))
+    const othersPercent = raw.othersRatio * 100
+    const slices =
+      othersPercent >= 0.05
+        ? [...topSlices, { label: t("Others"), percent: othersPercent, color: OTHERS_COLOR }]
+        : topSlices
+
+    return { subnetCount: raw.subnetCount, slices }
+  }, [weights, t])
+
+  if (isLoading) return <div className="h-6 w-14 animate-pulse rounded-xs bg-grey-800" />
+  if (isError) return null
+
+  if (!breakdown)
+    return (
+      <Tooltip placement="left">
+        <TooltipTrigger asChild>
+          <div className="flex items-center gap-2">
+            <PieChartIcon />
+            <span>–</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>{t("No allocation set — earnings follow subnet emissions")}</TooltipContent>
+      </Tooltip>
+    )
+
+  return (
+    <Tooltip placement="left">
+      <TooltipTrigger asChild>
+        <div className="flex items-center gap-2">
+          <PieChartIcon />
+          {breakdown.subnetCount}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="flex items-center gap-8 p-4">
+          <RootWeightsDonut subnetCount={breakdown.subnetCount} slices={breakdown.slices} />
+          <div className="flex min-w-64 flex-col gap-2">
+            {breakdown.slices.map((slice) => (
+              <div key={slice.label} className="flex items-center gap-4">
+                <div className="size-3 rounded-full" style={{ backgroundColor: slice.color }} />
+                <div className="text-body-secondary">{slice.label}</div>
+                <div className="ml-auto text-body">{slice.percent.toFixed(1)}%</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -1,8 +1,11 @@
 import type { DotNetworkId, SubDTaoToken } from "@talismn/chaindata-provider"
 import { PieChartIcon } from "@talismn/icons"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
+import { Button } from "@ui/components/Button"
+import { Modal } from "@ui/components/Modal"
+import { ScrollContainer } from "@ui/components/ScrollContainer"
+import { Tooltip, TooltipContent, TooltipTrigger, useTooltipContext } from "@ui/components/Tooltip"
 import { useTokens } from "@ui/state/chaindata"
-import { type FC, useMemo } from "react"
+import { type FC, type MouseEvent, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useBittensorRootWeights } from "../hooks/useBittensorRootWeights"
@@ -43,6 +46,44 @@ const useSubnetNamesByNetuid = (networkId: DotNetworkId | undefined) => {
   )
 }
 
+const useRootWeightsSlices = (networkId: DotNetworkId | undefined, hotkey: string) => {
+  const { t } = useTranslation()
+  const { data: weights, isLoading, isError } = useBittensorRootWeights(networkId, hotkey)
+  const subnetNames = useSubnetNamesByNetuid(networkId)
+
+  const breakdown = useMemo(() => {
+    const raw = weights ? getRootWeightsBreakdown(weights) : null
+    if (!raw) return null
+
+    const getLabel = (netuid: number) => {
+      if (netuid === ROOT_NETUID) return "TAO"
+      const name = subnetNames.get(netuid)
+      return name ? `SN${netuid} ${name}` : `SN${netuid}`
+    }
+
+    const toDonutSlice = ({ netuid, ratio }: { netuid: number; ratio: number }, index: number) => ({
+      label: getLabel(netuid),
+      percent: ratio * 100,
+      color: SLICE_COLORS[index] ?? OTHERS_COLOR,
+    })
+
+    const topSlices = raw.topSlices.map<DonutSlice>(toDonutSlice)
+    const othersPercent = raw.othersRatio * 100
+    const slices =
+      othersPercent >= 0.05
+        ? [...topSlices, { label: t("Others"), percent: othersPercent, color: OTHERS_COLOR }]
+        : topSlices
+
+    return {
+      subnetCount: raw.subnetCount,
+      slices,
+      allSlices: raw.allSlices.map<DonutSlice>(toDonutSlice),
+    }
+  }, [weights, subnetNames, t])
+
+  return { breakdown, isLoading, isError }
+}
+
 const RootWeightsDonut: FC<{ subnetCount: number; slices: DonutSlice[] }> = ({
   subnetCount,
   slices,
@@ -78,37 +119,83 @@ const RootWeightsDonut: FC<{ subnetCount: number; slices: DonutSlice[] }> = ({
   )
 }
 
+const SliceRow: FC<{ slice: DonutSlice }> = ({ slice }) => (
+  <div className="flex w-full items-center justify-between gap-4">
+    <div className="flex min-w-0 items-center gap-3">
+      <div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: slice.color }} />
+      <div className="truncate text-body-secondary">{slice.label}</div>
+    </div>
+    <div className="shrink-0 text-body">{slice.percent.toFixed(1)}%</div>
+  </div>
+)
+
+const ViewAllButton: FC<{ onClick: () => void }> = ({ onClick }) => {
+  const { t } = useTranslation()
+  const { setOpen } = useTooltipContext()
+
+  const handleClick = (e: MouseEvent) => {
+    // the stat lives inside the row button: don't let the click select the validator
+    e.stopPropagation()
+    setOpen(false)
+    onClick()
+  }
+
+  return (
+    <button
+      type="button"
+      className="text-grey-300 text-xs underline hover:text-body"
+      onClick={handleClick}
+    >
+      {t("View all")}
+    </button>
+  )
+}
+
+/**
+ * Rendered by the rows container, not by the stat: a virtualized row unmounts as soon as it leaves
+ * the viewport and would take an inlined modal down with it.
+ */
+export const RootWeightsViewAllModal: FC<{
+  networkId: DotNetworkId | undefined
+  hotkey: string
+  containerId?: string
+  isOpen: boolean
+  onDismiss: () => void
+}> = ({ networkId, hotkey, containerId, isOpen, onDismiss }) => {
+  const { t } = useTranslation()
+  const { breakdown } = useRootWeightsSlices(networkId, hotkey)
+
+  return (
+    <Modal containerId={containerId} isOpen={isOpen} onDismiss={onDismiss} className="size-full">
+      {breakdown && (
+        <div className="flex size-full flex-col bg-black">
+          <div className="flex flex-col items-center gap-4 p-12 pb-8">
+            <RootWeightsDonut subnetCount={breakdown.subnetCount} slices={breakdown.slices} />
+            <div className="font-bold text-body">{t("Root Weights")}</div>
+          </div>
+          <ScrollContainer className="grow" innerClassName="flex flex-col gap-4 px-12 pb-8">
+            {breakdown.allSlices.map((slice) => (
+              <SliceRow key={slice.label} slice={slice} />
+            ))}
+          </ScrollContainer>
+          <div className="p-12 pt-8">
+            <Button fullWidth onClick={onDismiss}>
+              {t("Close")}
+            </Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  )
+}
+
 export const RootWeightsStat: FC<{
   networkId: DotNetworkId | undefined
   hotkey: string
-}> = ({ networkId, hotkey }) => {
+  onViewAll?: () => void
+}> = ({ networkId, hotkey, onViewAll }) => {
   const { t } = useTranslation()
-  const { data: weights, isLoading, isError } = useBittensorRootWeights(networkId, hotkey)
-  const subnetNames = useSubnetNamesByNetuid(networkId)
-
-  const breakdown = useMemo(() => {
-    const raw = weights ? getRootWeightsBreakdown(weights) : null
-    if (!raw) return null
-
-    const getLabel = (netuid: number) => {
-      if (netuid === ROOT_NETUID) return "TAO"
-      const name = subnetNames.get(netuid)
-      return name ? `SN${netuid} ${name}` : `SN${netuid}`
-    }
-
-    const topSlices = raw.topSlices.map<DonutSlice>(({ netuid, ratio }, index) => ({
-      label: getLabel(netuid),
-      percent: ratio * 100,
-      color: SLICE_COLORS[index] ?? OTHERS_COLOR,
-    }))
-    const othersPercent = raw.othersRatio * 100
-    const slices =
-      othersPercent >= 0.05
-        ? [...topSlices, { label: t("Others"), percent: othersPercent, color: OTHERS_COLOR }]
-        : topSlices
-
-    return { subnetCount: raw.subnetCount, slices }
-  }, [weights, subnetNames, t])
+  const { breakdown, isLoading, isError } = useRootWeightsSlices(networkId, hotkey)
 
   if (isLoading) return <div className="h-6 w-14 animate-pulse rounded-xs bg-grey-800" />
   if (isError) return null
@@ -127,7 +214,7 @@ export const RootWeightsStat: FC<{
     )
 
   return (
-    <Tooltip placement="left">
+    <Tooltip placement="left" interactive>
       <TooltipTrigger asChild>
         <div className="flex items-center gap-2">
           <PieChartIcon />
@@ -139,18 +226,10 @@ export const RootWeightsStat: FC<{
           <RootWeightsDonut subnetCount={breakdown.subnetCount} slices={breakdown.slices} />
           <div className="flex w-full flex-col gap-2">
             {breakdown.slices.map((slice) => (
-              <div key={slice.label} className="flex w-full items-center justify-between gap-4">
-                <div className="flex min-w-0 items-center gap-3">
-                  <div
-                    className="size-3 shrink-0 rounded-full"
-                    style={{ backgroundColor: slice.color }}
-                  />
-                  <div className="truncate text-body-secondary">{slice.label}</div>
-                </div>
-                <div className="shrink-0 text-body">{slice.percent.toFixed(1)}%</div>
-              </div>
+              <SliceRow key={slice.label} slice={slice} />
             ))}
           </div>
+          {onViewAll && <ViewAllButton onClick={onViewAll} />}
         </div>
       </TooltipContent>
     </Tooltip>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -1,11 +1,21 @@
-import type { DotNetworkId, SubDTaoToken } from "@talismn/chaindata-provider"
+import {
+  type DotNetworkId,
+  type SubDTaoToken,
+  subNativeTokenId,
+  type TokenId,
+} from "@talismn/chaindata-provider"
 import { PieChartIcon } from "@talismn/icons"
 import { Button } from "@ui/components/Button"
 import { Modal } from "@ui/components/Modal"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
+import { SearchInputControlled } from "@ui/components/SearchInputControlled"
 import { Tooltip, TooltipContent, TooltipTrigger, useTooltipContext } from "@ui/components/Tooltip"
+import { AccountIcon } from "@ui/domains/Account/AccountIcon"
+import { TokenLogo } from "@ui/domains/Asset/TokenLogo"
+import { BittensorValidatorName } from "@ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorValidatorName"
 import { useTokens } from "@ui/state/chaindata"
-import { type FC, type MouseEvent, useMemo } from "react"
+import { cn } from "@ui/util/cn"
+import { type FC, type MouseEvent, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useBittensorRootWeights } from "../hooks/useBittensorRootWeights"
@@ -24,9 +34,9 @@ const SLICE_COLORS = [
 ]
 const OTHERS_COLOR = "#5a5a5a"
 
-type DonutSlice = { label: string; percent: number; color: string }
+type DonutSlice = { label: string; percent: number; color: string; tokenId?: TokenId }
 
-const useSubnetNamesByNetuid = (networkId: DotNetworkId | undefined) => {
+const useSubnetTokensByNetuid = (networkId: DotNetworkId | undefined) => {
   const tokens = useTokens()
 
   return useMemo(
@@ -35,12 +45,9 @@ const useSubnetNamesByNetuid = (networkId: DotNetworkId | undefined) => {
         tokens
           .filter(
             (token): token is SubDTaoToken =>
-              token.type === "substrate-dtao" &&
-              !token.hotkey &&
-              token.networkId === networkId &&
-              !!token.subnetName
+              token.type === "substrate-dtao" && !token.hotkey && token.networkId === networkId
           )
-          .map((token) => [token.netuid, token.subnetName as string])
+          .map((token) => [token.netuid, token])
       ),
     [tokens, networkId]
   )
@@ -49,7 +56,7 @@ const useSubnetNamesByNetuid = (networkId: DotNetworkId | undefined) => {
 const useRootWeightsSlices = (networkId: DotNetworkId | undefined, hotkey: string) => {
   const { t } = useTranslation()
   const { data: weights, isLoading, isError } = useBittensorRootWeights(networkId, hotkey)
-  const subnetNames = useSubnetNamesByNetuid(networkId)
+  const subnetTokens = useSubnetTokensByNetuid(networkId)
 
   const breakdown = useMemo(() => {
     const raw = weights ? getRootWeightsBreakdown(weights) : null
@@ -57,14 +64,20 @@ const useRootWeightsSlices = (networkId: DotNetworkId | undefined, hotkey: strin
 
     const getLabel = (netuid: number) => {
       if (netuid === ROOT_NETUID) return "TAO"
-      const name = subnetNames.get(netuid)
+      const name = subnetTokens.get(netuid)?.subnetName
       return name ? `SN${netuid} ${name}` : `SN${netuid}`
+    }
+
+    const getTokenId = (netuid: number) => {
+      if (netuid === ROOT_NETUID) return networkId ? subNativeTokenId(networkId) : undefined
+      return subnetTokens.get(netuid)?.id
     }
 
     const toDonutSlice = ({ netuid, ratio }: { netuid: number; ratio: number }, index: number) => ({
       label: getLabel(netuid),
       percent: ratio * 100,
       color: SLICE_COLORS[index] ?? OTHERS_COLOR,
+      tokenId: getTokenId(netuid),
     })
 
     const topSlices = raw.topSlices.map<DonutSlice>(toDonutSlice)
@@ -79,7 +92,7 @@ const useRootWeightsSlices = (networkId: DotNetworkId | undefined, hotkey: strin
       slices,
       allSlices: raw.allSlices.map<DonutSlice>(toDonutSlice),
     }
-  }, [weights, subnetNames, t])
+  }, [weights, subnetTokens, networkId, t])
 
   return { breakdown, isLoading, isError }
 }
@@ -119,13 +132,21 @@ const RootWeightsDonut: FC<{ subnetCount: number; slices: DonutSlice[] }> = ({
   )
 }
 
-const SliceRow: FC<{ slice: DonutSlice }> = ({ slice }) => (
+const SliceRow: FC<{ slice: DonutSlice; decimals?: number; withLogo?: boolean }> = ({
+  slice,
+  decimals = 1,
+  withLogo,
+}) => (
   <div className="flex w-full items-center justify-between gap-4">
     <div className="flex min-w-0 items-center gap-3">
-      <div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: slice.color }} />
+      {withLogo ? (
+        <TokenLogo tokenId={slice.tokenId} className="size-10 shrink-0" />
+      ) : (
+        <div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: slice.color }} />
+      )}
       <div className="truncate text-body-secondary">{slice.label}</div>
     </div>
-    <div className="shrink-0 text-body">{slice.percent.toFixed(1)}%</div>
+    <div className="shrink-0 text-body">{slice.percent.toFixed(decimals)}%</div>
   </div>
 )
 
@@ -165,18 +186,50 @@ export const RootWeightsViewAllModal: FC<{
   const { t } = useTranslation()
   const { breakdown } = useRootWeightsSlices(networkId, hotkey)
 
+  const [search, setSearch] = useState("")
+
+  useEffect(() => {
+    if (isOpen) setSearch("")
+  }, [isOpen])
+
+  const filteredSlices = useMemo(() => {
+    if (!breakdown) return []
+    const lowerSearch = search.toLowerCase()
+    return breakdown.allSlices.filter((slice) => slice.label.toLowerCase().includes(lowerSearch))
+  }, [breakdown, search])
+
   return (
     <Modal containerId={containerId} isOpen={isOpen} onDismiss={onDismiss} className="size-full">
       {breakdown && (
         <div className="flex size-full flex-col bg-black">
-          <div className="flex flex-col items-center gap-4 p-12 pb-8">
-            <RootWeightsDonut subnetCount={breakdown.subnetCount} slices={breakdown.slices} />
-            <div className="font-bold text-body">{t("Root Weights")}</div>
+          <div className="flex flex-col gap-8 p-12 pb-8">
+            <div className="flex items-center justify-center gap-4 overflow-hidden">
+              <AccountIcon address={hotkey} className="size-12 shrink-0 text-lg" />
+              <BittensorValidatorName
+                hotkey={hotkey}
+                noTooltip
+                className="truncate font-bold text-body"
+              />
+            </div>
+            <SearchInputControlled
+              containerClassName={cn(
+                "h-[2.25rem] shrink-0 grow rounded-sm border border-field bg-field! px-4! text-sm ring-transparent focus-within:border-grey-700",
+                "[&>button>svg]:size-10 [&>input]:text-sm [&>svg]:size-8"
+              )}
+              placeholder={t("Search subnets")}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onClear={() => setSearch("")}
+              autoFocus
+            />
           </div>
           <ScrollContainer className="grow" innerClassName="flex flex-col gap-4 px-12 pb-8">
-            {breakdown.allSlices.map((slice) => (
-              <SliceRow key={slice.label} slice={slice} />
+            {filteredSlices.map((slice) => (
+              <SliceRow key={slice.label} slice={slice} decimals={2} withLogo />
             ))}
+            {!filteredSlices.length && (
+              <div className="py-8 text-center text-body-secondary">{t("No subnets found")}</div>
+            )}
           </ScrollContainer>
           <div className="p-12 pt-8">
             <Button fullWidth onClick={onDismiss}>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -262,7 +262,19 @@ export const RootWeightsStat: FC<{
   const { breakdown, isLoading, isError } = useRootWeightsSlices(networkId, hotkey)
 
   if (isLoading) return <div className="h-6 w-14 animate-pulse rounded-xs bg-grey-800" />
-  if (isError) return null
+
+  if (isError)
+    return (
+      <Tooltip placement="left">
+        <TooltipTrigger asChild>
+          <div className="flex items-center gap-2">
+            <PieChartIcon />
+            <span>{t("N/A")}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>{t("Failed to load allocations")}</TooltipContent>
+      </Tooltip>
+    )
 
   if (!breakdown)
     return (

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -207,7 +207,8 @@ export const RootWeightsViewAllModal: FC<{
   containerId?: string
   isOpen: boolean
   onDismiss: () => void
-}> = ({ networkId, hotkey, containerId, isOpen, onDismiss }) => {
+  onClose: () => void
+}> = ({ networkId, hotkey, containerId, isOpen, onDismiss, onClose }) => {
   const { t } = useTranslation()
   const { breakdown } = useRootWeightsSlices(networkId, hotkey)
 
@@ -227,6 +228,7 @@ export const RootWeightsViewAllModal: FC<{
     <Modal containerId={containerId} isOpen={isOpen} onDismiss={onDismiss} className="size-full">
       <WizardModalDialog
         onBackClick={onDismiss}
+        onCloseClick={onClose}
         className="border-none"
         contentClassName="overflow-hidden! p-0! flex flex-col gap-4"
         title={

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -1,6 +1,7 @@
-import type { DotNetworkId } from "@talismn/chaindata-provider"
+import type { DotNetworkId, SubDTaoToken } from "@talismn/chaindata-provider"
 import { PieChartIcon } from "@talismn/icons"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
+import { useTokens } from "@ui/state/chaindata"
 import { type FC, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -22,6 +23,26 @@ const OTHERS_COLOR = "#5a5a5a"
 
 type DonutSlice = { label: string; percent: number; color: string }
 
+const useSubnetNamesByNetuid = (networkId: DotNetworkId | undefined) => {
+  const tokens = useTokens()
+
+  return useMemo(
+    () =>
+      new Map(
+        tokens
+          .filter(
+            (token): token is SubDTaoToken =>
+              token.type === "substrate-dtao" &&
+              !token.hotkey &&
+              token.networkId === networkId &&
+              !!token.subnetName
+          )
+          .map((token) => [token.netuid, token.subnetName as string])
+      ),
+    [tokens, networkId]
+  )
+}
+
 const RootWeightsDonut: FC<{ subnetCount: number; slices: DonutSlice[] }> = ({
   subnetCount,
   slices,
@@ -31,7 +52,7 @@ const RootWeightsDonut: FC<{ subnetCount: number; slices: DonutSlice[] }> = ({
   return (
     <div className="relative shrink-0">
       {/* r chosen so the circumference is 100: dash lengths are percentages */}
-      <svg className="size-32" viewBox="0 0 36 36">
+      <svg className="size-[64px]" viewBox="0 0 36 36">
         {slices.map((slice) => {
           const dashOffset = 25 - startPercent
           startPercent += slice.percent
@@ -63,13 +84,20 @@ export const RootWeightsStat: FC<{
 }> = ({ networkId, hotkey }) => {
   const { t } = useTranslation()
   const { data: weights, isLoading, isError } = useBittensorRootWeights(networkId, hotkey)
+  const subnetNames = useSubnetNamesByNetuid(networkId)
 
   const breakdown = useMemo(() => {
     const raw = weights ? getRootWeightsBreakdown(weights) : null
     if (!raw) return null
 
+    const getLabel = (netuid: number) => {
+      if (netuid === ROOT_NETUID) return "TAO"
+      const name = subnetNames.get(netuid)
+      return name ? `SN${netuid} ${name}` : `SN${netuid}`
+    }
+
     const topSlices = raw.topSlices.map<DonutSlice>(({ netuid, ratio }, index) => ({
-      label: netuid === ROOT_NETUID ? "TAO" : `SN${netuid}`,
+      label: getLabel(netuid),
       percent: ratio * 100,
       color: SLICE_COLORS[index] ?? OTHERS_COLOR,
     }))
@@ -80,14 +108,14 @@ export const RootWeightsStat: FC<{
         : topSlices
 
     return { subnetCount: raw.subnetCount, slices }
-  }, [weights, t])
+  }, [weights, subnetNames, t])
 
   if (isLoading) return <div className="h-6 w-14 animate-pulse rounded-xs bg-grey-800" />
   if (isError) return null
 
   if (!breakdown)
     return (
-      <Tooltip placement="left">
+      <Tooltip>
         <TooltipTrigger asChild>
           <div className="flex items-center gap-2">
             <PieChartIcon />
@@ -99,7 +127,7 @@ export const RootWeightsStat: FC<{
     )
 
   return (
-    <Tooltip placement="left">
+    <Tooltip>
       <TooltipTrigger asChild>
         <div className="flex items-center gap-2">
           <PieChartIcon />
@@ -107,14 +135,19 @@ export const RootWeightsStat: FC<{
         </div>
       </TooltipTrigger>
       <TooltipContent>
-        <div className="flex items-center gap-8 p-4">
+        <div className="flex w-[200px] max-w-[200px] flex-col items-center gap-4 p-4">
           <RootWeightsDonut subnetCount={breakdown.subnetCount} slices={breakdown.slices} />
-          <div className="flex min-w-64 flex-col gap-2">
+          <div className="flex w-full flex-col gap-2">
             {breakdown.slices.map((slice) => (
-              <div key={slice.label} className="flex items-center gap-4">
-                <div className="size-3 rounded-full" style={{ backgroundColor: slice.color }} />
-                <div className="text-body-secondary">{slice.label}</div>
-                <div className="ml-auto text-body">{slice.percent.toFixed(1)}%</div>
+              <div key={slice.label} className="flex w-full items-center justify-between gap-4">
+                <div className="flex min-w-0 items-center gap-3">
+                  <div
+                    className="size-3 shrink-0 rounded-full"
+                    style={{ backgroundColor: slice.color }}
+                  />
+                  <div className="truncate text-body-secondary">{slice.label}</div>
+                </div>
+                <div className="shrink-0 text-body">{slice.percent.toFixed(1)}%</div>
               </div>
             ))}
           </div>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -4,7 +4,7 @@ import {
   subNativeTokenId,
   type TokenId,
 } from "@talismn/chaindata-provider"
-import { PieChartIcon } from "@talismn/icons"
+import { ChevronRightIcon, PieChartIcon } from "@talismn/icons"
 import { Modal } from "@ui/components/Modal"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
 import { SearchInputControlled } from "@ui/components/SearchInputControlled"
@@ -33,7 +33,7 @@ const SLICE_COLORS = [
 ]
 const OTHERS_COLOR = "#5a5a5a"
 
-type DonutSlice = {
+type WeightSlice = {
   label: string
   code: string
   name?: string
@@ -77,10 +77,10 @@ const useRootWeightsSlices = (networkId: DotNetworkId | undefined, hotkey: strin
       return subnetTokens.get(netuid)?.id
     }
 
-    const toDonutSlice = (
+    const toWeightSlice = (
       { netuid, ratio }: { netuid: number; ratio: number },
       index: number
-    ): DonutSlice => {
+    ): WeightSlice => {
       const code = getCode(netuid)
       const name = getName(netuid)
       return {
@@ -93,7 +93,7 @@ const useRootWeightsSlices = (networkId: DotNetworkId | undefined, hotkey: strin
       }
     }
 
-    const topSlices = raw.topSlices.map<DonutSlice>(toDonutSlice)
+    const topSlices = raw.topSlices.map<WeightSlice>(toWeightSlice)
     const othersPercent = raw.othersRatio * 100
     const slices =
       othersPercent >= 0.05
@@ -106,70 +106,63 @@ const useRootWeightsSlices = (networkId: DotNetworkId | undefined, hotkey: strin
     return {
       subnetCount: raw.subnetCount,
       slices,
-      allSlices: raw.allSlices.map<DonutSlice>(toDonutSlice),
+      allSlices: raw.allSlices.map<WeightSlice>(toWeightSlice),
     }
   }, [weights, subnetTokens, networkId, t])
 
   return { breakdown, isLoading, isError }
 }
 
-const RootWeightsDonut: FC<{ subnetCount: number; slices: DonutSlice[] }> = ({
-  subnetCount,
-  slices,
-}) => {
-  let startPercent = 0
+const RootWeightsBar: FC<{ slices: WeightSlice[] }> = ({ slices }) => (
+  <div className="flex h-3 w-full shrink-0 overflow-hidden rounded-full">
+    {slices.map((slice) => (
+      <div
+        key={slice.label}
+        className="h-full rounded-full"
+        style={{ width: `${slice.percent}%`, backgroundColor: slice.color }}
+      />
+    ))}
+  </div>
+)
+
+const RootWeightsSummary: FC<{
+  subnetCount: number
+  slices: WeightSlice[]
+  className?: string
+}> = ({ subnetCount, slices, className }) => {
+  const { t } = useTranslation()
 
   return (
-    <div className="relative shrink-0">
-      {/* r chosen so the circumference is 100: dash lengths are percentages */}
-      <svg className="size-[64px]" viewBox="0 0 36 36">
-        {slices.map((slice) => {
-          const dashOffset = 25 - startPercent
-          startPercent += slice.percent
-          return (
-            <circle
-              key={slice.label}
-              cx="18"
-              cy="18"
-              r="15.9155"
-              fill="none"
-              stroke={slice.color}
-              strokeWidth="3"
-              strokeDasharray={`${slice.percent} ${100 - slice.percent}`}
-              strokeDashoffset={dashOffset}
-            />
-          )
-        })}
-      </svg>
-      <div className="absolute inset-0 flex items-center justify-center text-body text-sm">
-        {subnetCount}
-      </div>
+    <div className={cn("flex w-full flex-col gap-4", className)}>
+      <div>{t("{{count}} subnet weights", { count: subnetCount })}</div>
+      <RootWeightsBar slices={slices} />
     </div>
   )
 }
 
-const SliceLabel: FC<{ slice: DonutSlice }> = ({ slice }) => (
+const SliceLabel: FC<{ slice: WeightSlice }> = ({ slice }) => (
   <div className="truncate">
     <span className="text-body">{slice.code}</span>
     {slice.name && <span className="text-body-secondary"> {slice.name}</span>}
   </div>
 )
 
-const SliceRow: FC<{ slice: DonutSlice }> = ({ slice }) => (
+const SliceRow: FC<{ slice: WeightSlice }> = ({ slice }) => (
   <div className="flex w-full items-center justify-between gap-4">
     <div className="flex min-w-0 items-center gap-3">
-      <div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: slice.color }} />
+      <div className="size-4 shrink-0 rounded-full" style={{ backgroundColor: slice.color }} />
       <SliceLabel slice={slice} />
     </div>
-    <div className="shrink-0 text-body">{slice.percent.toFixed(1)}%</div>
+    <div className="shrink-0 text-body-secondary">{slice.percent.toFixed(1)}%</div>
   </div>
 )
 
-const RootWeightRow: FC<{ slice: DonutSlice }> = ({ slice }) => (
+const RootWeightRow: FC<{ slice: WeightSlice }> = ({ slice }) => (
   <div className="flex w-full items-center justify-between gap-4 p-3 px-12 text-sm hover:bg-grey-800">
     <div className="flex min-w-0 items-center gap-3">
       <TokenLogo tokenId={slice.tokenId} className="size-10 shrink-0" />
       <SliceLabel slice={slice} />
+      <div className="size-4 shrink-0 rounded-full" style={{ backgroundColor: slice.color }}></div>
     </div>
     <div className="shrink-0 text-body">{slice.percent.toFixed(2)}%</div>
   </div>
@@ -187,12 +180,9 @@ const ViewAllButton: FC<{ onClick: () => void }> = ({ onClick }) => {
   }
 
   return (
-    <button
-      type="button"
-      className="text-grey-300 text-xs underline hover:text-body"
-      onClick={handleClick}
-    >
-      {t("View all")}
+    <button type="button" className="text-body text-xs" onClick={handleClick}>
+      <span className="underline">{t("View all")}</span>{" "}
+      <ChevronRightIcon className="inline-block text-sm text-white" />
     </button>
   )
 }
@@ -254,7 +244,15 @@ export const RootWeightsViewAllModal: FC<{
             onClear={() => setSearch("")}
             autoFocus
           />
+          {breakdown && (
+            <RootWeightsSummary
+              subnetCount={breakdown.subnetCount}
+              slices={breakdown.slices}
+              className="text-body-secondary text-sm"
+            />
+          )}
         </div>
+        <div className="h-2 shrink-0"></div>
         <div className="flex w-full grow flex-col gap-2 overflow-hidden">
           <div className="flex justify-between px-12 text-body-disabled text-sm">
             <div>{t("Subnet")}</div>
@@ -319,14 +317,18 @@ export const RootWeightsStat: FC<{
         </div>
       </TooltipTrigger>
       <TooltipContent>
-        <div className="flex w-[200px] max-w-[200px] flex-col items-center gap-4 p-4">
-          <RootWeightsDonut subnetCount={breakdown.subnetCount} slices={breakdown.slices} />
+        <div className="flex w-[200px] max-w-[200px] flex-col gap-6 p-4">
+          <RootWeightsSummary subnetCount={breakdown.subnetCount} slices={breakdown.slices} />
           <div className="flex w-full flex-col gap-2">
             {breakdown.slices.map((slice) => (
               <SliceRow key={slice.label} slice={slice} />
             ))}
           </div>
-          {onViewAll && <ViewAllButton onClick={onViewAll} />}
+          {onViewAll && (
+            <div className="w-full text-right">
+              <ViewAllButton onClick={onViewAll} />
+            </div>
+          )}
         </div>
       </TooltipContent>
     </Tooltip>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/RootWeightsStat.tsx
@@ -10,6 +10,7 @@ import { Modal } from "@ui/components/Modal"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
 import { SearchInputControlled } from "@ui/components/SearchInputControlled"
 import { Tooltip, TooltipContent, TooltipTrigger, useTooltipContext } from "@ui/components/Tooltip"
+import { WizardModalDialog } from "@ui/components/WizardModalDialog"
 import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { TokenLogo } from "@ui/domains/Asset/TokenLogo"
 import { BittensorValidatorName } from "@ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorValidatorName"
@@ -17,7 +18,6 @@ import { useTokens } from "@ui/state/chaindata"
 import { cn } from "@ui/util/cn"
 import { type FC, type MouseEvent, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-
 import { useBittensorRootWeights } from "../hooks/useBittensorRootWeights"
 import { ROOT_NETUID } from "../utils/constants"
 import { getRootWeightsBreakdown } from "../utils/rootWeights"
@@ -132,12 +132,13 @@ const RootWeightsDonut: FC<{ subnetCount: number; slices: DonutSlice[] }> = ({
   )
 }
 
-const SliceRow: FC<{ slice: DonutSlice; decimals?: number; withLogo?: boolean }> = ({
-  slice,
-  decimals = 1,
-  withLogo,
-}) => (
-  <div className="flex w-full items-center justify-between gap-4">
+const SliceRow: FC<{
+  slice: DonutSlice
+  decimals?: number
+  withLogo?: boolean
+  className?: string
+}> = ({ slice, decimals = 1, withLogo, className }) => (
+  <div className={cn("flex w-full items-center justify-between gap-4", className)}>
     <div className="flex min-w-0 items-center gap-3">
       {withLogo ? (
         <TokenLogo tokenId={slice.tokenId} className="size-10 shrink-0" />
@@ -200,44 +201,54 @@ export const RootWeightsViewAllModal: FC<{
 
   return (
     <Modal containerId={containerId} isOpen={isOpen} onDismiss={onDismiss} className="size-full">
-      {breakdown && (
-        <div className="flex size-full flex-col bg-black">
-          <div className="flex flex-col gap-8 p-12 pb-8">
-            <div className="flex items-center justify-center gap-4 overflow-hidden">
-              <AccountIcon address={hotkey} className="size-12 shrink-0 text-lg" />
-              <BittensorValidatorName
-                hotkey={hotkey}
-                noTooltip
-                className="truncate font-bold text-body"
-              />
-            </div>
-            <SearchInputControlled
-              containerClassName={cn(
-                "h-[2.25rem] shrink-0 grow rounded-sm border border-field bg-field! px-4! text-sm ring-transparent focus-within:border-grey-700",
-                "[&>button>svg]:size-10 [&>input]:text-sm [&>svg]:size-8"
-              )}
-              placeholder={t("Search subnets")}
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              onClear={() => setSearch("")}
-              autoFocus
+      <WizardModalDialog
+        onBackClick={onDismiss}
+        className="border-none"
+        contentClassName="overflow-hidden! p-0! flex flex-col gap-4"
+        title={
+          <div className="flex h-full items-center justify-center gap-4 overflow-hidden">
+            <AccountIcon address={hotkey} className="size-12 shrink-0 text-lg" />
+            <BittensorValidatorName
+              hotkey={hotkey}
+              noTooltip
+              className="truncate font-bold text-body"
             />
           </div>
-          <ScrollContainer className="grow" innerClassName="flex flex-col gap-4 px-12 pb-8">
-            {filteredSlices.map((slice) => (
-              <SliceRow key={slice.label} slice={slice} decimals={2} withLogo />
-            ))}
-            {!filteredSlices.length && (
-              <div className="py-8 text-center text-body-secondary">{t("No subnets found")}</div>
+        }
+      >
+        <div className="flex flex-col gap-8 px-12">
+          <SearchInputControlled
+            containerClassName={cn(
+              "h-[2.25rem] shrink-0 grow rounded-sm border border-field bg-field! px-4! text-sm ring-transparent focus-within:border-grey-700",
+              "[&>button>svg]:size-10 [&>input]:text-sm [&>svg]:size-8"
             )}
-          </ScrollContainer>
-          <div className="p-12 pt-8">
-            <Button fullWidth onClick={onDismiss}>
-              {t("Close")}
-            </Button>
-          </div>
+            placeholder={t("Search subnets")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onClear={() => setSearch("")}
+            autoFocus
+          />
         </div>
-      )}
+        <ScrollContainer className="grow" innerClassName="flex flex-col">
+          {filteredSlices.map((slice) => (
+            <SliceRow
+              key={slice.label}
+              slice={slice}
+              decimals={2}
+              withLogo
+              className="p-3 px-12 text-sm hover:bg-grey-800"
+            />
+          ))}
+          {!filteredSlices.length && (
+            <div className="py-8 text-center text-body-secondary">{t("No subnets found")}</div>
+          )}
+        </ScrollContainer>
+        <div className="shrink-0 px-12 pb-12">
+          <Button fullWidth onClick={onDismiss}>
+            {t("Close")}
+          </Button>
+        </div>
+      </WizardModalDialog>
     </Modal>
   )
 }

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/ValidatorPicker.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/ValidatorPicker.tsx
@@ -16,12 +16,12 @@ import { Tokens } from "@ui/domains/Asset/Tokens"
 import { EarnTypeBadge } from "@ui/domains/Earn/components/EarnTypeBadge"
 import { useToken } from "@ui/state/chaindata"
 import { cn } from "@ui/util/cn"
-import { type FC, useMemo } from "react"
+import { type FC, useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import type { BondOption as BondOptionType } from "../../hooks/bittensor/types"
 import type { ValidatorSortValue } from "../utils/validatorSorting"
-import { RootWeightsStat } from "./RootWeightsStat"
+import { RootWeightsStat, RootWeightsViewAllModal } from "./RootWeightsStat"
 
 export const ValidatorSortMethodButton: FC<{
   method: ValidatorSortValue
@@ -77,9 +77,23 @@ export const ValidatorRows: FC<{
   selectedHotkey?: string | null
   isLoading?: boolean
   showRootWeights?: boolean
+  containerId?: string
   onSelect: (hotkey: string) => void
-}> = ({ taoTokenId, validators, selectedHotkey, isLoading, showRootWeights, onSelect }) => {
+}> = ({
+  taoTokenId,
+  validators,
+  selectedHotkey,
+  isLoading,
+  showRootWeights,
+  containerId,
+  onSelect,
+}) => {
   const { ref: refContainer } = useScrollContainer()
+  const tao = useToken(taoTokenId)
+
+  const [viewAllHotkey, setViewAllHotkey] = useState<string | null>(null)
+  const [isViewAllOpen, setIsViewAllOpen] = useState(false)
+  const closeViewAll = useCallback(() => setIsViewAllOpen(false), [])
 
   const virtualizer = useVirtualizer({
     count: validators.length,
@@ -120,11 +134,25 @@ export const ValidatorRows: FC<{
                 onClick={() => onSelect(validator.hotkey)}
                 isLoading={isLoading}
                 showRootWeights={showRootWeights}
+                onViewAllWeights={(hotkey) => {
+                  setViewAllHotkey(hotkey)
+                  setIsViewAllOpen(true)
+                }}
               />
             </div>
           )
         })}
       </div>
+      {/* hosted here, outside the virtualized rows, so a row unmount can't close it */}
+      {viewAllHotkey && (
+        <RootWeightsViewAllModal
+          networkId={tao?.networkId as DotNetworkId | undefined}
+          hotkey={viewAllHotkey}
+          containerId={containerId}
+          isOpen={isViewAllOpen}
+          onDismiss={closeViewAll}
+        />
+      )}
     </div>
   )
 }
@@ -161,8 +189,17 @@ const ValidatorRow: FC<{
   isSelected?: boolean
   isLoading?: boolean
   showRootWeights?: boolean
+  onViewAllWeights: (hotkey: string) => void
   onClick: () => void
-}> = ({ option, isSelected, isLoading, taoTokenId, showRootWeights, onClick }) => {
+}> = ({
+  option,
+  isSelected,
+  isLoading,
+  taoTokenId,
+  showRootWeights,
+  onViewAllWeights,
+  onClick,
+}) => {
   const { t } = useTranslation()
   const tao = useToken(taoTokenId)
 
@@ -268,6 +305,7 @@ const ValidatorRow: FC<{
             <RootWeightsStat
               networkId={tao?.networkId as DotNetworkId | undefined}
               hotkey={option.hotkey}
+              onViewAll={() => onViewAllWeights(option.hotkey)}
             />
           )}
         </div>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/ValidatorPicker.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/ValidatorPicker.tsx
@@ -1,4 +1,4 @@
-import type { TokenId } from "@talismn/chaindata-provider"
+import type { DotNetworkId, TokenId } from "@talismn/chaindata-provider"
 import { GlobeIcon, LockIcon, TalismanHandIcon, ToolbarSortIcon, UserIcon } from "@talismn/icons"
 import { planckToTokens } from "@talismn/util"
 import { useVirtualizer } from "@tanstack/react-virtual"
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next"
 
 import type { BondOption as BondOptionType } from "../../hooks/bittensor/types"
 import type { ValidatorSortValue } from "../utils/validatorSorting"
+import { RootWeightsStat } from "./RootWeightsStat"
 
 export const ValidatorSortMethodButton: FC<{
   method: ValidatorSortValue
@@ -50,7 +51,7 @@ export const ValidatorSortMethodButton: FC<{
       <ContextMenuTrigger asChild>
         <button
           type="button"
-          className="flex h-full items-center gap-4 text-nowrap rounded-sm border border-grey-850 bg-field px-[8px] py-[6px] text-body-secondary text-sm hover:bg-grey-800 hover:text-grey-300"
+          className="flex h-full items-center gap-4 text-nowrap rounded-sm border border-grey-850 bg-field px-4 py-3 text-body-secondary text-sm hover:bg-grey-800 hover:text-grey-300"
         >
           <div>{selected?.label}</div>
           <ToolbarSortIcon className="size-10" />
@@ -75,8 +76,9 @@ export const ValidatorRows: FC<{
   validators: BondOptionType[]
   selectedHotkey?: string | null
   isLoading?: boolean
+  showRootWeights?: boolean
   onSelect: (hotkey: string) => void
-}> = ({ taoTokenId, validators, selectedHotkey, isLoading, onSelect }) => {
+}> = ({ taoTokenId, validators, selectedHotkey, isLoading, showRootWeights, onSelect }) => {
   const { ref: refContainer } = useScrollContainer()
 
   const virtualizer = useVirtualizer({
@@ -117,6 +119,7 @@ export const ValidatorRows: FC<{
                 isSelected={validator.hotkey === selectedHotkey}
                 onClick={() => onSelect(validator.hotkey)}
                 isLoading={isLoading}
+                showRootWeights={showRootWeights}
               />
             </div>
           )
@@ -130,7 +133,7 @@ export const ValidatorRowSkeleton = () => {
   return (
     <div className="flex h-14.5 w-full shrink-0 items-center gap-6 px-12 pl-8 text-left">
       <div className="size-16 animate-pulse rounded-full bg-grey-750"></div>
-      <div className="grow space-y-[5px]">
+      <div className="grow space-y-2.5">
         <div className={"flex w-full justify-between font-bold text-body text-sm"}>
           <div>
             <div className="inline-block h-7 w-56 animate-pulse rounded-xs bg-grey-750"></div>
@@ -157,8 +160,9 @@ const ValidatorRow: FC<{
   taoTokenId: TokenId
   isSelected?: boolean
   isLoading?: boolean
+  showRootWeights?: boolean
   onClick: () => void
-}> = ({ option, isSelected, isLoading, taoTokenId, onClick }) => {
+}> = ({ option, isSelected, isLoading, taoTokenId, showRootWeights, onClick }) => {
   const { t } = useTranslation()
   const tao = useToken(taoTokenId)
 
@@ -189,8 +193,8 @@ const ValidatorRow: FC<{
                 <Address startCharCount={8} endCharCount={8} address={option.hotkey} />
               )}
               {option.isFeatured && (
-                <EarnTypeBadge className="inline-flex h-[18px] shrink-0 items-center gap-[4px] rounded-[12px] border-none bg-primary/10 px-[8px] font-light text-[10px] text-primary normal-case">
-                  <TalismanHandIcon className="size-[12px]" />
+                <EarnTypeBadge className="inline-flex h-9 shrink-0 items-center gap-2 rounded-[12px] border-none bg-primary/10 px-4 font-light text-primary text-tiny normal-case">
+                  <TalismanHandIcon className="size-6" />
                   {t("Featured")}
                 </EarnTypeBadge>
               )}
@@ -205,12 +209,14 @@ const ValidatorRow: FC<{
         {/* metagraph entries have no registry stats: stakers/subnets would be fake zeros */}
         <div
           className={cn(
-            "flex w-full justify-between text-body-secondary text-xs",
+            "flex w-full items-center justify-between text-body-secondary text-xs",
             isLoading && "animate-pulse",
-            option.source === "metagraph" && "hidden"
+            option.source === "metagraph" && !showRootWeights && "hidden"
           )}
         >
-          <div className="flex items-center gap-4">
+          <div
+            className={cn("flex items-center gap-4", option.source === "metagraph" && "invisible")}
+          >
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="flex items-center gap-2">
@@ -258,6 +264,12 @@ const ValidatorRow: FC<{
               </TooltipContent>
             </Tooltip>
           </div>
+          {showRootWeights && (
+            <RootWeightsStat
+              networkId={tao?.networkId as DotNetworkId | undefined}
+              hotkey={option.hotkey}
+            />
+          )}
         </div>
       </div>
     </button>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/ValidatorPicker.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/ValidatorPicker.tsx
@@ -79,6 +79,7 @@ export const ValidatorRows: FC<{
   showRootWeights?: boolean
   containerId?: string
   onSelect: (hotkey: string) => void
+  onClose: () => void
 }> = ({
   taoTokenId,
   validators,
@@ -87,6 +88,7 @@ export const ValidatorRows: FC<{
   showRootWeights,
   containerId,
   onSelect,
+  onClose,
 }) => {
   const { ref: refContainer } = useScrollContainer()
   const tao = useToken(taoTokenId)
@@ -151,6 +153,7 @@ export const ValidatorRows: FC<{
           containerId={containerId}
           isOpen={isViewAllOpen}
           onDismiss={closeViewAll}
+          onClose={onClose}
         />
       )}
     </div>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/__tests__/useBittensorRootWeights.test.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/__tests__/useBittensorRootWeights.test.tsx
@@ -17,6 +17,7 @@ import { useBittensorRootWeights } from "../useBittensorRootWeights"
 // ── Test fixtures ─────────────────────────────────────────────────
 
 const HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+const BLOCK_HASH = "0xabc"
 
 // storage keys are faked as "<entry>:<keyArgs>" strings so prefix matching
 // and key decoding mirror the real getKeysPaged/queryStorageAt flow
@@ -34,12 +35,15 @@ const makeSapi = (storage: Record<string, unknown>) => ({
     },
     connector: {
       send: async (method: string, params: unknown[]) => {
+        if (method === "chain_getBlockHash") return BLOCK_HASH
         if (method === "state_getKeysPaged") {
-          const [prefix] = params as [string]
+          const [prefix, , , at] = params as [string, number, null, string]
+          expect(at).toBe(BLOCK_HASH)
           return Object.keys(storage).filter((key) => key.startsWith(prefix))
         }
         if (method === "state_queryStorageAt") {
-          const [keys] = params as [string[]]
+          const [keys, at] = params as [string[], string]
+          expect(at).toBe(BLOCK_HASH)
           return [{ changes: keys.map((key) => [key, storage[key]]) }]
         }
         throw new Error(`Unexpected RPC method: ${method}`)

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/__tests__/useBittensorRootWeights.test.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/__tests__/useBittensorRootWeights.test.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import type { FC, ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ── Module mocks ──────────────────────────────────────────────────
+
+const mockUseScaleApi = vi.fn()
+
+vi.mock("@ui/hooks/sapi/useScaleApi", () => ({
+  useScaleApi: () => mockUseScaleApi(),
+}))
+
+// eslint-disable-next-line import/first
+import { useBittensorRootWeights } from "../useBittensorRootWeights"
+
+// ── Test fixtures ─────────────────────────────────────────────────
+
+const HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+
+// storage keys are faked as "<entry>:<keyArgs>" strings so prefix matching
+// and key decoding mirror the real getKeysPaged/queryStorageAt flow
+const makeSapi = (storage: Record<string, unknown>) => ({
+  id: "bittensor::v100",
+  chain: {
+    builder: {
+      buildStorage: (_pallet: string, entry: string) => ({
+        keys: {
+          enc: (...args: number[]) => [entry, ...args, ""].join(":"),
+          dec: (key: string) => key.split(":").slice(1).map(Number),
+        },
+        value: { dec: (value: unknown) => value },
+      }),
+    },
+    connector: {
+      send: async (method: string, params: unknown[]) => {
+        if (method === "state_getKeysPaged") {
+          const [prefix] = params as [string]
+          return Object.keys(storage).filter((key) => key.startsWith(prefix))
+        }
+        if (method === "state_queryStorageAt") {
+          const [keys] = params as [string[]]
+          return [{ changes: keys.map((key) => [key, storage[key]]) }]
+        }
+        throw new Error(`Unexpected RPC method: ${method}`)
+      },
+    },
+  },
+})
+
+const STORAGE = {
+  "Keys:0:1": HOTKEY,
+  "Weights:0:1": [
+    [0, 5000],
+    [3, 3000],
+    [99, 2000],
+  ],
+  "NetworksAdded:0": true,
+  "NetworksAdded:3": true,
+}
+
+const createWrapper = (): FC<{ children: ReactNode }> => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const renderRootWeights = (hotkey = HOTKEY) =>
+  renderHook(() => useBittensorRootWeights("bittensor", hotkey), { wrapper: createWrapper() })
+
+describe("useBittensorRootWeights", () => {
+  beforeEach(() => {
+    mockUseScaleApi.mockReset()
+  })
+
+  it("returns weights filtered to root and existing subnets", async () => {
+    mockUseScaleApi.mockReturnValue({ data: makeSapi(STORAGE), isPending: false, isError: false })
+
+    const { result } = renderRootWeights()
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isError).toBe(false)
+    expect(result.current.data).toEqual([
+      [0, 5000],
+      [3, 3000],
+    ])
+  })
+
+  it("returns an empty vector for a hotkey without weights", async () => {
+    mockUseScaleApi.mockReturnValue({ data: makeSapi(STORAGE), isPending: false, isError: false })
+
+    const { result } = renderRootWeights("some-other-hotkey")
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isError).toBe(false)
+    expect(result.current.data).toEqual([])
+  })
+
+  it("stays loading while the scale api is pending", () => {
+    mockUseScaleApi.mockReturnValue({ data: undefined, isPending: true, isError: false })
+
+    const { result } = renderRootWeights()
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it("reports an error when the scale api query fails", () => {
+    mockUseScaleApi.mockReturnValue({ data: undefined, isPending: false, isError: true })
+
+    const { result } = renderRootWeights()
+
+    expect(result.current.isError).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("reports an error when the scale api resolves without metadata", () => {
+    mockUseScaleApi.mockReturnValue({ data: null, isPending: false, isError: false })
+
+    const { result } = renderRootWeights()
+
+    expect(result.current.isError).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("reports an error when the storage sweep fails", async () => {
+    const sapi = makeSapi(STORAGE)
+    sapi.chain.connector.send = async () => {
+      throw new Error("RPC unavailable")
+    }
+    mockUseScaleApi.mockReturnValue({ data: sapi, isPending: false, isError: false })
+
+    const { result } = renderRootWeights()
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.isLoading).toBe(false)
+  })
+})

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
@@ -9,6 +9,8 @@ import { getDeployableWeights, type RootWeightEntry } from "../utils/rootWeights
 
 type StorageChanges = [{ changes: [key: string, value: string | null][] }]
 
+const NO_WEIGHTS: RootWeightEntry[] = []
+
 const fetchStorageEntries = async (
   sapi: ScaleApi,
   at: string,
@@ -80,7 +82,7 @@ export const useBittensorRootWeights = (networkId: DotNetworkId | undefined, hot
     },
     enabled: !!sapi,
     staleTime: 5 * 60_000,
-    select: (byHotkey) => byHotkey[hotkey] ?? [],
+    select: (byHotkey) => byHotkey[hotkey] ?? NO_WEIGHTS,
   })
 
   // useScaleApi resolving to null (metadata unavailable) leaves the weights query

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
@@ -5,59 +5,70 @@ import { useQuery } from "@tanstack/react-query"
 import { useScaleApi } from "@ui/hooks/sapi/useScaleApi"
 
 import { ROOT_NETUID } from "../utils/constants"
-import type { RootWeightEntry } from "../utils/rootWeights"
+import { getDeployableWeights, type RootWeightEntry } from "../utils/rootWeights"
 
 type StorageChanges = [{ changes: [key: string, value: string | null][] }]
+
+const fetchStorageEntries = async (
+  sapi: ScaleApi,
+  entry: string,
+  ...keyArgs: number[]
+): Promise<[key: number[], value: unknown][]> => {
+  const { connector, builder } = sapi.chain
+  const codec = builder.buildStorage("SubtensorModule", entry)
+
+  const prefix = codec.keys.enc(...keyArgs)
+  const keys = (await connector.send("state_getKeysPaged", [prefix, 1000, null])) as string[]
+  if (!keys.length) return []
+
+  const [{ changes }] = (await connector.send("state_queryStorageAt", [keys])) as StorageChanges
+
+  return changes
+    .filter(([, value]) => value !== null)
+    .map(([key, value]) => [codec.keys.dec(key) as number[], codec.value.dec(value as string)])
+}
 
 const fetchDoubleMapEntries = async <T>(
   sapi: ScaleApi,
   entry: string,
   firstKey: number
 ): Promise<Map<number, T>> => {
-  const { connector, builder } = sapi.chain
-  const codec = builder.buildStorage("SubtensorModule", entry)
+  const entries = await fetchStorageEntries(sapi, entry, firstKey)
+  return new Map(entries.map(([[, uid], value]) => [uid, value as T]))
+}
 
-  const prefix = codec.keys.enc(firstKey)
-  const keys = (await connector.send("state_getKeysPaged", [prefix, 1000, null])) as string[]
-  if (!keys.length) return new Map()
-
-  const [{ changes }] = (await connector.send("state_queryStorageAt", [keys])) as StorageChanges
-
-  return new Map(
-    changes
-      .filter(([, value]) => value !== null)
-      .map(([key, value]) => {
-        const [, uid] = codec.keys.dec(key) as [number, number]
-        return [uid, codec.value.dec(value as string) as T]
-      })
-  )
+const fetchExistingNetuids = async (sapi: ScaleApi): Promise<Set<number>> => {
+  const entries = await fetchStorageEntries(sapi, "NetworksAdded")
+  return new Set(entries.filter(([, added]) => added === true).map(([[netuid]]) => netuid))
 }
 
 /**
  * Declared root weights of every root validator, keyed by hotkey: how each root-stake
- * fund allocates deposits across subnets. Swept from the `Weights` and `Keys` storage
- * maps in four RPC calls total, instead of one runtime API call per validator.
- * A missing hotkey means the validator never set weights (uncurated fund) — stakers
- * still earn, dividends accumulate in place following raw subnet emissions.
+ * fund allocates deposits across subnets. Swept from the `Weights`, `Keys` and
+ * `NetworksAdded` storage maps in six RPC calls total, instead of one runtime API call
+ * per validator. Weights targeting removed subnets are dropped, matching the runtime's
+ * deployable basket. A missing hotkey means the validator never set weights (uncurated
+ * fund) — stakers still earn, dividends accumulate in place following raw subnet emissions.
  */
 const fetchRootWeightsByHotkey = async (sapi: ScaleApi) => {
-  const [hotkeyByUid, weightsByUid] = await Promise.all([
+  const [hotkeyByUid, weightsByUid, existingNetuids] = await Promise.all([
     fetchDoubleMapEntries<string>(sapi, "Keys", ROOT_NETUID),
     fetchDoubleMapEntries<RootWeightEntry[]>(sapi, "Weights", ROOT_NETUID),
+    fetchExistingNetuids(sapi),
   ])
 
   const byHotkey: Record<string, RootWeightEntry[]> = {}
   for (const [uid, weights] of weightsByUid) {
     const hotkey = hotkeyByUid.get(uid)
-    if (hotkey) byHotkey[hotkey] = weights
+    if (hotkey) byHotkey[hotkey] = getDeployableWeights(weights, existingNetuids)
   }
   return byHotkey
 }
 
 export const useBittensorRootWeights = (networkId: DotNetworkId | undefined, hotkey: string) => {
-  const { data: sapi } = useScaleApi(networkId)
+  const { data: sapi, isPending: isSapiPending, isError: isSapiError } = useScaleApi(networkId)
 
-  return useQuery({
+  const query = useQuery({
     queryKey: ["useBittensorRootWeights", sapi?.id],
     queryFn: async () => {
       if (!sapi) throw new Error("Chain connection not ready")
@@ -67,4 +78,14 @@ export const useBittensorRootWeights = (networkId: DotNetworkId | undefined, hot
     staleTime: 5 * 60_000,
     select: (byHotkey) => byHotkey[hotkey] ?? [],
   })
+
+  // useScaleApi resolving to null (metadata unavailable) leaves the weights query
+  // disabled forever: surface it as an error, not as an endless loading state
+  const isSapiUnavailable = isSapiError || (!isSapiPending && !sapi)
+
+  return {
+    data: query.data,
+    isError: isSapiUnavailable || query.isError,
+    isLoading: !isSapiUnavailable && !query.isError && query.isPending,
+  }
 }

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
@@ -1,30 +1,70 @@
 import type { DotNetworkId } from "@talismn/chaindata-provider"
+import type { ScaleApi } from "@talismn/sapi"
 import { useQuery } from "@tanstack/react-query"
 
 import { useScaleApi } from "@ui/hooks/sapi/useScaleApi"
 
+import { ROOT_NETUID } from "../utils/constants"
 import type { RootWeightEntry } from "../utils/rootWeights"
 
+type StorageChanges = [{ changes: [key: string, value: string | null][] }]
+
+const fetchDoubleMapEntries = async <T>(
+  sapi: ScaleApi,
+  entry: string,
+  firstKey: number
+): Promise<Map<number, T>> => {
+  const { connector, builder } = sapi.chain
+  const codec = builder.buildStorage("SubtensorModule", entry)
+
+  const prefix = codec.keys.enc(firstKey)
+  const keys = (await connector.send("state_getKeysPaged", [prefix, 1000, null])) as string[]
+  if (!keys.length) return new Map()
+
+  const [{ changes }] = (await connector.send("state_queryStorageAt", [keys])) as StorageChanges
+
+  return new Map(
+    changes
+      .filter(([, value]) => value !== null)
+      .map(([key, value]) => {
+        const [, uid] = codec.keys.dec(key) as [number, number]
+        return [uid, codec.value.dec(value as string) as T]
+      })
+  )
+}
+
 /**
- * Declared root weights of a validator (`get_validator_weights`): how its root-stake
- * fund allocates deposits across subnets. An empty vector means the validator never
- * set weights (uncurated fund) — stakers still earn, dividends accumulate in place
- * following raw subnet emissions.
+ * Declared root weights of every root validator, keyed by hotkey: how each root-stake
+ * fund allocates deposits across subnets. Swept from the `Weights` and `Keys` storage
+ * maps in four RPC calls total, instead of one runtime API call per validator.
+ * A missing hotkey means the validator never set weights (uncurated fund) — stakers
+ * still earn, dividends accumulate in place following raw subnet emissions.
  */
+const fetchRootWeightsByHotkey = async (sapi: ScaleApi) => {
+  const [hotkeyByUid, weightsByUid] = await Promise.all([
+    fetchDoubleMapEntries<string>(sapi, "Keys", ROOT_NETUID),
+    fetchDoubleMapEntries<RootWeightEntry[]>(sapi, "Weights", ROOT_NETUID),
+  ])
+
+  const byHotkey: Record<string, RootWeightEntry[]> = {}
+  for (const [uid, weights] of weightsByUid) {
+    const hotkey = hotkeyByUid.get(uid)
+    if (hotkey) byHotkey[hotkey] = weights
+  }
+  return byHotkey
+}
+
 export const useBittensorRootWeights = (networkId: DotNetworkId | undefined, hotkey: string) => {
   const { data: sapi } = useScaleApi(networkId)
 
   return useQuery({
-    queryKey: ["useBittensorRootWeights", sapi?.id, hotkey],
+    queryKey: ["useBittensorRootWeights", sapi?.id],
     queryFn: async () => {
       if (!sapi) throw new Error("Chain connection not ready")
-      return sapi.getRuntimeCallValue<RootWeightEntry[]>(
-        "BetaBasketRuntimeApi",
-        "get_validator_weights",
-        [hotkey]
-      )
+      return fetchRootWeightsByHotkey(sapi)
     },
     enabled: !!sapi,
     staleTime: 5 * 60_000,
+    select: (byHotkey) => byHotkey[hotkey] ?? [],
   })
 }

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
@@ -1,0 +1,30 @@
+import type { DotNetworkId } from "@talismn/chaindata-provider"
+import { useQuery } from "@tanstack/react-query"
+
+import { useScaleApi } from "@ui/hooks/sapi/useScaleApi"
+
+import type { RootWeightEntry } from "../utils/rootWeights"
+
+/**
+ * Declared root weights of a validator (`get_validator_weights`): how its root-stake
+ * fund allocates deposits across subnets. An empty vector means the validator never
+ * set weights (uncurated fund) — stakers still earn, dividends accumulate in place
+ * following raw subnet emissions.
+ */
+export const useBittensorRootWeights = (networkId: DotNetworkId | undefined, hotkey: string) => {
+  const { data: sapi } = useScaleApi(networkId)
+
+  return useQuery({
+    queryKey: ["useBittensorRootWeights", sapi?.id, hotkey],
+    queryFn: async () => {
+      if (!sapi) throw new Error("Chain connection not ready")
+      return sapi.getRuntimeCallValue<RootWeightEntry[]>(
+        "BetaBasketRuntimeApi",
+        "get_validator_weights",
+        [hotkey]
+      )
+    },
+    enabled: !!sapi,
+    staleTime: 5 * 60_000,
+  })
+}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorRootWeights.ts
@@ -11,6 +11,7 @@ type StorageChanges = [{ changes: [key: string, value: string | null][] }]
 
 const fetchStorageEntries = async (
   sapi: ScaleApi,
+  at: string,
   entry: string,
   ...keyArgs: number[]
 ): Promise<[key: number[], value: unknown][]> => {
@@ -18,10 +19,10 @@ const fetchStorageEntries = async (
   const codec = builder.buildStorage("SubtensorModule", entry)
 
   const prefix = codec.keys.enc(...keyArgs)
-  const keys = (await connector.send("state_getKeysPaged", [prefix, 1000, null])) as string[]
+  const keys = (await connector.send("state_getKeysPaged", [prefix, 1000, null, at])) as string[]
   if (!keys.length) return []
 
-  const [{ changes }] = (await connector.send("state_queryStorageAt", [keys])) as StorageChanges
+  const [{ changes }] = (await connector.send("state_queryStorageAt", [keys, at])) as StorageChanges
 
   return changes
     .filter(([, value]) => value !== null)
@@ -30,31 +31,34 @@ const fetchStorageEntries = async (
 
 const fetchDoubleMapEntries = async <T>(
   sapi: ScaleApi,
+  at: string,
   entry: string,
   firstKey: number
 ): Promise<Map<number, T>> => {
-  const entries = await fetchStorageEntries(sapi, entry, firstKey)
+  const entries = await fetchStorageEntries(sapi, at, entry, firstKey)
   return new Map(entries.map(([[, uid], value]) => [uid, value as T]))
 }
 
-const fetchExistingNetuids = async (sapi: ScaleApi): Promise<Set<number>> => {
-  const entries = await fetchStorageEntries(sapi, "NetworksAdded")
+const fetchExistingNetuids = async (sapi: ScaleApi, at: string): Promise<Set<number>> => {
+  const entries = await fetchStorageEntries(sapi, at, "NetworksAdded")
   return new Set(entries.filter(([, added]) => added === true).map(([[netuid]]) => netuid))
 }
 
 /**
  * Declared root weights of every root validator, keyed by hotkey: how each root-stake
  * fund allocates deposits across subnets. Swept from the `Weights`, `Keys` and
- * `NetworksAdded` storage maps in six RPC calls total, instead of one runtime API call
- * per validator. Weights targeting removed subnets are dropped, matching the runtime's
- * deployable basket. A missing hotkey means the validator never set weights (uncurated
- * fund) — stakers still earn, dividends accumulate in place following raw subnet emissions.
+ * `NetworksAdded` storage maps at one pinned block, so a uid reassigned mid-sweep can't
+ * pair a hotkey with another validator's weights. Weights targeting removed subnets are
+ * dropped, matching the runtime's deployable basket. A missing hotkey means the validator
+ * never set weights (uncurated fund) — stakers still earn, dividends accumulate in place
+ * following raw subnet emissions.
  */
 const fetchRootWeightsByHotkey = async (sapi: ScaleApi) => {
+  const at = (await sapi.chain.connector.send("chain_getBlockHash", [])) as string
   const [hotkeyByUid, weightsByUid, existingNetuids] = await Promise.all([
-    fetchDoubleMapEntries<string>(sapi, "Keys", ROOT_NETUID),
-    fetchDoubleMapEntries<RootWeightEntry[]>(sapi, "Weights", ROOT_NETUID),
-    fetchExistingNetuids(sapi),
+    fetchDoubleMapEntries<string>(sapi, at, "Keys", ROOT_NETUID),
+    fetchDoubleMapEntries<RootWeightEntry[]>(sapi, at, "Weights", ROOT_NETUID),
+    fetchExistingNetuids(sapi, at),
   ])
 
   const byHotkey: Record<string, RootWeightEntry[]> = {}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.test.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+
+import { getRootWeightsBreakdown, type RootWeightEntry } from "./rootWeights"
+
+describe("getRootWeightsBreakdown", () => {
+  it("returns null when no weights are set", () => {
+    expect(getRootWeightsBreakdown([])).toBeNull()
+  })
+
+  it("returns null when all weights are zero", () => {
+    expect(
+      getRootWeightsBreakdown([
+        [3, 0],
+        [8, 0],
+      ])
+    ).toBeNull()
+  })
+
+  it("ranks slices by weight and computes ratios over the vector sum", () => {
+    const weights: RootWeightEntry[] = [
+      [3, 1000],
+      [8, 3000],
+      [51, 4000],
+      [64, 2000],
+    ]
+
+    const breakdown = getRootWeightsBreakdown(weights)
+
+    expect(breakdown).toEqual({
+      subnetCount: 4,
+      topSlices: [
+        { netuid: 51, ratio: 0.4 },
+        { netuid: 8, ratio: 0.3 },
+        { netuid: 64, ratio: 0.2 },
+        { netuid: 3, ratio: 0.1 },
+      ],
+      othersRatio: expect.closeTo(0),
+    })
+  })
+
+  it("excludes the netuid 0 TAO cash slice from the subnet count but keeps its ratio", () => {
+    const weights: RootWeightEntry[] = [
+      [0, 5000],
+      [3, 3000],
+      [8, 2000],
+    ]
+
+    const breakdown = getRootWeightsBreakdown(weights)
+
+    expect(breakdown?.subnetCount).toBe(2)
+    expect(breakdown?.topSlices).toEqual([
+      { netuid: 0, ratio: 0.5 },
+      { netuid: 3, ratio: 0.3 },
+      { netuid: 8, ratio: 0.2 },
+    ])
+    expect(breakdown?.othersRatio).toBe(0)
+  })
+
+  it("ignores zero-weight entries", () => {
+    const breakdown = getRootWeightsBreakdown([
+      [3, 100],
+      [8, 0],
+    ])
+
+    expect(breakdown?.subnetCount).toBe(1)
+    expect(breakdown?.topSlices).toEqual([{ netuid: 3, ratio: 1 }])
+  })
+
+  it("counts every weighted subnet even beyond the top slices", () => {
+    const weights: RootWeightEntry[] = Array.from(
+      { length: 12 },
+      (_, i): RootWeightEntry => [i + 1, 100]
+    )
+
+    const breakdown = getRootWeightsBreakdown(weights)
+
+    expect(breakdown?.subnetCount).toBe(12)
+    expect(breakdown?.topSlices).toHaveLength(8)
+    expect(breakdown?.othersRatio).toBeCloseTo(4 / 12)
+  })
+})

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.test.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.test.ts
@@ -66,6 +66,19 @@ describe("getRootWeightsBreakdown", () => {
     expect(breakdown?.topSlices).toEqual([{ netuid: 3, ratio: 1 }])
   })
 
+  it("breaks weight ties by ascending netuid", () => {
+    const weights: RootWeightEntry[] = [
+      [51, 500],
+      [3, 500],
+      [8, 700],
+      [19, 500],
+    ]
+
+    const breakdown = getRootWeightsBreakdown(weights)
+
+    expect(breakdown?.topSlices.map(({ netuid }) => netuid)).toEqual([8, 3, 19, 51])
+  })
+
   it("counts every weighted subnet even beyond the top slices", () => {
     const weights: RootWeightEntry[] = Array.from(
       { length: 12 },

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.test.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.test.ts
@@ -26,14 +26,16 @@ describe("getRootWeightsBreakdown", () => {
 
     const breakdown = getRootWeightsBreakdown(weights)
 
+    const slices = [
+      { netuid: 51, ratio: 0.4 },
+      { netuid: 8, ratio: 0.3 },
+      { netuid: 64, ratio: 0.2 },
+      { netuid: 3, ratio: 0.1 },
+    ]
     expect(breakdown).toEqual({
       subnetCount: 4,
-      topSlices: [
-        { netuid: 51, ratio: 0.4 },
-        { netuid: 8, ratio: 0.3 },
-        { netuid: 64, ratio: 0.2 },
-        { netuid: 3, ratio: 0.1 },
-      ],
+      topSlices: slices,
+      allSlices: slices,
       othersRatio: expect.closeTo(0),
     })
   })
@@ -89,6 +91,7 @@ describe("getRootWeightsBreakdown", () => {
 
     expect(breakdown?.subnetCount).toBe(12)
     expect(breakdown?.topSlices).toHaveLength(8)
+    expect(breakdown?.allSlices).toHaveLength(12)
     expect(breakdown?.othersRatio).toBeCloseTo(4 / 12)
   })
 })

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.test.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, it } from "vitest"
 
-import { getRootWeightsBreakdown, type RootWeightEntry } from "./rootWeights"
+import { getDeployableWeights, getRootWeightsBreakdown, type RootWeightEntry } from "./rootWeights"
+
+describe("getDeployableWeights", () => {
+  it("drops entries targeting removed subnets", () => {
+    const weights: RootWeightEntry[] = [
+      [3, 1000],
+      [99, 4000],
+      [8, 2000],
+    ]
+
+    expect(getDeployableWeights(weights, new Set([3, 8]))).toEqual([
+      [3, 1000],
+      [8, 2000],
+    ])
+  })
+
+  it("keeps the root netuid even when absent from the existing set", () => {
+    const weights: RootWeightEntry[] = [
+      [0, 5000],
+      [3, 1000],
+    ]
+
+    expect(getDeployableWeights(weights, new Set([3]))).toEqual(weights)
+  })
+})
 
 describe("getRootWeightsBreakdown", () => {
   it("returns null when no weights are set", () => {

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.ts
@@ -26,7 +26,7 @@ export const getRootWeightsBreakdown = (
   if (!total) return null
 
   const topSlices = positive
-    .toSorted(([, a], [, b]) => b - a)
+    .toSorted(([netuidA, weightA], [netuidB, weightB]) => weightB - weightA || netuidA - netuidB)
     .slice(0, TOP_SLICE_COUNT)
     .map(([netuid, weight]) => ({ netuid, ratio: weight / total }))
 

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.ts
@@ -1,0 +1,38 @@
+import { ROOT_NETUID } from "./constants"
+
+/** decoded element of `get_validator_weights`: declared root weight for one destination */
+export type RootWeightEntry = [netuid: number, weight: number]
+
+export type RootWeightsBreakdown = {
+  /** subnets with exposure — a netuid 0 (TAO cash position) slice is excluded */
+  subnetCount: number
+  /** largest slices first, ratios over the full vector including the TAO slice */
+  topSlices: { netuid: number; ratio: number }[]
+  othersRatio: number
+}
+
+const TOP_SLICE_COUNT = 8
+
+/**
+ * Weights are max-upscaled on chain (largest entry = u16::MAX), not sum-normalized:
+ * proportions only exist relative to the vector's own sum, mirroring how the chain
+ * deploys deposits (`deploy_tao_into_basket`).
+ */
+export const getRootWeightsBreakdown = (
+  weights: RootWeightEntry[]
+): RootWeightsBreakdown | null => {
+  const positive = weights.filter(([, weight]) => weight > 0)
+  const total = positive.reduce((sum, [, weight]) => sum + weight, 0)
+  if (!total) return null
+
+  const topSlices = positive
+    .toSorted(([, a], [, b]) => b - a)
+    .slice(0, TOP_SLICE_COUNT)
+    .map(([netuid, weight]) => ({ netuid, ratio: weight / total }))
+
+  return {
+    subnetCount: positive.filter(([netuid]) => netuid !== ROOT_NETUID).length,
+    topSlices,
+    othersRatio: Math.max(0, 1 - topSlices.reduce((sum, slice) => sum + slice.ratio, 0)),
+  }
+}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.ts
@@ -18,6 +18,16 @@ export type RootWeightsBreakdown = {
 const TOP_SLICE_COUNT = 8
 
 /**
+ * The runtime only deploys to root or currently existing subnets (`do_claim_root`):
+ * stale entries pointing at removed subnets must not dilute the displayed ratios.
+ */
+export const getDeployableWeights = (
+  weights: RootWeightEntry[],
+  existingNetuids: ReadonlySet<number>
+): RootWeightEntry[] =>
+  weights.filter(([netuid]) => netuid === ROOT_NETUID || existingNetuids.has(netuid))
+
+/**
  * Weights are max-upscaled on chain (largest entry = u16::MAX), not sum-normalized:
  * proportions only exist relative to the vector's own sum, mirroring how the chain
  * deploys deposits (`deploy_tao_into_basket`).

--- a/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/utils/rootWeights.ts
@@ -3,11 +3,15 @@ import { ROOT_NETUID } from "./constants"
 /** decoded element of `get_validator_weights`: declared root weight for one destination */
 export type RootWeightEntry = [netuid: number, weight: number]
 
+export type RootWeightSlice = { netuid: number; ratio: number }
+
 export type RootWeightsBreakdown = {
   /** subnets with exposure — a netuid 0 (TAO cash position) slice is excluded */
   subnetCount: number
   /** largest slices first, ratios over the full vector including the TAO slice */
-  topSlices: { netuid: number; ratio: number }[]
+  topSlices: RootWeightSlice[]
+  /** every positive slice, same order as topSlices */
+  allSlices: RootWeightSlice[]
   othersRatio: number
 }
 
@@ -25,14 +29,15 @@ export const getRootWeightsBreakdown = (
   const total = positive.reduce((sum, [, weight]) => sum + weight, 0)
   if (!total) return null
 
-  const topSlices = positive
+  const allSlices = positive
     .toSorted(([netuidA, weightA], [netuidB, weightB]) => weightB - weightA || netuidA - netuidB)
-    .slice(0, TOP_SLICE_COUNT)
     .map(([netuid, weight]) => ({ netuid, ratio: weight / total }))
+  const topSlices = allSlices.slice(0, TOP_SLICE_COUNT)
 
   return {
     subnetCount: positive.filter(([netuid]) => netuid !== ROOT_NETUID).length,
     topSlices,
+    allSlices,
     othersRatio: Math.max(0, 1 - topSlices.reduce((sum, slice) => sum + slice.ratio, 0)),
   }
 }

--- a/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/BittensorValidatorPicker.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/BittensorValidatorPicker.tsx
@@ -125,6 +125,7 @@ export const BittensorValidatorPicker: FC<{
               validators={displayedValidators}
               selectedHotkey={hotkey}
               isLoading={isLoading}
+              showRootWeights={isRoot}
               onSelect={onSelect}
             />
           )}

--- a/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/BittensorValidatorPicker.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/BittensorValidatorPicker.tsx
@@ -31,7 +31,8 @@ export const BittensorValidatorPicker: FC<{
   hotkey: string | null
   containerId?: string
   onSelect: (hotkey: string) => void
-}> = ({ networkId, netuid, hotkey, containerId, onSelect }) => {
+  onClose: () => void
+}> = ({ networkId, netuid, hotkey, containerId, onSelect, onClose }) => {
   const { t } = useTranslation()
   const isRoot = netuid === ROOT_NETUID
   const apyColumnLabel = isRoot ? t("APR [30D]") : t("APY [30D]")
@@ -129,6 +130,7 @@ export const BittensorValidatorPicker: FC<{
               showRootWeights={isRoot}
               containerId={containerId}
               onSelect={onSelect}
+              onClose={onClose}
             />
           )}
           {!isError && displayedValidators?.length === 0 && (

--- a/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/BittensorValidatorPicker.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/BittensorValidatorPicker.tsx
@@ -29,8 +29,9 @@ export const BittensorValidatorPicker: FC<{
   networkId: DotNetworkId
   netuid: number
   hotkey: string | null
+  containerId?: string
   onSelect: (hotkey: string) => void
-}> = ({ networkId, netuid, hotkey, onSelect }) => {
+}> = ({ networkId, netuid, hotkey, containerId, onSelect }) => {
   const { t } = useTranslation()
   const isRoot = netuid === ROOT_NETUID
   const apyColumnLabel = isRoot ? t("APR [30D]") : t("APY [30D]")
@@ -126,6 +127,7 @@ export const BittensorValidatorPicker: FC<{
               selectedHotkey={hotkey}
               isLoading={isLoading}
               showRootWeights={isRoot}
+              containerId={containerId}
               onSelect={onSelect}
             />
           )}

--- a/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/SelectValidatorPill.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/SelectValidatorPill.tsx
@@ -60,6 +60,7 @@ export const SelectValidatorPill: FC<{
               hotkey={hotkey}
               containerId="select-validator-picker-modal"
               onSelect={handleSelect}
+              onClose={close}
             />
           </WizardModalDialog>
         </PopupSizeModalContainer>

--- a/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/SelectValidatorPill.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnet/swap/SelectValidatorPill.tsx
@@ -58,6 +58,7 @@ export const SelectValidatorPill: FC<{
               networkId={networkId}
               netuid={netuid}
               hotkey={hotkey}
+              containerId="select-validator-picker-modal"
               onSelect={handleSelect}
             />
           </WizardModalDialog>


### PR DESCRIPTION
When staking on root, validator rows show how many subnets the validator allocates root weights to, with a hover tooltip (subnet count + horizontal bar + top 8 allocations, netuid 0 shown as TAO) and a "View all" modal listing every allocation with search. The modal repeats the count and bar below the search box.

- Weights are swept once for all validators from the `Keys`, `Weights` and `NetworksAdded` storage maps, pinned to a single block.
- Weights targeting removed subnets are dropped, matching what the runtime deploys.
- Validators without weights show a dash with an explanatory tooltip; fetch or metadata failures show N/A.
- `Tooltip` gains an `interactive` prop so its content can hold buttons.