### PR TITLE
✨ bittensor validator logos

### DIFF
--- a/.changeset/bittensor-hotkey-logo-url.md
+++ b/.changeset/bittensor-hotkey-logo-url.md
@@ -1,0 +1,5 @@
+---
+"@talismn/chaindata-provider": patch
+---
+
+Add `getGithubBittensorHotkeyAssetUrl` to resolve chaindata's Bittensor hotkey logo assets

--- a/apps/extension/src/ui/domains/Portfolio/AssetDetails/ConvictionLockHotkeyTag.tsx
+++ b/apps/extension/src/ui/domains/Portfolio/AssetDetails/ConvictionLockHotkeyTag.tsx
@@ -1,5 +1,5 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
+import { BittensorHotkeyAvatar } from "@ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar"
 import { useBittensorValidator } from "@ui/state/bittensor"
 import { cn } from "@ui/util/cn"
 import { shortenAddress } from "@ui/util/shortenAddress"
@@ -26,7 +26,7 @@ export const ConvictionLockHotkeyTag: FC<{
             className
           )}
         >
-          <AccountIcon address={hotkey} className="shrink-0 text-[1.2em]" />
+          <BittensorHotkeyAvatar hotkey={hotkey} className="shrink-0 text-[1.2em]" />
           <span className={cn("truncate", status === "loading" && "animate-pulse")}>
             {identity?.name ?? shortenAddress(hotkey, 6, 6)}
           </span>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeLockHotkeyModal/BittensorChangeLockHotkeyConfirm.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeLockHotkeyModal/BittensorChangeLockHotkeyConfirm.tsx
@@ -1,9 +1,9 @@
 import { AlertCircleIcon } from "@talismn/icons"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
 import { WizardModalDialog } from "@ui/components/WizardModalDialog"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
 import { BittensorValidatorName } from "@ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorValidatorName"
+import { BittensorHotkeyAvatar } from "@ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar"
 import { StakingAccountDisplay } from "@ui/domains/Staking/shared/StakingAccountDisplay"
 import { StakingFeeEstimate } from "@ui/domains/Staking/shared/StakingFeeEstimate"
 import { SapiSendButton } from "@ui/domains/Transactions/SapiSendButton"
@@ -18,7 +18,7 @@ import {
 
 const HotkeyDisplay: FC<{ hotkey: string }> = ({ hotkey }) => (
   <span className="inline-flex max-w-full items-center gap-4 overflow-hidden align-middle">
-    <AccountIcon className="shrink-0 text-lg!" address={hotkey} />
+    <BittensorHotkeyAvatar hotkey={hotkey} className="shrink-0 text-lg!" />
     <BittensorValidatorName hotkey={hotkey} className="truncate" />
   </span>
 )

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeLockHotkeyModal/BittensorChangeLockHotkeyForm.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeLockHotkeyModal/BittensorChangeLockHotkeyForm.tsx
@@ -2,11 +2,11 @@ import { Button } from "@ui/components/Button"
 import { PillButton } from "@ui/components/PillButton"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
 import { WizardModalDialog } from "@ui/components/WizardModalDialog"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { AccountPicker } from "@ui/domains/AccountProxies/AddProxy/AccountPicker"
 import { TokenLogo } from "@ui/domains/Asset/TokenLogo"
 import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
 import { AddressPillButton } from "@ui/domains/SendFunds/SendFundsAmountForm/AddressPillButton"
+import { BittensorHotkeyAvatar } from "@ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar"
 import { StakingFeeEstimate } from "@ui/domains/Staking/shared/StakingFeeEstimate"
 import { useTranslation } from "react-i18next"
 
@@ -100,7 +100,7 @@ export const BittensorChangeLockHotkeyForm = () => {
               <div className="flex h-16 max-w-full flex-nowrap items-center gap-4 overflow-x-hidden text-base text-body">
                 {selectedHotkey ? (
                   <>
-                    <AccountIcon className="shrink-0 text-lg!" address={selectedHotkey} />
+                    <BittensorHotkeyAvatar hotkey={selectedHotkey} className="shrink-0 text-lg!" />
                     <div className="grow truncate leading-base">{destinationHotkeyName}</div>
                   </>
                 ) : (

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeLockTypeModal/BittensorChangeLockTypeConfirm.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeLockTypeModal/BittensorChangeLockTypeConfirm.tsx
@@ -1,9 +1,9 @@
 import { AlertCircleIcon } from "@talismn/icons"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
 import { WizardModalDialog } from "@ui/components/WizardModalDialog"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
 import { BittensorValidatorName } from "@ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorValidatorName"
+import { BittensorHotkeyAvatar } from "@ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar"
 import { StakingAccountDisplay } from "@ui/domains/Staking/shared/StakingAccountDisplay"
 import { StakingFeeEstimate } from "@ui/domains/Staking/shared/StakingFeeEstimate"
 import { SapiSendButton } from "@ui/domains/Transactions/SapiSendButton"
@@ -76,7 +76,7 @@ export const BittensorChangeLockTypeConfirm = () => {
           </SummaryRow>
           <SummaryRow label={t("Hotkey")}>
             <span className="inline-flex max-w-full items-center gap-4 overflow-hidden align-middle">
-              <AccountIcon className="shrink-0 text-lg!" address={existingLock.hotkey} />
+              <BittensorHotkeyAvatar hotkey={existingLock.hotkey} className="shrink-0 text-lg!" />
               <BittensorValidatorName hotkey={existingLock.hotkey} className="truncate" />
             </span>
           </SummaryRow>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeLockTypeModal/BittensorChangeLockTypeForm.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorChangeLockTypeModal/BittensorChangeLockTypeForm.tsx
@@ -2,11 +2,11 @@ import { Button } from "@ui/components/Button"
 import { PillButton } from "@ui/components/PillButton"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
 import { WizardModalDialog } from "@ui/components/WizardModalDialog"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { AccountPicker } from "@ui/domains/AccountProxies/AddProxy/AccountPicker"
 import { TokenLogo } from "@ui/domains/Asset/TokenLogo"
 import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
 import { AddressPillButton } from "@ui/domains/SendFunds/SendFundsAmountForm/AddressPillButton"
+import { BittensorHotkeyAvatar } from "@ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar"
 import { StakingFeeEstimate } from "@ui/domains/Staking/shared/StakingFeeEstimate"
 import { useTranslation } from "react-i18next"
 
@@ -111,7 +111,7 @@ export const BittensorChangeLockTypeForm = () => {
             <div className="whitespace-nowrap">{t("Hotkey")}</div>
             {existingLock && (
               <div className="flex h-12 max-w-full flex-nowrap items-center gap-4 overflow-x-hidden text-body">
-                <AccountIcon className="text-lg!" address={existingLock.hotkey} />
+                <BittensorHotkeyAvatar hotkey={existingLock.hotkey} className="text-lg!" />
                 <div className="grow truncate leading-base">{hotkeyName}</div>
               </div>
             )}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/BittensorConvictionLockModal/BittensorConvictionLockConfirm.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/BittensorConvictionLockModal/BittensorConvictionLockConfirm.tsx
@@ -1,9 +1,9 @@
 import { AlertCircleIcon } from "@talismn/icons"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
 import { WizardModalDialog } from "@ui/components/WizardModalDialog"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
 import { BittensorValidatorName } from "@ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorValidatorName"
+import { BittensorHotkeyAvatar } from "@ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar"
 import { StakingAccountDisplay } from "@ui/domains/Staking/shared/StakingAccountDisplay"
 import { StakingFeeEstimate } from "@ui/domains/Staking/shared/StakingFeeEstimate"
 import { SapiSendButton } from "@ui/domains/Transactions/SapiSendButton"
@@ -78,7 +78,7 @@ export const BittensorConvictionLockConfirm = () => {
           </SummaryRow>
           <SummaryRow label={t("Hotkey")}>
             <span className="inline-flex max-w-full items-center gap-4 overflow-hidden align-middle">
-              <AccountIcon className="shrink-0 text-lg!" address={effectiveHotkey} />
+              <BittensorHotkeyAvatar hotkey={effectiveHotkey} className="shrink-0 text-lg!" />
               <BittensorValidatorName hotkey={effectiveHotkey} className="truncate" />
             </span>
           </SummaryRow>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar.test.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar.test.tsx
@@ -1,0 +1,80 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { BittensorHotkeyAvatar } from "./BittensorHotkeyAvatar"
+
+const HOTKEY = "5DywxdtESjskgPZrDXL86qV44SpPgJuqs9X6noyJJwX9PaSD"
+const UNKNOWN_HOTKEY = "5C4jtv7VBZ1WfDbsJD9zwj3w83D7Ltoi7tJ7YhS3AhTLsn57"
+
+vi.mock("@ui/domains/Account/AccountIcon", () => ({
+  AccountIcon: () => <span data-testid="account-icon" />,
+}))
+
+vi.mock("@ui/hooks/queryStoragePersister", () => ({
+  createQueryStoragePersister: () => undefined,
+  PERSIST_AGE_ONE_YEAR: 0,
+}))
+
+vi.mock("@ui/hooks/imageCache", () => ({
+  invalidateCachedImage: vi.fn(),
+  useImageSwr: () => null,
+}))
+
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  json: async () => ({ [HOTKEY]: "coldkey.webp" }),
+}))
+vi.stubGlobal("fetch", fetchMock)
+
+const renderAvatar = (hotkey: string) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BittensorHotkeyAvatar hotkey={hotkey} />
+    </QueryClientProvider>
+  )
+}
+
+afterEach(() => {
+  fetchMock.mockClear()
+})
+
+describe("BittensorHotkeyAvatar", () => {
+  it("renders the chaindata logo for a hotkey listed in logos.json", async () => {
+    const { container } = renderAvatar(HOTKEY)
+
+    await waitFor(() => expect(container.querySelector("img")).not.toBeNull())
+
+    expect(container.querySelector("img")?.getAttribute("src")).toMatch(
+      /\/assets\/bittensor\/hotkeys\/coldkey\.webp$/
+    )
+    expect(container.querySelector("[data-testid=account-icon]")).toBeNull()
+  })
+
+  it("renders the account icon for a hotkey without logo", async () => {
+    const { container } = renderAvatar(UNKNOWN_HOTKEY)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    expect(container.querySelector("[data-testid=account-icon]")).not.toBeNull()
+    expect(container.querySelector("img")).toBeNull()
+  })
+
+  it("falls back to the account icon once every image source failed", async () => {
+    const { container } = renderAvatar(HOTKEY)
+
+    await waitFor(() => expect(container.querySelector("img")).not.toBeNull())
+    const firstSrc = container.querySelector("img")?.getAttribute("src")
+
+    fireEvent.error(container.querySelector("img")!)
+    await waitFor(() =>
+      expect(container.querySelector("img")?.getAttribute("src")).not.toBe(firstSrc)
+    )
+
+    fireEvent.error(container.querySelector("img")!)
+    await waitFor(() => expect(container.querySelector("img")).toBeNull())
+
+    expect(container.querySelector("[data-testid=account-icon]")).not.toBeNull()
+  })
+})

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar.tsx
@@ -1,0 +1,31 @@
+import { IS_FIREFOX } from "@common/constants"
+import { AccountIcon } from "@ui/domains/Account/AccountIcon"
+import { useGithubImageUrl } from "@ui/hooks/useGithubImageUrl"
+import { cn } from "@ui/util/cn"
+import type { FC } from "react"
+
+import { useBittensorHotkeyLogoUrl } from "../hooks/useBittensorHotkeyLogoUrl"
+
+export const BittensorHotkeyAvatar: FC<{ hotkey: string; className?: string }> = ({
+  hotkey,
+  className,
+}) => {
+  const logoUrl = useBittensorHotkeyLogoUrl(hotkey)
+  const { src, onError } = useGithubImageUrl(logoUrl)
+
+  if (!src) return <AccountIcon address={hotkey} className={className} />
+
+  return (
+    <div className={cn("relative inline-block shrink-0", className)}>
+      <img
+        key={src}
+        src={src}
+        alt=""
+        className="block size-[1em] rounded-full"
+        crossOrigin={IS_FIREFOX ? undefined : "anonymous"}
+        loading="lazy"
+        onError={onError}
+      />
+    </div>
+  )
+}

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/ConvictionLockHotkeyPicker.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/ConvictionLockHotkeyPicker.tsx
@@ -3,19 +3,18 @@ import { isAddressEqual, isSs58Address } from "@talismn/crypto"
 import { ScrollContainer } from "@ui/components/ScrollContainer"
 import { SearchInputControlled } from "@ui/components/SearchInputControlled"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { Address } from "@ui/domains/Account/Address"
 import { useBittensorValidatorsMap } from "@ui/state/bittensor"
 import { cn } from "@ui/util/cn"
 import { type FC, useDeferredValue, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-
 import { useBittensorHotkeyExists } from "../hooks/useBittensorHotkeyExists"
 import {
   type NeuronRole,
   type SubnetNeuron,
   useBittensorSubnetNeurons,
 } from "../hooks/useBittensorSubnetNeurons"
+import { BittensorHotkeyAvatar } from "./BittensorHotkeyAvatar"
 import {
   ConvictionKeeperBadge,
   getConvictionKeeperKind,
@@ -146,7 +145,7 @@ export const ConvictionLockHotkeyPicker: FC<{
                   "bg-grey-800 text-body-secondary"
               )}
             >
-              <AccountIcon address={offSubnetMatch} className="size-16 shrink-0 text-xl" />
+              <BittensorHotkeyAvatar hotkey={offSubnetMatch} className="size-16 shrink-0 text-xl" />
               <div className="flex grow items-center justify-between gap-4 overflow-hidden text-body text-sm">
                 {offSubnetName ? (
                   <Tooltip>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/HotkeyPickerRows.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/HotkeyPickerRows.tsx
@@ -14,7 +14,6 @@ import { planckToTokens } from "@talismn/util"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { useScrollContainer } from "@ui/components/ScrollContainer"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { Address } from "@ui/domains/Account/Address"
 import { Tokens } from "@ui/domains/Asset/Tokens"
 import { EarnTypeBadge } from "@ui/domains/Earn/components/EarnTypeBadge"
@@ -22,9 +21,9 @@ import { useToken } from "@ui/state/chaindata"
 import { cn } from "@ui/util/cn"
 import type { FC, SVGProps } from "react"
 import { useTranslation } from "react-i18next"
-
 import { useBittensorHotkeyConviction } from "../hooks/useBittensorHotkeyConviction"
 import type { NeuronRole, SubnetNeuron } from "../hooks/useBittensorSubnetNeurons"
+import { BittensorHotkeyAvatar } from "./BittensorHotkeyAvatar"
 
 const ROLE_BADGE: Record<NeuronRole, { Icon: FC<SVGProps<SVGSVGElement>>; className: string }> = {
   owner: { Icon: HomeIcon, className: "bg-primary/10 text-primary" },
@@ -196,7 +195,7 @@ const HotkeyRow: FC<{
         isSelected && "bg-grey-800 text-body-secondary"
       )}
     >
-      <AccountIcon address={neuron.hotkey} className="size-16 shrink-0 text-xl" />
+      <BittensorHotkeyAvatar hotkey={neuron.hotkey} className="size-16 shrink-0 text-xl" />
       <div className="flex h-full grow flex-col justify-center gap-2 overflow-hidden">
         <div className="flex w-full items-center justify-between gap-8 text-body text-sm">
           <div className="min-w-0">

--- a/apps/extension/src/ui/domains/Staking/Bittensor/components/ValidatorPicker.tsx
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/components/ValidatorPicker.tsx
@@ -10,7 +10,6 @@ import {
 } from "@ui/components/ContextMenu"
 import { useScrollContainer } from "@ui/components/ScrollContainer"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { Address } from "@ui/domains/Account/Address"
 import { Tokens } from "@ui/domains/Asset/Tokens"
 import { EarnTypeBadge } from "@ui/domains/Earn/components/EarnTypeBadge"
@@ -18,9 +17,9 @@ import { useToken } from "@ui/state/chaindata"
 import { cn } from "@ui/util/cn"
 import { type FC, useMemo } from "react"
 import { useTranslation } from "react-i18next"
-
 import type { BondOption as BondOptionType } from "../../hooks/bittensor/types"
 import type { ValidatorSortValue } from "../utils/validatorSorting"
+import { BittensorHotkeyAvatar } from "./BittensorHotkeyAvatar"
 
 export const ValidatorSortMethodButton: FC<{
   method: ValidatorSortValue
@@ -173,7 +172,7 @@ const ValidatorRow: FC<{
         isSelected && "bg-grey-800 text-body-secondary"
       )}
     >
-      <AccountIcon address={option.hotkey} className="size-16 shrink-0 text-xl" />
+      <BittensorHotkeyAvatar hotkey={option.hotkey} className="size-16 shrink-0 text-xl" />
       <div className="flex h-full grow flex-col justify-center gap-2 overflow-hidden">
         <div className="flex w-full justify-between gap-8 text-body text-sm">
           <div className={cn("min-w-0", option.isRecommended && "font-bold text-primary")}>

--- a/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorHotkeyLogoUrl.ts
+++ b/apps/extension/src/ui/domains/Staking/Bittensor/hooks/useBittensorHotkeyLogoUrl.ts
@@ -1,0 +1,21 @@
+import { getGithubBittensorHotkeyAssetUrl } from "@talismn/chaindata-provider"
+import { useQuery } from "@tanstack/react-query"
+import { createQueryStoragePersister, PERSIST_AGE_ONE_YEAR } from "@ui/hooks/queryStoragePersister"
+
+type HotkeyLogos = Record<string, string>
+
+const fetchHotkeyLogos = async ({ signal }: { signal: AbortSignal }): Promise<HotkeyLogos> => {
+  const res = await fetch(getGithubBittensorHotkeyAssetUrl("logos.json"), { signal })
+  if (!res.ok) throw new Error(`Failed to fetch hotkey logos (${res.status})`)
+  return res.json()
+}
+
+export const useBittensorHotkeyLogoUrl = (hotkey: string) =>
+  useQuery({
+    queryKey: ["bittensor", "hotkeyLogos"] as const,
+    queryFn: fetchHotkeyLogos,
+    select: (logos) =>
+      logos[hotkey] ? getGithubBittensorHotkeyAssetUrl(logos[hotkey]) : undefined,
+    staleTime: 6 * 60 * 60_000,
+    persister: createQueryStoragePersister({ maxAge: PERSIST_AGE_ONE_YEAR }),
+  }).data

--- a/apps/extension/src/ui/domains/TaoDashboard/subnet/components/SubnetStakingOperationModal.tsx
+++ b/apps/extension/src/ui/domains/TaoDashboard/subnet/components/SubnetStakingOperationModal.tsx
@@ -6,10 +6,10 @@ import { Modal } from "@ui/components/Modal"
 import { PopupSizeModalContainer } from "@ui/components/PopupSizeModalContainer"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@ui/components/Tooltip"
 import { WizardModalDialog } from "@ui/components/WizardModalDialog"
-import { AccountIcon } from "@ui/domains/Account/AccountIcon"
 import { TokensAndFiat } from "@ui/domains/Asset/TokensAndFiat"
 import { AccountDisplay } from "@ui/domains/Earn/shared/AccountDisplay"
 import { BittensorValidatorName } from "@ui/domains/Portfolio/AssetDetails/DashboardTokenBalances/BittensorValidatorName"
+import { BittensorHotkeyAvatar } from "@ui/domains/Staking/Bittensor/components/BittensorHotkeyAvatar"
 import { useCopyToClipboard } from "@ui/hooks/useCopyToClipboard"
 import { cn } from "@ui/util/cn"
 import { shortenAddress } from "@ui/util/shortenAddress"
@@ -503,7 +503,7 @@ const FieldValueValidator: FC<{ hotkey: string }> = ({ hotkey }) => {
 
   return (
     <div className="flex max-w-full items-center gap-4 overflow-hidden">
-      <AccountIcon address={hotkey} className="text-[1.5em]" />
+      <BittensorHotkeyAvatar hotkey={hotkey} className="text-[1.5em]" />
       <BittensorValidatorName hotkey={hotkey} className="truncate text-body" />
       <button
         type="button"

--- a/apps/extension/src/ui/hooks/useGithubImageUrl.test.ts
+++ b/apps/extension/src/ui/hooks/useGithubImageUrl.test.ts
@@ -163,3 +163,27 @@ describe("useGithubImageUrl / getFileUrl (debug flow: gitraw -> jsdelivr)", () =
     expect(getFileUrl(JSDELIVR_SLASHED, FALLBACK, true)).toBe(FALLBACK)
   })
 })
+
+describe("useGithubImageUrl / getFileUrl (no fallback)", () => {
+  it("returns undefined for nullish input", async () => {
+    const getFileUrl = await loadGetFileUrl(false)
+
+    expect(getFileUrl(null)).toBeUndefined()
+    expect(getFileUrl(undefined)).toBeUndefined()
+  })
+
+  it("rotates through every source then ends on undefined", async () => {
+    const getFileUrl = await loadGetFileUrl(false)
+
+    expect(getFileUrl(GITRAW_SIMPLE)).toBe(JSDELIVR_SIMPLE)
+    expect(getFileUrl(JSDELIVR_SIMPLE, undefined, true)).toBe(GITRAW_SIMPLE)
+    expect(getFileUrl(GITRAW_SIMPLE, undefined, true)).toBeUndefined()
+  })
+
+  it("drops non-github urls on rotation", async () => {
+    const getFileUrl = await loadGetFileUrl(false)
+
+    expect(getFileUrl("https://example.com/logo.png")).toBe("https://example.com/logo.png")
+    expect(getFileUrl("https://example.com/logo.png", undefined, true)).toBeUndefined()
+  })
+})

--- a/apps/extension/src/ui/hooks/useGithubImageUrl.ts
+++ b/apps/extension/src/ui/hooks/useGithubImageUrl.ts
@@ -62,9 +62,9 @@ const isGithubUrl = (url: string): boolean => parseGithubUrl(url) !== null
 // exported for tests
 export const getFileUrl = (
   url: string | null | undefined,
-  fallbackUrl: string,
+  fallbackUrl?: string,
   rotate?: boolean
-) => {
+): string | undefined => {
   if (!url || url === fallbackUrl) return fallbackUrl
 
   const parsed = parseGithubUrl(url)
@@ -80,7 +80,7 @@ export const getFileUrl = (
   return GITHUB_SOURCE_FLOW[sourceIndex].build(parsed.asset)
 }
 
-export const useGithubImageUrl = (url: string | null | undefined, fallbackUrl: string) => {
+export const useGithubImageUrl = (url: string | null | undefined, fallbackUrl?: string) => {
   // SWR data-URL cache for non-GitHub images (provider logos, defi logos, etc.)
   const shouldCache =
     !!url && (url.startsWith("https://") || url.startsWith("http://")) && !isGithubUrl(url)

--- a/packages/chaindata-provider/src/util.ts
+++ b/packages/chaindata-provider/src/util.ts
@@ -14,3 +14,7 @@ export const getGithubTokenLogoUrl = (tokenId: KNOWN_TOKEN_ID): string => {
 export const getGithubTokenLogoUrlByCoingeckoId = (coingeckoId: string): string => {
   return `${githubChaindataBaseUrl}/assets/tokens/coingecko/${coingeckoId}.webp`
 }
+
+export const getGithubBittensorHotkeyAssetUrl = (fileName: string): string => {
+  return `${githubChaindataBaseUrl}/assets/bittensor/hotkeys/${fileName}`
+}


### PR DESCRIPTION
Uses the hotkey logos published by chaindata (`assets/bittensor/hotkeys/logos.json`) as validator avatars, with the account icon as fallback when a hotkey has no logo. The logo map is cached locally through the react-query storage persister.

Screens:
- Stake modal validator picker (also used by change validator and the TaoDashboard subnet swap validator pill)
- Conviction lock hotkey picker (subnet neurons + off-subnet match row)
- Conviction lock confirm (Hotkey row)
- Change lock hotkey form + confirm
- Change lock type form + confirm
- Portfolio TAO details, dTAO conviction lock hotkey tag
- TaoDashboard subnet staking operation modal (Validator field)