### PR TITLE
🐛 decode personal_sign messages once for every sign surface

### DIFF
--- a/apps/extension/src/core/domains/ethereum/handler.tabs.ts
+++ b/apps/extension/src/core/domains/ethereum/handler.tabs.ts
@@ -66,6 +66,7 @@ import {
   isValidWatchAssetRequestParam,
   sanitizeWatchAssetRequestParam,
 } from "./helpers"
+import { assertPersonalSignMessageDecodable } from "./personalSignMessage"
 import { requestAddNetwork, requestWatchAsset } from "./requests"
 import { assertTypedDataTargetsChain } from "./typedData"
 import type {
@@ -536,6 +537,8 @@ export class EthTabsHandler extends TabsHandler {
 
     // throws if `from` is not one of the accounts connected to the site
     const site = await this.getSiteDetails(url, from)
+
+    if (method === "personal_sign") assertPersonalSignMessageDecodable(message)
 
     if (["eth_signTypedData_v3", "eth_signTypedData_v4"].includes(method))
       assertTypedDataTargetsChain(message, site.ethChainId)

--- a/apps/extension/src/core/domains/ethereum/personalSignMessage.test.ts
+++ b/apps/extension/src/core/domains/ethereum/personalSignMessage.test.ts
@@ -1,0 +1,38 @@
+import { stringToHex } from "viem"
+import { describe, expect, it } from "vitest"
+
+import {
+  assertPersonalSignMessageDecodable,
+  decodePersonalSignMessage,
+} from "./personalSignMessage"
+
+describe("decodePersonalSignMessage", () => {
+  it("decodes a hex payload as utf-8", () => {
+    expect(decodePersonalSignMessage(stringToHex("hello wörld"))).toBe("hello wörld")
+  })
+
+  it("returns a raw text payload unchanged", () => {
+    expect(decodePersonalSignMessage("hello world")).toBe("hello world")
+  })
+
+  it("decodes an empty hex payload to an empty string", () => {
+    expect(decodePersonalSignMessage("0x")).toBe("")
+  })
+
+  it("refuses an odd number of hex digits instead of guessing the padding side", () => {
+    expect(decodePersonalSignMessage(`${stringToHex("ab")}6`)).toBeNull()
+  })
+})
+
+describe("assertPersonalSignMessageDecodable", () => {
+  it("accepts hex and text payloads", () => {
+    expect(() => assertPersonalSignMessageDecodable(stringToHex("ok"))).not.toThrow()
+    expect(() => assertPersonalSignMessageDecodable("ok")).not.toThrow()
+  })
+
+  it("rejects an odd-length hex payload as an invalid parameter", () => {
+    expect(() => assertPersonalSignMessageDecodable("0x616")).toThrow(
+      expect.objectContaining({ message: "Invalid parameter", code: -32602 })
+    )
+  })
+})

--- a/apps/extension/src/core/domains/ethereum/personalSignMessage.ts
+++ b/apps/extension/src/core/domains/ethereum/personalSignMessage.ts
@@ -1,0 +1,18 @@
+import { isHexString } from "@talismn/util"
+import { hexToBytes } from "viem"
+import { ETH_ERROR_EIP1474_INVALID_PARAMS, EthProviderRpcError } from "./EthProviderRpcError"
+
+// Single source of truth for the text a personal_sign payload stands for: the signer hashes hex
+// payloads as bytes and anything else as utf-8, and every surface that reads the message must see
+// the same text. An odd number of hex digits is ambiguous (libraries pad on different sides), so it
+// decodes to nothing rather than to a guess.
+export const decodePersonalSignMessage = (message: string): string | null => {
+  if (!isHexString(message)) return message
+  if (message.length % 2) return null
+  return new TextDecoder().decode(hexToBytes(message))
+}
+
+export const assertPersonalSignMessageDecodable = (message: string) => {
+  if (decodePersonalSignMessage(message) === null)
+    throw new EthProviderRpcError("Invalid parameter", ETH_ERROR_EIP1474_INVALID_PARAMS)
+}

--- a/apps/extension/src/core/domains/ethereum/siwe.test.ts
+++ b/apps/extension/src/core/domains/ethereum/siwe.test.ts
@@ -1,7 +1,7 @@
 import { stringToHex } from "viem"
 import { describe, expect, it } from "vitest"
 
-import { isSiweDomainMismatch } from "./siwe"
+import { isSiweDomainMismatch, parseSiweMessage } from "./siwe"
 
 // minimal valid EIP-4361 message for the given domain
 const siweMessage = (domain: string) =>
@@ -41,6 +41,12 @@ describe("isSiweDomainMismatch", () => {
     ).toBe(true)
   })
 
+  it("detects the domain of a SIWE message sent as raw text", () => {
+    expect(
+      isSiweDomainMismatch("personal_sign", siweMessage("evil.com"), "https://example.com/login")
+    ).toBe(true)
+  })
+
   it("returns false for a non-SIWE personal_sign message", () => {
     expect(
       isSiweDomainMismatch("personal_sign", hex("just a plain message"), "https://example.com")
@@ -65,5 +71,21 @@ describe("isSiweDomainMismatch", () => {
     expect(isSiweDomainMismatch("personal_sign", hex(siweMessage("evil.com")), undefined)).toBe(
       false
     )
+  })
+})
+
+describe("parseSiweMessage", () => {
+  it("parses hex and raw text SIWE messages to the same domain", () => {
+    expect(parseSiweMessage(hex(siweMessage("example.com")))?.domain).toBe("example.com")
+    expect(parseSiweMessage(siweMessage("example.com"))?.domain).toBe("example.com")
+  })
+
+  it("returns null for an odd-length hex payload, so no surface treats it as a sign-in", () => {
+    expect(parseSiweMessage(`${hex(siweMessage("evil.com"))}0`)).toBeNull()
+  })
+
+  it("returns null for a non-SIWE message", () => {
+    expect(parseSiweMessage(hex("just a plain message"))).toBeNull()
+    expect(parseSiweMessage(undefined)).toBeNull()
   })
 })

--- a/apps/extension/src/core/domains/ethereum/siwe.ts
+++ b/apps/extension/src/core/domains/ethereum/siwe.ts
@@ -1,5 +1,16 @@
 import { ParsedMessage } from "@spruceid/siwe-parser"
-import { type Hex, hexToString } from "viem"
+import { decodePersonalSignMessage } from "./personalSignMessage"
+
+export const parseSiweMessage = (message: string | undefined): ParsedMessage | null => {
+  if (!message) return null
+  const text = decodePersonalSignMessage(message)
+  if (text === null) return null
+  try {
+    return new ParsedMessage(text)
+  } catch {
+    return null
+  }
+}
 
 /**
  * EIP-4361: a Sign-In With Ethereum message must declare a `domain` matching the requesting site.
@@ -9,15 +20,15 @@ import { type Hex, hexToString } from "viem"
  */
 export const isSiweDomainMismatch = (
   method: string | undefined,
-  messageHex: string | undefined,
+  message: string | undefined,
   url: string | undefined
 ): boolean => {
-  if (method !== "personal_sign" || !messageHex || !url) return false
+  if (method !== "personal_sign" || !url) return false
+  const siwe = parseSiweMessage(message)
+  if (!siwe) return false
   try {
-    const siwe = new ParsedMessage(hexToString(messageHex as Hex))
     return siwe.domain !== new URL(url).hostname
   } catch {
-    // not a SIWE message (or unparseable) => nothing to flag
     return false
   }
 }

--- a/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessage.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessage.tsx
@@ -1,9 +1,10 @@
 import { log } from "@common/log"
 import { sentry } from "@core/config/sentry"
+import { decodePersonalSignMessage } from "@core/domains/ethereum/personalSignMessage"
+import { parseSiweMessage } from "@core/domains/ethereum/siwe"
 import type { Account } from "@core/domains/keyring/exports"
 import type { EthSignRequest } from "@core/domains/signing/types"
-import { ParsedMessage } from "@spruceid/siwe-parser"
-import { hexToString, isHexString, stripHexPrefix } from "@talismn/util"
+import { isHexString } from "@talismn/util"
 import { Button } from "@ui/components/Button"
 import { Drawer } from "@ui/components/Drawer"
 import { decodeEvmTypedData } from "@ui/domains/Ethereum/util/decodeEvmTypedData"
@@ -65,27 +66,15 @@ const useEthSignMessage = (request: EthSignRequest) => {
         sentry.captureException(err)
       }
     }
-    try {
-      if (isHexString(request.request)) {
-        const stripped = stripHexPrefix(request.request)
-        const buff = Buffer.from(stripped, "hex")
-        // if 32 bytes display as is, can be tested when approving NFT listings on tofunft.com
-        return buff.length === 32 ? request.request : buff.toString("utf8")
-      }
-    } catch (err) {
-      log.error(err)
-    }
-    return request.request
+    // a 32 bytes payload is a hash, not text - can be tested when approving NFT listings on tofunft.com
+    if (isHexString(request.request) && request.request.length === 66) return request.request
+    return decodePersonalSignMessage(request.request) ?? request.request
   }, [request.request, typedMessage])
 
-  const siwe = useMemo(() => {
-    try {
-      const text = hexToString(request.request)
-      return new ParsedMessage(text)
-    } catch {
-      return null
-    }
-  }, [request.request])
+  const siwe = useMemo(
+    () => (request.method === "personal_sign" ? parseSiweMessage(request.request) : null),
+    [request.method, request.request]
+  )
 
   return {
     siwe,

--- a/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessageSIWE.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyMessageSIWE.tsx
@@ -1,8 +1,8 @@
+import { decodePersonalSignMessage } from "@core/domains/ethereum/personalSignMessage"
 import type { Account } from "@core/domains/keyring/exports"
 import type { EthSignRequest } from "@core/domains/signing/types"
 import type { ParsedMessage } from "@spruceid/siwe-parser"
 import { UserRightIcon } from "@talismn/icons"
-import { hexToString } from "@talismn/util"
 import { Button } from "@ui/components/Button"
 import { Checkbox } from "@ui/components/Checkbox"
 import { Drawer } from "@ui/components/Drawer"
@@ -26,7 +26,10 @@ const ViewDetailsContent: FC<{
   const { t } = useTranslation()
   const evmNetwork = useNetworkById(String(siwe.chainId), "ethereum")
 
-  const message = useMemo(() => hexToString(request.request), [request.request])
+  const message = useMemo(
+    () => decodePersonalSignMessage(request.request) ?? request.request,
+    [request.request]
+  )
 
   return (
     <div className="flex max-h-150 w-full flex-col gap-12 bg-grey-850 p-12">

--- a/apps/extension/src/ui/domains/Sign/Ethereum/__tests__/EthSignBodyMessage.test.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/__tests__/EthSignBodyMessage.test.tsx
@@ -12,6 +12,7 @@ const fx = vi.hoisted(() => ({
   },
   nativeToken: { id: "1-evm-native", symbol: "ETH", decimals: 18 },
   erc20Token: { id: "1-evm-erc20-usdc", symbol: "USDC", decimals: 6 },
+  siweDomainMismatch: false,
 }))
 
 vi.mock("@ui/state/chaindata", async (importOriginal) => ({
@@ -48,11 +49,27 @@ vi.mock("@ui/domains/Sign/risk-analysis/RiskAnalysisPillButton", () => ({
 
 vi.mock("@ui/domains/Sign/ViewDetails/ViewDetailsButton", () => ({ ViewDetailsButton: () => null }))
 
+vi.mock("@talismn/icons", () => ({
+  UserRightIcon: () => null,
+  InfoIcon: () => null,
+  LoaderIcon: () => null,
+}))
+
+vi.mock("@ui/domains/Sign/SignRequestContext", () => ({
+  useEthSignMessageRequest: () => ({
+    siweDomainMismatch: fx.siweDomainMismatch,
+    isSiweMismatchAcknowledged: false,
+    setIsSiweMismatchAcknowledged: () => {},
+  }),
+}))
+
 vi.mock("@ui/components/Drawer", () => ({
   Drawer: ({ isOpen, children }: { isOpen?: boolean; children?: ReactNode }) =>
     isOpen ? <div>{children}</div> : null,
 }))
 
+import { isSiweDomainMismatch } from "@core/domains/ethereum/siwe"
+import { stringToHex } from "viem"
 import { EthSignBodyMessage } from "../EthSignBodyMessage"
 
 const SIGNER = "0x1111111111111111111111111111111111111111"
@@ -104,6 +121,70 @@ const renderMessage = (typedData: unknown) =>
       }
     />
   )
+
+const SITE_URL = "https://example.com/login"
+
+const siweMessage = (domain: string) =>
+  [
+    `${domain} wants you to sign in with your Ethereum account:`,
+    SIGNER,
+    "",
+    "Sign in.",
+    "",
+    `URI: https://${domain}/`,
+    "Version: 1",
+    "Chain ID: 1",
+    "Nonce: 12345678",
+    "Issued At: 2021-09-30T16:25:24.000Z",
+  ].join("\n")
+
+const renderPersonalSign = (message: string) => {
+  const request = {
+    method: "personal_sign",
+    request: message,
+    url: SITE_URL,
+    ethChainId: 1,
+  } as unknown as EthSignRequest
+  fx.siweDomainMismatch = isSiweDomainMismatch(request.method, request.request, request.url)
+  return render(
+    <EthSignBodyMessage
+      account={{ address: SIGNER } as Parameters<typeof EthSignBodyMessage>[0]["account"]}
+      request={request}
+    />
+  )
+}
+
+describe("EthSignBodyMessage personal_sign", () => {
+  it("shows the sign-in screen and the domain warning for a hex SIWE message", () => {
+    const { container } = renderPersonalSign(stringToHex(siweMessage("evil.com")))
+
+    expect(container.textContent).toContain("Sign In")
+    expect(container.textContent).toContain("evil.com")
+    expect(container.textContent).toContain("Sign in domain is different from website domain.")
+  })
+
+  it("treats a raw text SIWE message the same as its hex encoding", () => {
+    const { container } = renderPersonalSign(siweMessage("evil.com"))
+
+    expect(container.textContent).toContain("Sign In")
+    expect(container.textContent).toContain("Sign in domain is different from website domain.")
+  })
+
+  it("shows no domain warning when the sign-in domain matches the site", () => {
+    const { container } = renderPersonalSign(stringToHex(siweMessage("example.com")))
+
+    expect(container.textContent).toContain("Sign In")
+    expect(container.textContent).not.toContain("Sign in domain is different")
+  })
+
+  it("never shows the sign-in screen for an odd-length hex payload", () => {
+    const { container } = renderPersonalSign(`${stringToHex(siweMessage("evil.com"))}0`)
+
+    expect(container.textContent).not.toContain("Sign In")
+    expect(container.textContent).toContain("Sign Request")
+    expect(screen.getByTestId("raw-message")).toBeDefined()
+  })
+})
 
 describe("EthSignBodyMessage", () => {
   it("decodes a Permit2 allowance instead of showing raw typed data", () => {


### PR DESCRIPTION
The domain check, the Sign In screen and the raw message view each decoded `personal_sign` payloads on their own and could disagree on odd-length hex. They now share one decoder in `core/domains/ethereum/personalSignMessage.ts`.

- odd-length hex is rejected at request intake with `-32602`
- sign-in messages sent as raw text are now recognised, same as their hex encoding
- unit tests for the decoder, the SIWE parser and the sign screen
