### PR TITLE
💄 soften undecoded evm call warning

### DIFF
--- a/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyDefault.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/EthSignBodyDefault.tsx
@@ -64,9 +64,9 @@ export const EthSignBodyDefault: FC<EthSignBodyDefaultProps> = ({ unexpectedNati
               </SignAlertMessage>
             )}
             {undecodedSelector && (
-              <SignAlertMessage type="error">
+              <SignAlertMessage type="warning">
                 {t(
-                  "Talisman cannot decode this contract call, so what it does is unknown - the app could be requesting anything, including access to your funds. Only approve it if you trust this app."
+                  "Talisman can't read what this transaction does. Check that you trust this site before you approve."
                 )}
               </SignAlertMessage>
             )}

--- a/apps/extension/src/ui/domains/Sign/Ethereum/__tests__/EthSignBody.test.tsx
+++ b/apps/extension/src/ui/domains/Sign/Ethereum/__tests__/EthSignBody.test.tsx
@@ -213,7 +213,7 @@ describe("EthSignBody", () => {
 
     const { container } = renderBody(decodedTx)
 
-    expect(screen.getByTestId("alert").textContent).toContain("cannot decode")
+    expect(screen.getByTestId("alert").textContent).toContain("can't read")
     expect(container.textContent).toContain("0x87517c45")
   })
 

--- a/apps/extension/src/ui/domains/Sign/SignAlertMessage.tsx
+++ b/apps/extension/src/ui/domains/Sign/SignAlertMessage.tsx
@@ -31,7 +31,7 @@ export const SignAlertMessage: FC<SignAlertMessageProps> = ({
   children,
   className,
   type = "warning",
-  iconSize = "xl",
+  iconSize = "base",
   processing,
 }) => {
   return (


### PR DESCRIPTION
Downgrades the undecoded-call alert on the EVM sign screen from error to warning and shortens the copy.

Verified with the new test-dapp scenario "Ethereum unknown-call" (TalismanSociety/test-dapp main).